### PR TITLE
docs: add no-direct-push-to-main rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ If any of these files are missing, flag the gap before proceeding.
 
 # Code Review — Mandatory Checklist
 
+Never push directly to `main`. All changes must go through a pull request.
+
 Every PR you open must follow this workflow. No exceptions unless the human
 explicitly authorizes a break-glass override in chat.
 

--- a/rules/repo_rules.md
+++ b/rules/repo_rules.md
@@ -33,6 +33,7 @@ The following tool config directories must contain only configuration — no ins
 
 ## Forbidden Patterns
 
+- **Never push directly to `main`.** All changes must go through a pull request—even single-line fixes, documentation updates, and deploy config changes. The only exception is if the human explicitly authorizes a direct push in chat as a break-glass override.
 - **No frameworks, bundlers, or package managers.** This site is intentionally dependency-free. Do not introduce npm, a bundler, or any JavaScript framework without explicit discussion and a `plans/` entry.
 - **No hard-coded motion values.** All CSS durations and easing functions must use the motion token variables defined in `:root`. No bare `ms` values or bare `ease` keywords anywhere.
 - **No instruction files in tool folders.** `.claude/` and `.cursor/` must not contain plain `.md` or `.txt` instruction files. Cursor `.mdc` rule files are permitted as valid Cursor configuration format.


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
- Add explicit "never push directly to main" rule to `rules/repo_rules.md` Forbidden Patterns
- Add prominent reminder line to `CLAUDE.md` Code Review section
- Prevents agents from bypassing the PR review workflow

## Self-Review
- **Correctness:** Rule text is clear and matches existing break-glass override pattern
- **Regression risk:** None—documentation only
- **Style:** Consistent with existing forbidden pattern entries
- **Test coverage:** N/A (docs only)
- **Security/dependency hygiene:** No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)