### PR TITLE
Add code review policy and enforcement workflows

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -1,0 +1,53 @@
+name: Weekly PR Audit
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  audit:
+    name: Audit Merged PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Audit merged PRs for review policy compliance
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          SINCE=$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -v-7d '+%Y-%m-%dT%H:%M:%SZ')
+          TODAY=$(date -u '+%Y-%m-%d')
+          MERGED_PRS=$(gh pr list --repo "$REPO" --state merged --json number,title,mergedAt,body,labels,author --jq "[.[] | select(.mergedAt >= \"$SINCE\")]")
+          VIOLATION_COUNT=0
+          VIOLATIONS=""
+          for row in $(echo "$MERGED_PRS" | jq -r '.[] | @base64'); do
+            _jq() { echo "$row" | base64 --decode | jq -r "${1}"; }
+            PR_NUM=$(_jq '.number')
+            PR_TITLE=$(_jq '.title')
+            PR_BODY=$(_jq '.body')
+            PR_AUTHOR=$(_jq '.author.login')
+            HAD_REVIEW_LABEL=$(echo "$row" | base64 --decode | jq '[.labels[].name] | any(. == "needs-external-review")')
+            MISSING_SELF_REVIEW=false
+            if ! echo "$PR_BODY" | grep -qE '^## Self-Review'; then MISSING_SELF_REVIEW=true; fi
+            MISSING_HUMAN_APPROVAL=false
+            if [ "$HAD_REVIEW_LABEL" = "true" ]; then
+              REVIEWS=$(gh pr view "$PR_NUM" --repo "$REPO" --json reviews --jq '[.reviews[] | select(.state == "APPROVED" and .authorAssociation != "BOT")] | length')
+              if [ "$REVIEWS" -eq 0 ]; then MISSING_HUMAN_APPROVAL=true; fi
+            fi
+            if [ "$MISSING_SELF_REVIEW" = "true" ] || [ "$MISSING_HUMAN_APPROVAL" = "true" ]; then
+              VIOLATION_COUNT=$((VIOLATION_COUNT + 1))
+              VIOLATION_DETAIL="- **#${PR_NUM}** — ${PR_TITLE} (by ${PR_AUTHOR})"
+              if [ "$MISSING_SELF_REVIEW" = "true" ]; then VIOLATION_DETAIL="${VIOLATION_DETAIL}\n  - Missing Self-Review section"; fi
+              if [ "$MISSING_HUMAN_APPROVAL" = "true" ]; then VIOLATION_DETAIL="${VIOLATION_DETAIL}\n  - Had needs-external-review label but no human approval"; fi
+              VIOLATIONS="${VIOLATIONS}\n${VIOLATION_DETAIL}"
+            fi
+          done
+          if [ "$VIOLATION_COUNT" -gt 0 ]; then
+            gh issue create --repo "$REPO" --title "Weekly PR Audit — $TODAY" --body "## PR Review Policy Violations\n\n**Audit period:** $SINCE to $TODAY\n**Violations found:** $VIOLATION_COUNT\n\n### Details\n\n$(echo -e "$VIOLATIONS")\n\n---\n\nPer policy, these PRs must be retroactively reviewed by a human within one business day.\n\ncc @nathanjohnpayne" --label "audit"
+          else
+            echo "No policy violations found for the past 7 days."
+          fi

--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -1,0 +1,65 @@
+name: PR Review Policy
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  self-review-check:
+    name: Self-Review Required
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for Self-Review section
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if echo "$PR_BODY" | grep -qE '^## Self-Review'; then
+            echo "Self-Review section found."
+          else
+            echo "PR description must contain a '## Self-Review' section."
+            exit 1
+          fi
+
+  external-review-labeling:
+    name: External Review Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for external review triggers
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          NEEDS_REVIEW=false
+          REASONS=""
+          BASE_SHA=${{ github.event.pull_request.base.sha }}
+          HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          LINES_CHANGED=$(git diff --stat "$BASE_SHA"..."$HEAD_SHA" -- ':!*.lock' ':!*lock.json' ':!*.min.js' ':!*.min.css' ':!*.generated.*' ':!*.g.dart' ':!*.freezed.dart' | tail -1 | awk '{print $4+$6}')
+          LINES_CHANGED=${LINES_CHANGED:-0}
+          if [ "$LINES_CHANGED" -gt 300 ]; then
+            NEEDS_REVIEW=true
+            REASONS="${REASONS}\n- Over 300 non-generated lines changed (${LINES_CHANGED})"
+          fi
+          SENSITIVE_FILES=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA" | grep -E '(^\.github/|/ci/|/auth/|/security/|^package\.json$|^package-lock\.json$|^requirements\.txt$|^Cargo\.toml$|^go\.mod$|^go\.sum$|^Gemfile$|^Gemfile\.lock$|^pubspec\.yaml$|^pubspec\.lock$)' || true)
+          if [ -n "$SENSITIVE_FILES" ]; then
+            NEEDS_REVIEW=true
+            REASONS="${REASONS}\n- Sensitive files modified:\n$(echo "$SENSITIVE_FILES" | sed 's/^/  - /')"
+          fi
+          echo "needs_review=$NEEDS_REVIEW" >> "$GITHUB_OUTPUT"
+          echo -e "reasons=$REASONS" >> "$GITHUB_OUTPUT"
+      - name: Apply label and comment
+        if: steps.check.outputs.needs_review == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit "$PR_NUMBER" --add-label "needs-external-review" --repo "${{ github.repository }}"
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "External Review Required - This PR has been labeled needs-external-review. A human reviewer must remove the label before merge."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,3 +249,41 @@ op-firebase-deploy --only hosting   # hosting only
 ```
 
 See `DEPLOYMENT.md` for the 1Password-backed GCP ADC bootstrap, `gcloud` wrapper install, first-time impersonation setup, cache-bust steps, caching rules, security headers, rollback procedure, and secrets management.
+
+---
+
+## 7. Code Review Requirements
+
+All AI-generated code must undergo peer review before merge.
+
+### Self-Review (Required for Every PR)
+
+Before opening or updating a pull request, the authoring agent must perform a structured self-review covering:
+
+- Correctness against the stated requirements or ticket
+- Regression risk—does this change break existing behavior?
+- Style and convention adherence per this repository's standards
+- Test coverage—are new paths tested and existing tests still passing?
+- Security and dependency hygiene
+
+The self-review summary must be included in the PR description under a `## Self-Review` heading.
+
+### External Peer Review
+
+External review is required when any of the following apply:
+
+- The PR touches more than 300 lines of non-generated code
+- The PR modifies shared infrastructure, CI/CD pipelines, or dependency versions
+- The PR introduces a new architectural pattern or departs from an established one
+- The PR affects authentication, authorization, or data handling
+- The author agent's confidence in any portion of the change is below high
+
+When external review is required, the agent must explicitly request it by tagging the appropriate reviewer(s) and must not self-merge. The PR description should include a `## Review Guidance` section that flags the specific areas where human judgment is needed and why.
+
+### Enforcement
+
+1. **CI gate:** A required status check must validate that every PR description contains a `## Self-Review` section. PRs missing this section will be blocked from merge at the CI level.
+2. **Auto-labeling:** A CI step or GitHub Action must evaluate the PR against the external review triggers above (line count, file paths touching infrastructure or auth, dependency file changes). PRs that meet any trigger are automatically labeled `needs-external-review`. This label blocks merge until removed by a human reviewer.
+3. **No self-removal of labels:** Agents must not remove the `needs-external-review` label. Only a human reviewer may remove it after completing their review. Agent attempts to remove the label should be treated as a policy violation and logged.
+4. **Post-merge audit:** On a recurring cadence (weekly or per-sprint), run an automated audit of merged PRs to catch any that bypassed review policy. Flag these in a report surfaced to Nathan Payne.
+5. **Violation handling:** PRs identified as policy violations in post-merge audit must be retroactively reviewed by a human within one business day. Repeat violations from a specific agent configuration should trigger a review of that agent's permissions and autonomy level. Escalation owner: Nathan Payne.


### PR DESCRIPTION
## Summary
- Adds code review requirements section to AGENTS.md (Section 7) covering self-review, external peer review triggers, and enforcement rules
- Adds `pr-review-policy.yml` workflow: CI gate that requires a `## Self-Review` section in PR descriptions and auto-labels PRs needing external review based on line count and sensitive file paths
- Adds `pr-audit.yml` workflow: Weekly audit of merged PRs checking for policy compliance, creates GitHub issues for violations tagging @nathanjohnpayne

## Self-Review
- **Correctness:** All three files implement the code review policy as specified in rules/code-review-requirements.md
- **Regression risk:** No existing behavior modified; purely additive changes
- **Style:** Follows existing AGENTS.md section numbering convention
- **Test coverage:** Workflow files will be validated by GitHub Actions on first PR trigger
- **Security:** No secrets or credentials introduced; workflows use standard GITHUB_TOKEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)