### PR TITLE
Fix remaining review policy conflicts

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -84,7 +84,16 @@ jobs:
               }
             );
 
-            const totalChanges = files.reduce(
+            // Exclude lockfiles, minified, and generated files from line count
+            // to match REVIEW_POLICY.md threshold definition
+            const excludePatterns = [
+              /\.lock$/, /lock\.json$/, /\.min\.js$/, /\.min\.css$/,
+              /\.generated\./, /\.g\.dart$/, /\.freezed\.dart$/,
+            ];
+            const countedFiles = files.filter(
+              f => !excludePatterns.some(p => p.test(f.filename))
+            );
+            const totalChanges = countedFiles.reduce(
               (sum, f) => sum + f.additions + f.deletions, 0
             );
 
@@ -127,7 +136,7 @@ jobs:
       (github.event.action == 'opened' || github.event.action == 'ready_for_review' || github.event.action == 'labeled')
     runs-on: ubuntu-latest
     steps:
-      - name: Assign reviewer identity
+      - name: Assign reviewer identity based on Authoring-Agent
         uses: actions/github-script@v7
         env:
           AUTHOR_IDENTITY: ${{ needs.load-config.outputs.author_identity }}
@@ -135,12 +144,12 @@ jobs:
         with:
           github-token: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           script: |
-            const author = context.payload.pull_request.user.login;
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
             const authorIdentity = process.env.AUTHOR_IDENTITY || 'nathanjohnpayne';
             const reviewers = JSON.parse(process.env.REVIEWERS_JSON || '[]');
 
             // Under the new policy, all PRs are authored by the author identity.
-            // The reviewing agent's identity is assigned for internal self-peer review.
             if (author !== authorIdentity) {
               console.log(`Author ${author} is not ${authorIdentity}; skipping auto-assignment.`);
               return;
@@ -151,14 +160,34 @@ jobs:
               return;
             }
 
-            // Assign the first available reviewer identity for internal review.
-            // The agent performing the review will use its own reviewer identity.
-            const reviewer = reviewers[0];
+            // Read the Authoring-Agent line from the PR body to determine which
+            // agent wrote the code. Per REVIEW_POLICY.md, the same agent reviews
+            // under its own reviewer identity (e.g., claude → nathanpayne-claude).
+            const body = pr.body || '';
+            const agentMatch = body.match(/^Authoring-Agent:\s*(\w+)/mi);
+            let reviewer;
+
+            if (agentMatch) {
+              const agentName = agentMatch[1].toLowerCase();
+              const matchingReviewer = reviewers.find(
+                r => r.endsWith(`-${agentName}`)
+              );
+              if (matchingReviewer) {
+                reviewer = matchingReviewer;
+                console.log(`Authoring-Agent: ${agentName} → assigning ${reviewer}`);
+              } else {
+                console.log(`Authoring-Agent: ${agentName} has no matching reviewer identity, using first available.`);
+                reviewer = reviewers[0];
+              }
+            } else {
+              console.log('No Authoring-Agent line found in PR body; assigning first available reviewer.');
+              reviewer = reviewers[0];
+            }
 
             const { data: existingReviewers } = await github.rest.pulls.listRequestedReviewers({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
+              pull_number: pr.number,
             });
             const alreadyRequested = existingReviewers.users.map(u => u.login);
 
@@ -166,10 +195,10 @@ jobs:
               await github.rest.pulls.requestReviewers({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                pull_number: context.payload.pull_request.number,
+                pull_number: pr.number,
                 reviewers: [reviewer],
               });
-              console.log(`Assigned ${reviewer} for internal review.`);
+              console.log(`Assigned ${reviewer} for internal self-peer review.`);
             }
 
   # ──────────────────────────────────────────────
@@ -331,15 +360,38 @@ jobs:
       github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     steps:
-      - name: Dismiss if reviewer is PR author
+      - name: Dismiss self-approval from reviewer bot accounts
+        uses: actions/checkout@v4
+
+      - name: Check and dismiss
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           script: |
+            const fs = require('fs');
+            const yaml = require('js-yaml');
+
             const prAuthor = context.payload.pull_request.user.login;
             const reviewer = context.payload.review.user.login;
 
-            if (prAuthor === reviewer) {
+            // Only block self-approval from reviewer bot accounts.
+            // The human (nathanjohnpayne) IS the PR author under the shared
+            // identity model, but must be allowed to approve for tiebreaker
+            // and human-escalated reviews per REVIEW_POLICY.md.
+            let reviewerAccounts;
+            try {
+              const config = yaml.load(fs.readFileSync('.github/review-policy.yml', 'utf8'));
+              reviewerAccounts = config.available_reviewers || [];
+            } catch (e) {
+              reviewerAccounts = ['nathanpayne-claude', 'nathanpayne-codex', 'nathanpayne-cursor'];
+            }
+
+            // A reviewer bot account cannot approve a PR it authored.
+            // Since all PRs are authored by nathanjohnpayne, this only fires
+            // if a bot account somehow ends up as the PR author (shouldn't
+            // happen under the policy, but guard against it).
+            const isReviewerBot = reviewerAccounts.includes(reviewer);
+            if (prAuthor === reviewer && isReviewerBot) {
               await github.rest.pulls.dismissReview({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -86,52 +86,55 @@ jobs:
                   r => r.state === 'APPROVED'
                 );
 
-                // Per REVIEW_POLICY.md: PRs authored by authorIdentity need
-                // at least one reviewer identity approval for internal review,
-                // plus external review coordination via the human.
-                const isAuthorPR = pr.user.login === authorIdentity;
-                if (isAuthorPR) {
-                  const reviewerApprovals = approvals.filter(
-                    r => reviewerAccounts.includes(r.user.login) || r.user.login === 'nathanjohnpayne'
+                // Per REVIEW_POLICY.md: external-review PRs need at least one
+                // approval from a reviewer identity (nathanpayne-{agent}).
+                // nathanjohnpayne is the PR author, so their approval does not
+                // count toward the reviewer approval requirement.
+                const reviewerApprovals = approvals.filter(
+                  r => reviewerAccounts.includes(r.user.login)
+                );
+                if (reviewerApprovals.length === 0) {
+                  prViolations.push(
+                    'External-review PR merged with no reviewer identity approval'
                   );
-                  if (reviewerApprovals.length === 0) {
-                    prViolations.push(
-                      'External-review PR merged with no reviewer approval'
-                    );
-                  }
                 }
               }
 
-              // Check 3: Self-approval (author approved their own PR)
+              // Check 3: Self-approval from bot accounts
+              // Under the shared identity model, all PRs are authored by
+              // authorIdentity (nathanjohnpayne). The human IS that identity,
+              // so nathanjohnpayne approving is legitimate (human tiebreaker).
+              // Only flag if a reviewer bot account approved its own PR.
               const reviews = await github.rest.pulls.listReviews({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: pr.number,
               });
 
-              const selfApproval = reviews.data.some(
-                r => r.user.login === pr.user.login && r.state === 'APPROVED'
+              const botSelfApproval = reviews.data.some(
+                r => r.user.login === pr.user.login &&
+                     r.state === 'APPROVED' &&
+                     reviewerAccounts.includes(r.user.login)
               );
 
-              if (selfApproval) {
-                prViolations.push('Self-approval detected (author approved own PR)');
+              if (botSelfApproval) {
+                prViolations.push('Bot self-approval detected (reviewer account approved its own PR)');
               }
 
-              // Check 4: Had needs-human-review label — verify Nathan approved
+              // Check 4: Had needs-human-review label — verify it was removed before merge.
+              // Under the shared identity model, nathanjohnpayne is the PR author
+              // and cannot self-approve via the GitHub review API. The human
+              // resolves escalation by removing the label (which unblocks the
+              // label-gate check). If the label is still present at merge time,
+              // it means the label gate was bypassed.
               const hadHumanLabel = pr.labels.some(
                 l => l.name === 'needs-human-review'
               );
 
               if (hadHumanLabel) {
-                const nathanApproved = reviews.data.some(
-                  r => r.user.login === 'nathanjohnpayne' && r.state === 'APPROVED'
+                prViolations.push(
+                  'Merged with `needs-human-review` label still present — human resolution was bypassed'
                 );
-
-                if (!nathanApproved) {
-                  prViolations.push(
-                    'Had `needs-human-review` label but @nathanjohnpayne did not approve'
-                  );
-                }
               }
 
               // Check 5: Had policy-violation label — should not have been merged

--- a/REVIEW_POLICY.md
+++ b/REVIEW_POLICY.md
@@ -38,7 +38,7 @@ To add a new agent, register a GitHub account following the pattern `nathanpayne
 
 1. The agent creates a feature branch from the target branch (e.g., `main`).
 2. The agent writes code as `nathanjohnpayne`, following all project-level rules (linting, testing, conventions).
-3. The agent files a PR from the feature branch to the target branch under `nathanjohnpayne`.
+3. The agent files a PR from the feature branch to the target branch under `nathanjohnpayne`. The PR description must include an `Authoring-Agent:` line identifying which agent wrote the code (e.g., `Authoring-Agent: claude`). This is required because all PRs share the `nathanjohnpayne` author identity, and the workflow uses this line to assign the correct reviewer identity for internal self-peer review.
 
 ### Phase 2: Internal Review (Self-Peer Review)
 
@@ -50,6 +50,8 @@ To add a new agent, register a GitHub account following the pattern `nathanpayne
 **All review rounds are captured as GitHub PR comments and commits.** The back-and-forth should read like two developers collaborating.
 
 ### Phase 3: External Review Threshold Check
+
+> **Note on automation timing:** CI workflows may apply the `needs-external-review` label automatically when a PR is opened or updated, as an early advisory based on line count and protected paths. This label blocks merge immediately. The agent's responsibility is to post the handoff message and alert the human after internal review passes—the label itself may already be present.
 
 8. After internal review passes, the agent evaluates whether the PR meets the external review threshold (see [Review Policy Configuration](#review-policy-configuration)).
 9. If the threshold is **not** met, the agent merges the PR as `nathanjohnpayne`. Done.
@@ -156,10 +158,12 @@ If the internal reviewer and external reviewer disagree on whether code is ready
 
 Each repository contains a `.github/review-policy.yml` file that governs review behavior. This file is read by the agent at the start of every review cycle.
 
-```yaml
-# .github/review-policy.yml
+The following is an **illustrative example with default values**. Each repository's actual `.github/review-policy.yml` may have different `external_review_paths` customized to its directory structure. Always read the repo's actual file, not this example.
 
-# Lines changed (additions + deletions) that trigger external review.
+```yaml
+# .github/review-policy.yml (example defaults — actual config may differ)
+
+# Lines changed (additions + deletions, excluding generated/lockfiles) that trigger external review.
 # Set to 0 to require external review on every PR.
 # Set to a very high number to effectively disable.
 external_review_threshold: 300
@@ -188,10 +192,10 @@ default_external_reviewer: nathanpayne-codex
 
 A PR requires external review if **either** condition is true:
 
-1. Total lines changed (additions + deletions) ≥ `external_review_threshold`
+1. Total non-generated lines changed (additions + deletions) ≥ `external_review_threshold`. Lockfiles (`*.lock`, `*lock.json`), minified files (`*.min.js`, `*.min.css`), and generated files (`*.generated.*`) are excluded from the count.
 2. Any file in the PR diff matches a pattern in `external_review_paths`
 
-The agent evaluates this after internal review passes, before merging.
+The agent evaluates this after internal review passes, before merging. CI workflows may also evaluate and label earlier as an advisory (see Phase 3 note above).
 
 ## Git Identity Switching
 


### PR DESCRIPTION
## Summary
- Updates REVIEW_POLICY.md, agent-review.yml, and pr-audit.yml to resolve remaining policy conflicts
- Adds Authoring-Agent requirement, threshold timing note, non-generated line count definition, and marks example YAML as illustrative
- Scopes self-approval to bot accounts, excludes generated files from line counts, and requires reviewer identity for external-review approval

## Test plan
- [ ] Verify agent-review workflow parses Authoring-Agent from PR body correctly
- [ ] Confirm generated files are excluded from non-generated line count
- [ ] Check pr-audit workflow enforces reviewer identity for external-review approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)