### PR TITLE
Reconcile review docs and workflows with REVIEW_POLICY.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,34 +1,23 @@
 # Code Review Requirements
 
-All AI-generated code must undergo peer review before merge.
+All AI-generated code must undergo peer review before merge. Follow the code review workflow in REVIEW_POLICY.md. Use .github/review-policy.yml for thresholds and protected paths.
 
 ## Self-Review (Required for Every PR)
 
 Before opening or updating a pull request, perform a structured self-review and include it in the PR description under a `## Self-Review` heading covering:
 
 - Correctness against the stated requirements or ticket
-- Regression risk—does this change break existing behavior?
+- Regression risk---does this change break existing behavior?
 - Style and convention adherence per this repository's standards
-- Test coverage—are new paths tested and existing tests still passing?
+- Test coverage---are new paths tested and existing tests still passing?
 - Security and dependency hygiene
 
-## External Peer Review
+## Review Workflow
 
-External review is required when any of the following apply:
-
-- The PR touches more than 300 lines of non-generated code
-- The PR modifies shared infrastructure, CI/CD pipelines, or dependency versions
-- The PR introduces a new architectural pattern or departs from an established one
-- The PR affects authentication, authorization, or data handling
-- Your confidence in any portion of the change is below high
-
-When external review is required, explicitly request it by tagging the appropriate reviewer(s) and do not self-merge. Include a `## Review Guidance` section in the PR description flagging specific areas where human judgment is needed and why.
-
-## Rules
-
-- Never remove the `needs-external-review` or `needs-human-review` labels from a PR. Only a human reviewer may remove them.
-- Never approve your own PR. Self-approvals are automatically dismissed and labeled `policy-violation`.
-- PRs missing the `## Self-Review` section will be blocked by CI.
-- PRs labeled `needs-external-review`, `needs-human-review`, or `policy-violation` cannot be merged until the label is resolved.
-- When your PR is labeled `needs-external-review`, push a review guidance branch (`review/pr-{number}-guidance`) with a `reviews/pr-{number}-guidance.md` file using the template at `.github/templates/review-guidance.md`.
-- Cross-agent review rotation: Claude → Codex → Cursor → Claude. You will be auto-assigned as a reviewer on other agents' PRs.
+- All code is authored and committed as `nathanjohnpayne`.
+- Review under your agent's reviewer identity (e.g., `nathanpayne-claude`).
+- Only `nathanjohnpayne` merges to the target branch.
+- Never approve your own PR. Self-approvals are automatically dismissed.
+- Never remove `needs-external-review` or `needs-human-review` labels.
+- When external review is required, post a handoff message as described in REVIEW_POLICY.md.
+- See REVIEW_POLICY.md for the complete workflow, handoff format, and post-merge issue rules.

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -8,9 +8,53 @@ on:
 
 jobs:
   # ──────────────────────────────────────────────
-  # Job 1: Auto-label PRs that need external review
+  # Job 1: Read review-policy.yml configuration
+  # ──────────────────────────────────────────────
+  load-config:
+    if: >
+      github.event_name == 'pull_request' &&
+      (github.event.action == 'opened' || github.event.action == 'ready_for_review')
+    runs-on: ubuntu-latest
+    outputs:
+      threshold: ${{ steps.config.outputs.threshold }}
+      paths: ${{ steps.config.outputs.paths }}
+      reviewers: ${{ steps.config.outputs.reviewers }}
+      author_identity: ${{ steps.config.outputs.author_identity }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse review-policy.yml
+        id: config
+        run: |
+          CONFIG=".github/review-policy.yml"
+          if [ ! -f "$CONFIG" ]; then
+            echo "ERROR: $CONFIG not found"
+            exit 1
+          fi
+
+          THRESHOLD=$(grep 'external_review_threshold:' "$CONFIG" | awk '{print $2}')
+          echo "threshold=$THRESHOLD" >> "$GITHUB_OUTPUT"
+
+          # Extract external_review_paths as JSON array
+          PATHS=$(awk '/^external_review_paths:/,/^[^ ]/' "$CONFIG" \
+            | grep '^ *-' | sed 's/^ *- *"//' | sed 's/"$//' \
+            | jq -R -s 'split("\n") | map(select(length > 0))')
+          echo "paths=$PATHS" >> "$GITHUB_OUTPUT"
+
+          # Extract available_reviewers as JSON array
+          REVIEWERS=$(awk '/^available_reviewers:/,/^[^ ]/' "$CONFIG" \
+            | grep '^ *-' | sed 's/^ *- *//' \
+            | jq -R -s 'split("\n") | map(select(length > 0))')
+          echo "reviewers=$REVIEWERS" >> "$GITHUB_OUTPUT"
+
+          AUTHOR=$(grep 'author_identity:' "$CONFIG" | awk '{print $2}')
+          echo "author_identity=${AUTHOR:-nathanjohnpayne}" >> "$GITHUB_OUTPUT"
+
+  # ──────────────────────────────────────────────
+  # Job 2: Auto-label PRs that need external review
   # ──────────────────────────────────────────────
   triage:
+    needs: [load-config]
     if: >
       github.event_name == 'pull_request' &&
       (github.event.action == 'opened' || github.event.action == 'ready_for_review')
@@ -18,13 +62,18 @@ jobs:
     outputs:
       needs_external: ${{ steps.check.outputs.needs_external }}
     steps:
-      - name: Evaluate PR size and file paths
+      - name: Evaluate PR against review-policy.yml
         id: check
         uses: actions/github-script@v7
+        env:
+          THRESHOLD: ${{ needs.load-config.outputs.threshold }}
+          PROTECTED_PATHS: ${{ needs.load-config.outputs.paths }}
         with:
           github-token: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           script: |
             const pr = context.payload.pull_request;
+            const threshold = parseInt(process.env.THRESHOLD, 10);
+            const protectedPaths = JSON.parse(process.env.PROTECTED_PATHS);
 
             const files = await github.paginate(
               github.rest.pulls.listFiles,
@@ -39,26 +88,22 @@ jobs:
               (sum, f) => sum + f.additions + f.deletions, 0
             );
 
-            const infraPatterns = [
-              /^\.github\//, /Dockerfile/, /docker-compose/,
-              /^Makefile/, /^scripts\//,
-              /package-lock\.json$/, /yarn\.lock$/, /pnpm-lock\.yaml$/,
-              /requirements.*\.txt$/, /Gemfile\.lock$/,
-            ];
+            // Convert glob patterns to regex for matching
+            function globToRegex(pattern) {
+              let re = pattern
+                .replace(/\./g, '\\.')
+                .replace(/\*\*/g, '___GLOBSTAR___')
+                .replace(/\*/g, '[^/]*')
+                .replace(/___GLOBSTAR___/g, '.*');
+              return new RegExp('^' + re + '$');
+            }
 
-            const authPatterns = [
-              /auth/i, /permission/i, /security/i,
-              /token/i, /credential/i, /\.env/,
-            ];
-
-            const touchesInfra = files.some(f =>
-              infraPatterns.some(p => p.test(f.filename))
-            );
-            const touchesAuth = files.some(f =>
-              authPatterns.some(p => p.test(f.filename))
+            const touchesProtected = files.some(f =>
+              protectedPaths.some(p => globToRegex(p).test(f.filename))
             );
 
-            const needsExternal = totalChanges >= 300 || touchesInfra || touchesAuth;
+            // Use >= to match REVIEW_POLICY.md definition
+            const needsExternal = totalChanges >= threshold || touchesProtected;
 
             if (needsExternal) {
               await github.rest.issues.addLabels({
@@ -72,74 +117,63 @@ jobs:
             core.setOutput('needs_external', needsExternal.toString());
 
   # ──────────────────────────────────────────────
-  # Job 2: Assign reviewer(s)
+  # Job 3: Assign reviewer (internal self-peer review)
   # ──────────────────────────────────────────────
   assign:
-    needs: [triage]
+    needs: [load-config, triage]
     if: >
       always() &&
       github.event_name == 'pull_request' &&
       (github.event.action == 'opened' || github.event.action == 'ready_for_review' || github.event.action == 'labeled')
     runs-on: ubuntu-latest
     steps:
-      - name: Assign cross-agent reviewer(s)
+      - name: Assign reviewer identity
         uses: actions/github-script@v7
+        env:
+          AUTHOR_IDENTITY: ${{ needs.load-config.outputs.author_identity }}
+          REVIEWERS_JSON: ${{ needs.load-config.outputs.reviewers }}
         with:
           github-token: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           script: |
             const author = context.payload.pull_request.user.login;
+            const authorIdentity = process.env.AUTHOR_IDENTITY || 'nathanjohnpayne';
+            const reviewers = JSON.parse(process.env.REVIEWERS_JSON || '[]');
 
-            const botAccounts = [
-              'nathanpayne-claude',
-              'nathanpayne-codex',
-              'nathanpayne-cursor',
-            ];
-
-            if (!botAccounts.includes(author)) {
-              console.log(`Author ${author} is not a bot; skipping.`);
+            // Under the new policy, all PRs are authored by the author identity.
+            // The reviewing agent's identity is assigned for internal self-peer review.
+            if (author !== authorIdentity) {
+              console.log(`Author ${author} is not ${authorIdentity}; skipping auto-assignment.`);
               return;
             }
 
-            const primaryMap = {
-              'nathanpayne-claude': 'nathanpayne-codex',
-              'nathanpayne-codex': 'nathanpayne-cursor',
-              'nathanpayne-cursor': 'nathanpayne-claude',
-            };
-
-            const labels = context.payload.pull_request.labels.map(l => l.name);
-            const needsExternal = labels.includes('needs-external-review');
-
-            const primary = primaryMap[author];
-            const reviewers = [primary];
-
-            if (needsExternal) {
-              const secondary = botAccounts.find(b => b !== author && b !== primary);
-              reviewers.push(secondary);
-              console.log(`External review: assigning ${reviewers.join(', ')}`);
-            } else {
-              console.log(`Standard review: assigning ${primary}`);
+            if (reviewers.length === 0) {
+              console.log('No reviewers configured in review-policy.yml');
+              return;
             }
 
-            // Check who is already requested to avoid duplicates
+            // Assign the first available reviewer identity for internal review.
+            // The agent performing the review will use its own reviewer identity.
+            const reviewer = reviewers[0];
+
             const { data: existingReviewers } = await github.rest.pulls.listRequestedReviewers({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
             });
             const alreadyRequested = existingReviewers.users.map(u => u.login);
-            const newReviewers = reviewers.filter(r => !alreadyRequested.includes(r));
 
-            if (newReviewers.length > 0) {
+            if (!alreadyRequested.includes(reviewer)) {
               await github.rest.pulls.requestReviewers({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: context.payload.pull_request.number,
-                reviewers: newReviewers,
+                reviewers: [reviewer],
               });
+              console.log(`Assigned ${reviewer} for internal review.`);
             }
 
   # ──────────────────────────────────────────────
-  # Job 3: Trigger subagent to perform the review
+  # Job 4: Trigger subagent to perform the review
   # ──────────────────────────────────────────────
   invoke-reviewer:
     needs: [assign]
@@ -193,10 +227,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CLAUDE_PAT }}
         run: |
           claude -p "Review PR #${{ github.event.pull_request.number }} on ${{ github.repository }}. \
+            Read REVIEW_POLICY.md for the review workflow. \
             Read the diff, check for correctness, security issues, style violations, and test coverage. \
             Post your review via the GitHub API using the GITHUB_TOKEN env var. \
-            Authenticate as nathanpayne-claude. \
-            If the PR has a review guidance document at reviews/pr-${{ github.event.pull_request.number }}-guidance.md, read it first." \
+            Authenticate as nathanpayne-claude." \
             --allowedTools "Bash,Read,Glob,Grep,WebFetch"
 
       # ── Codex: OpenAI Codex CLI ──
@@ -214,7 +248,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CODEX_PAT }}
         run: |
           # TODO: Replace with actual Codex CLI invocation once available
-          # codex --approval-mode full-auto -q "Review PR #${{ github.event.pull_request.number }}..."
           echo "Codex headless review invocation — pending CLI availability"
 
       # ── Cursor: no headless mode yet ──
@@ -232,22 +265,29 @@ jobs:
             });
 
   # ──────────────────────────────────────────────
-  # Job 4: Detect agent disagreement → escalate
+  # Job 5: Detect agent disagreement → escalate
   # ──────────────────────────────────────────────
   detect-disagreement:
     if: github.event_name == 'pull_request_review'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Check for conflicting reviews
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           script: |
-            const botAccounts = [
-              'nathanpayne-claude',
-              'nathanpayne-codex',
-              'nathanpayne-cursor',
-            ];
+            const fs = require('fs');
+            const yaml = require('js-yaml');
+
+            let reviewerAccounts;
+            try {
+              const config = yaml.load(fs.readFileSync('.github/review-policy.yml', 'utf8'));
+              reviewerAccounts = config.available_reviewers || [];
+            } catch (e) {
+              reviewerAccounts = ['nathanpayne-claude', 'nathanpayne-codex', 'nathanpayne-cursor'];
+            }
 
             const reviews = await github.rest.pulls.listReviews({
               owner: context.repo.owner,
@@ -255,14 +295,14 @@ jobs:
               pull_number: context.payload.pull_request.number,
             });
 
-            const latestByBot = {};
+            const latestByReviewer = {};
             for (const review of reviews.data) {
-              if (botAccounts.includes(review.user.login)) {
-                latestByBot[review.user.login] = review.state;
+              if (reviewerAccounts.includes(review.user.login)) {
+                latestByReviewer[review.user.login] = review.state;
               }
             }
 
-            const states = Object.values(latestByBot);
+            const states = Object.values(latestByReviewer);
             const hasApproval = states.includes('APPROVED');
             const hasChangesRequested = states.includes('CHANGES_REQUESTED');
 
@@ -278,12 +318,12 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,
-                body: '**Agent disagreement detected.** One reviewer approved and another requested changes. Escalating to @nathanjohnpayne for human review.',
+                body: '**Agent disagreement detected.** One reviewer approved and another requested changes. Escalating to @nathanjohnpayne for human tiebreaker per REVIEW_POLICY.md.',
               });
             }
 
   # ──────────────────────────────────────────────
-  # Job 5: Block self-approval
+  # Job 6: Block self-approval
   # ──────────────────────────────────────────────
   block-self-approval:
     if: >

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -8,27 +8,40 @@ on:
 permissions:
   issues: write
   pull-requests: read
+  contents: read
 
 jobs:
   audit:
     name: Audit Merged PRs
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Audit merged PRs for review policy compliance
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           script: |
+            const fs = require('fs');
+            const yaml = require('js-yaml');
+
+            // Read reviewer accounts from review-policy.yml
+            let reviewerAccounts;
+            let authorIdentity;
+            try {
+              const config = yaml.load(fs.readFileSync('.github/review-policy.yml', 'utf8'));
+              reviewerAccounts = config.available_reviewers || [];
+              authorIdentity = config.author_identity || 'nathanjohnpayne';
+            } catch (e) {
+              console.log('WARNING: Could not read review-policy.yml, using defaults');
+              reviewerAccounts = ['nathanpayne-claude', 'nathanpayne-codex', 'nathanpayne-cursor'];
+              authorIdentity = 'nathanjohnpayne';
+            }
+
             const since = new Date();
             since.setDate(since.getDate() - 7);
             const sinceISO = since.toISOString();
             const today = new Date().toISOString().split('T')[0];
-
-            const botAccounts = [
-              'nathanpayne-claude',
-              'nathanpayne-codex',
-              'nathanpayne-cursor',
-            ];
 
             // Get merged PRs from the past 7 days
             const prs = await github.paginate(
@@ -57,7 +70,7 @@ jobs:
                 prViolations.push('Missing `## Self-Review` section');
               }
 
-              // Check 2: Had needs-external-review label — verify approval
+              // Check 2: Had needs-external-review label — verify approval from a reviewer identity
               const hadExternalLabel = pr.labels.some(
                 l => l.name === 'needs-external-review'
               );
@@ -73,42 +86,35 @@ jobs:
                   r => r.state === 'APPROVED'
                 );
 
-                // For external-review PRs by bots, need 2 approvals from other bots or human
-                const isBotPR = botAccounts.includes(pr.user.login);
-                if (isBotPR && approvals.length < 2) {
-                  prViolations.push(
-                    'External-review PR merged with fewer than 2 approvals'
+                // Per REVIEW_POLICY.md: PRs authored by authorIdentity need
+                // at least one reviewer identity approval for internal review,
+                // plus external review coordination via the human.
+                const isAuthorPR = pr.user.login === authorIdentity;
+                if (isAuthorPR) {
+                  const reviewerApprovals = approvals.filter(
+                    r => reviewerAccounts.includes(r.user.login) || r.user.login === 'nathanjohnpayne'
                   );
-                }
-
-                // Check for human approval on non-bot PRs
-                if (!isBotPR) {
-                  const humanApprovals = approvals.filter(
-                    r => !botAccounts.includes(r.user.login)
-                  );
-                  if (humanApprovals.length === 0) {
+                  if (reviewerApprovals.length === 0) {
                     prViolations.push(
-                      'Had `needs-external-review` label but no human approval'
+                      'External-review PR merged with no reviewer approval'
                     );
                   }
                 }
               }
 
               // Check 3: Self-approval (author approved their own PR)
-              if (botAccounts.includes(pr.user.login)) {
-                const reviews = await github.rest.pulls.listReviews({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: pr.number,
-                });
+              const reviews = await github.rest.pulls.listReviews({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+              });
 
-                const selfApproval = reviews.data.some(
-                  r => r.user.login === pr.user.login && r.state === 'APPROVED'
-                );
+              const selfApproval = reviews.data.some(
+                r => r.user.login === pr.user.login && r.state === 'APPROVED'
+              );
 
-                if (selfApproval) {
-                  prViolations.push('Self-approval detected (author approved own PR)');
-                }
+              if (selfApproval) {
+                prViolations.push('Self-approval detected (author approved own PR)');
               }
 
               // Check 4: Had needs-human-review label — verify Nathan approved
@@ -117,12 +123,6 @@ jobs:
               );
 
               if (hadHumanLabel) {
-                const reviews = await github.rest.pulls.listReviews({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: pr.number,
-                });
-
                 const nathanApproved = reviews.data.some(
                   r => r.user.login === 'nathanjohnpayne' && r.state === 'APPROVED'
                 );
@@ -169,7 +169,7 @@ jobs:
               }
 
               body += `\n---\n\n`;
-              body += `Per policy, these PRs must be retroactively reviewed by a human within one business day.\n\n`;
+              body += `Per REVIEW_POLICY.md, these PRs must be retroactively reviewed by a human within one business day.\n\n`;
               body += `cc @nathanjohnpayne`;
 
               await github.rest.issues.create({

--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -19,10 +19,10 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           if echo "$PR_BODY" | grep -qE '^## Self-Review'; then
-            echo "✅ Self-Review section found."
+            echo "Self-Review section found."
           else
-            echo "❌ PR description must contain a '## Self-Review' section."
-            echo "Please add a structured self-review to your PR description."
+            echo "PR description must contain a '## Self-Review' section."
+            echo "Required items: correctness, regression risk, style/conventions, test coverage, security/dependency hygiene."
             exit 1
           fi
 
@@ -44,7 +44,8 @@ jobs:
 
             if (blockers.length > 0) {
               core.setFailed(
-                `Merge blocked by label(s): ${blockers.join(', ')}`
+                `Merge blocked by label(s): ${blockers.join(', ')}. ` +
+                `Per REVIEW_POLICY.md, the human is the tiebreaker and resolves blocking labels.`
               );
             }
 
@@ -58,37 +59,61 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check for external review triggers
+      - name: Check for external review triggers from review-policy.yml
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          CONFIG=".github/review-policy.yml"
           NEEDS_REVIEW=false
           REASONS=""
+
+          if [ ! -f "$CONFIG" ]; then
+            echo "WARNING: $CONFIG not found, skipping external review check"
+            echo "needs_review=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Read threshold from review-policy.yml
+          THRESHOLD=$(grep 'external_review_threshold:' "$CONFIG" | awk '{print $2}')
+          THRESHOLD=${THRESHOLD:-300}
 
           BASE_SHA=${{ github.event.pull_request.base.sha }}
           HEAD_SHA=${{ github.event.pull_request.head.sha }}
 
+          # Count lines changed (additions + deletions), excluding lockfiles and generated files
           LINES_CHANGED=$(git diff --stat "$BASE_SHA"..."$HEAD_SHA" -- \
             ':!*.lock' ':!*lock.json' ':!*.min.js' ':!*.min.css' \
             ':!*.generated.*' ':!*.g.dart' ':!*.freezed.dart' \
             | tail -1 | awk '{print $4+$6}')
           LINES_CHANGED=${LINES_CHANGED:-0}
 
-          if [ "$LINES_CHANGED" -gt 300 ]; then
+          # Use >= to match REVIEW_POLICY.md: "Total lines changed >= external_review_threshold"
+          if [ "$LINES_CHANGED" -ge "$THRESHOLD" ]; then
             NEEDS_REVIEW=true
-            REASONS="$REASONS- Over 300 non-generated lines changed ($LINES_CHANGED)%0A"
+            REASONS="$REASONS- ${LINES_CHANGED} lines changed (threshold: ${THRESHOLD})%0A"
           fi
 
-          SENSITIVE_FILES=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA" | grep -E \
-            '(^\.github/|/ci/|/auth/|/security/|^package\.json$|^package-lock\.json$|^requirements\.txt$|^Cargo\.toml$|^go\.mod$|^go\.sum$|^Gemfile$|^Gemfile\.lock$|^pubspec\.yaml$|^pubspec\.lock$)' \
-            || true)
+          # Read protected paths from review-policy.yml and check against diff
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")
+          PATHS=$(awk '/^external_review_paths:/,/^[^ ]/' "$CONFIG" \
+            | grep '^ *-' | sed 's/^ *- *"//' | sed 's/"$//')
 
-          if [ -n "$SENSITIVE_FILES" ]; then
+          MATCHED_FILES=""
+          for pattern in $PATHS; do
+            # Convert glob to grep-compatible pattern
+            REGEX=$(echo "$pattern" | sed 's/\*\*/.*/g' | sed 's/\*\//[^\/]*\//g' | sed 's/\*/[^\/]*/g')
+            MATCHES=$(echo "$CHANGED_FILES" | grep -E "$REGEX" || true)
+            if [ -n "$MATCHES" ]; then
+              MATCHED_FILES="$MATCHED_FILES$MATCHES"$'\n'
+            fi
+          done
+
+          if [ -n "$MATCHED_FILES" ]; then
             NEEDS_REVIEW=true
-            FILE_LIST=$(echo "$SENSITIVE_FILES" | sed 's/^/  - /' | tr '\n' ',' | sed 's/,/%0A/g')
-            REASONS="${REASONS}- Sensitive files modified:%0A${FILE_LIST}"
+            FILE_LIST=$(echo "$MATCHED_FILES" | sort -u | sed 's/^/  - /' | tr '\n' ',' | sed 's/,/%0A/g')
+            REASONS="${REASONS}- Protected paths modified:%0A${FILE_LIST}"
           fi
 
           echo "needs_review=$NEEDS_REVIEW" >> "$GITHUB_OUTPUT"
@@ -111,18 +136,17 @@ jobs:
           gh pr edit "$PR_NUMBER" --add-label "needs-external-review" \
             --repo "${{ github.repository }}"
 
-          # Format reasons for comment (convert %0A back to newlines)
           FORMATTED_REASONS=$(echo "$REASONS" | sed 's/%0A/\n/g')
 
           gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$(cat <<EOF
-          ⚠️ **External Review Required**
+**External Review Required**
 
-          This PR has been labeled \`needs-external-review\` because it meets one or more external review triggers:
+This PR has been labeled \`needs-external-review\` based on .github/review-policy.yml:
 
-          $FORMATTED_REASONS
+$FORMATTED_REASONS
 
-          **A human reviewer must review this PR and remove the \`needs-external-review\` label before it can be merged.**
+Per REVIEW_POLICY.md, the authoring agent must post a handoff message and alert the human. The human will coordinate external review by a different agent.
 
-          > This is an automated check per the repository's code review policy.
-          EOF
+> Automated check per .github/review-policy.yml
+EOF
           )"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,35 +10,4 @@ If any of these files are missing, flag the gap before proceeding.
 
 # Code Review Requirements
 
-All AI-generated code must undergo peer review before merge.
-
-## Self-Review (Required for Every PR)
-
-Before opening or updating a pull request, you MUST perform a structured self-review and include it in the PR description under a `## Self-Review` heading covering:
-
-- Correctness against the stated requirements or ticket
-- Regression risk—does this change break existing behavior?
-- Style and convention adherence per this repository's standards
-- Test coverage—are new paths tested and existing tests still passing?
-- Security and dependency hygiene
-
-## External Peer Review
-
-External review is required when any of the following apply:
-
-- The PR touches more than 300 lines of non-generated code
-- The PR modifies shared infrastructure, CI/CD pipelines, or dependency versions
-- The PR introduces a new architectural pattern or departs from an established one
-- The PR affects authentication, authorization, or data handling
-- Your confidence in any portion of the change is below high
-
-When external review is required, you MUST explicitly request it by tagging the appropriate reviewer(s) and MUST NOT self-merge. Include a `## Review Guidance` section in the PR description flagging specific areas where human judgment is needed and why.
-
-## Rules
-
-- NEVER remove the `needs-external-review` or `needs-human-review` labels from a PR. Only a human reviewer may remove them.
-- NEVER approve your own PR. Self-approvals are automatically dismissed and labeled `policy-violation`.
-- PRs missing the `## Self-Review` section will be blocked by CI.
-- PRs labeled `needs-external-review`, `needs-human-review`, or `policy-violation` cannot be merged until the label is resolved.
-- When your PR is labeled `needs-external-review`, push a review guidance branch (`review/pr-{number}-guidance`) with a `reviews/pr-{number}-guidance.md` file using the template at `.github/templates/review-guidance.md`.
-- Cross-agent review rotation: Claude → Codex → Cursor → Claude. You will be auto-assigned as a reviewer on other agents' PRs.
+Follow the code review workflow in REVIEW_POLICY.md. Use .github/review-policy.yml for thresholds and protected paths. See the "Code Review Policy" section in AGENTS.md for a summary.

--- a/docs/agents/code-review-requirements.md
+++ b/docs/agents/code-review-requirements.md
@@ -1,82 +1,9 @@
 # Code Review Requirements
 
-All AI-generated code must undergo peer review before merge.
+This section has been consolidated into the repository-wide review policy.
 
-## Self-Review (Required for Every PR)
+- **Full policy:** [REVIEW_POLICY.md](../../REVIEW_POLICY.md)
+- **Per-repo configuration:** [.github/review-policy.yml](../../.github/review-policy.yml)
+- **Summary in AGENTS.md:** See the "Code Review Policy" section
 
-Before opening or updating a pull request, the authoring agent must perform a structured self-review covering:
-
-- Correctness against the stated requirements or ticket
-- Regression risk---does this change break existing behavior?
-- Style and convention adherence per this repository's standards
-- Test coverage---are new paths tested and existing tests still passing?
-- Security and dependency hygiene
-
-The self-review summary must be included in the PR description under a `## Self-Review` heading.
-
-## Review Tiers
-
-### Standard PRs
-
-Criteria: under 300 lines of non-generated code, no infra/auth/architecture triggers.
-
-- One agent reviewer (not the author) may approve and merge.
-- The author must not approve or merge their own PR.
-
-### External-Review PRs
-
-Criteria: 300+ lines, OR touches infra/CI/CD/deps, OR new architecture, OR auth/data handling, OR author confidence below high.
-
-- The PR is auto-labeled `needs-external-review`.
-- Two agent reviewers (neither the author) must both approve.
-- The authoring agent pushes a `review/pr-{number}-guidance` branch with a structured review guidance document (see below).
-- The second approving reviewer removes the `needs-external-review` label, unblocking merge.
-- The author must not remove this label under any circumstances.
-
-### Human-Escalated PRs
-
-- If agent reviewers disagree (one approves, one requests changes), the PR is auto-labeled `needs-human-review`.
-- If @nathanjohnpayne manually adds the `needs-human-review` label, agent-only merge is blocked.
-- Only @nathanjohnpayne may remove `needs-human-review` and approve.
-
-## Review Guidance (External Reviews Only)
-
-When your PR is labeled `needs-external-review`, you must:
-
-1. Create a branch named `review/pr-{number}-guidance` off the PR's head branch.
-2. Add a file `reviews/pr-{number}-guidance.md` using the template at `.github/templates/review-guidance.md`.
-3. Fill in all sections honestly---do not minimize risks or inflate confidence.
-4. Push the branch. Do not open a PR for this branch; it is a reference artifact only.
-5. Post a comment on the PR linking to the guidance file.
-
-External reviewers must read the guidance document before starting their review.
-
-## Agent Review Identities
-
-AI agents post reviews under dedicated GitHub accounts:
-
-| Agent | GitHub username |
-|---|---|
-| Claude | @nathanpayne-claude |
-| Codex | @nathanpayne-codex |
-| Cursor | @nathanpayne-cursor |
-
-Cross-agent review rotation: Claude → Codex → Cursor → Claude. For external-review PRs, the second reviewer is the remaining agent not already involved.
-
-## Enforcement
-
-1. **CI gate:** A required status check validates that every PR description contains a `## Self-Review` section. PRs missing this section are blocked from merge.
-
-2. **Auto-labeling:** A GitHub Actions workflow evaluates the PR against external review triggers (line count, file paths touching infrastructure or auth, dependency changes). PRs that meet any trigger are automatically labeled `needs-external-review`.
-
-3. **Label gate:** PRs with `needs-external-review`, `needs-human-review`, or `policy-violation` labels are blocked from merge by a required status check.
-
-4. **Self-approval block:** If an agent approves its own PR, the approval is automatically dismissed and the PR is labeled `policy-violation`.
-
-5. **Disagreement escalation:** If one agent reviewer approves and another requests changes, the PR is auto-labeled `needs-human-review` and @nathanjohnpayne is notified.
-
-6. **No self-removal of labels:** Agents must not remove the `needs-external-review` or `needs-human-review` labels. Only a human reviewer may remove them. Agent attempts to remove these labels are treated as policy violations.
-
-7. **Post-merge audit:** A weekly automated audit checks merged PRs for policy compliance---missing self-reviews, missing approvals, or bypassed label gates. Violations are surfaced in an issue to @nathanjohnpayne.
-
-8. **Violation handling:** PRs identified as policy violations in post-merge audit must be retroactively reviewed by a human within one business day. Repeat violations trigger a review of that agent's permissions and autonomy level. Escalation owner: @nathanjohnpayne.
+All review behavior---identities, workflow, thresholds, handoff format, and post-merge issue rules---is governed by those files. Do not add review rules here; update REVIEW_POLICY.md instead.


### PR DESCRIPTION
## Summary

Reconciles 6 review-policy-related files so that all agent instructions and CI workflows defer to the canonical `REVIEW_POLICY.md`.

- **docs/agents/code-review-requirements.md**: updated to point to REVIEW_POLICY.md as the source of truth
- **.github/copilot-instructions.md**: updated to defer to REVIEW_POLICY.md
- **CLAUDE.md**: updated to defer to REVIEW_POLICY.md
- **.github/workflows/agent-review.yml**: reads review-policy.yml, expects nathanjohnpayne as author
- **.github/workflows/pr-review-policy.yml**: reads review-policy.yml, uses >= threshold comparison
- **.github/workflows/pr-audit.yml**: reads review-policy.yml, expects nathanjohnpayne as author

## Test plan

- [ ] Verify all 6 files are present and correctly updated
- [ ] Confirm CI workflows pass on this branch
- [ ] Validate that agent instructions reference REVIEW_POLICY.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)