### PR TITLE
Improve blog visual presentation across index and post pages

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -66,6 +66,7 @@
         <p class="project-kicker">Essays × Systems × Product</p>
         <h1>Blog</h1>
         <p class="project-deck">Essays and notes on AI agents, product systems, debugging, and the invisible constraints that shape what people actually experience.</p>
+        <p class="blog-index-aside">Writing about system boundaries, product judgment, engineering tradeoffs, and where AI-generated code breaks when the model never forms the right mental model.</p>
         <div class="project-actions">
           <a class="project-action" href="/">Back to Homepage</a>
         </div>
@@ -86,13 +87,14 @@
             </div>
           </div>
         </section>
-        <aside class="project-sidebar">
-          <section class="project-card" aria-labelledby="blog-about">
-            <h2 id="blog-about">What lives here</h2>
-            <p class="project-note">Writing about system boundaries, product judgment, engineering tradeoffs, and where AI-generated code breaks when the model never forms the right mental model.</p>
-          </section>
-        </aside>
       </div>
+
+      <footer class="blog-footer">
+        <p class="blog-footer-attribution">Nathan Payne · San Francisco</p>
+        <nav class="blog-footer-nav">
+          <a class="project-action" href="/">&larr; Back to Homepage</a>
+        </nav>
+      </footer>
     </article>
   </main>
 </body>

--- a/blog/six-prs-one-bug-agent-failure-modes/index.html
+++ b/blog/six-prs-one-bug-agent-failure-modes/index.html
@@ -82,6 +82,14 @@
       </header>
 
       <div class="project-layout blog-layout">
+        <div class="blog-meta-bar">
+          <dl>
+            <div><dt>Published</dt><dd>April 4, 2026</dd></div>
+            <div><dt>Author</dt><dd>Nathan Payne</dd></div>
+            <div><dt>Reading time</dt><dd>11 min read</dd></div>
+            <div><dt>Tags</dt><dd>AI · Engineering · Product · Systems · Debugging</dd></div>
+          </dl>
+        </div>
         <div class="project-copy">
           <article class="project-section blog-prose" aria-labelledby="post-body">
             <h2 id="post-body" class="blog-prose-title">Essay</h2>
@@ -92,9 +100,9 @@
 <p>I have the full session log: eighteen user prompts, nine external code review rounds, three automated stop-hook interventions, and the task document that finally produced the fix. This post is about what that record shows.</p>
 <h2>The invariant was simple</h2>
 <p>If a template editor is going to be trustworthy, it has to preserve one basic invariant:</p>
-<pre class="blog-code-block"><code class="language-text">Editor = Preview = Sent email</code></pre>
+<pre class="blog-code-block blog-code-block--light"><code class="language-text">Editor = Preview = Sent email</code></pre>
 <p>Here is what the actual pipeline looked like after the TipTap migration:</p>
-<pre class="blog-code-block"><code class="language-text">Editor:  TipTap / ProseMirror document -&gt; Editor DOM
+<pre class="blog-code-block blog-code-block--light"><code class="language-text">Editor:  TipTap / ProseMirror document -&gt; Editor DOM
 Preview: TipTap / ProseMirror document -&gt; docToPlainTextWithTokens() -&gt; CommonMark renderer -&gt; Preview HTML
 Email:   TipTap / ProseMirror document -&gt; docToPlainTextWithTokens() -&gt; Regex-based renderer -&gt; Sent email HTML</code></pre>
 <p>The editor rendered structured content directly. Preview and send did not. They first flattened that structured document back into markdown-like plain text, then reparsed it through two different HTML pipelines.</p>
@@ -102,13 +110,13 @@ Email:   TipTap / ProseMirror document -&gt; docToPlainTextWithTokens() -&gt; Re
 <h2>What the screenshots were actually saying</h2>
 <p>The screenshots in <a href="https://github.com/nathanjohnpayne/friends-and-family-billing/issues/159">issue #159</a> are not just visual proof that something looked off. They are evidence that different layers of the system were interpreting the same content differently.</p>
 <h3>1. Editor: the structured document still looked sane</h3>
-<figure class="blog-figure"><img src="https://raw.githubusercontent.com/nathanjohnpayne/friends-and-family-billing/issue/invoice-rendering-bug-screenshots/.github/screenshots/invoice-bug-01-editor-view.png" alt="Editor Screenshot" loading="lazy" /><figcaption>Editor Screenshot</figcaption></figure>
+<figure class="blog-figure"><img src="https://raw.githubusercontent.com/nathanjohnpayne/friends-and-family-billing/issue/invoice-rendering-bug-screenshots/.github/screenshots/invoice-bug-01-editor-view.png" alt="Editor Screenshot" loading="lazy" /><figcaption><strong>Figure 1:</strong> Editor Screenshot</figcaption></figure>
 <p>In Edit mode, the intro paragraph is ordinary body text. The billing-summary link, payment options block, divider, and signature are all in the expected order. At this point the content still lives as structured TipTap / ProseMirror JSON, so the system has not yet lost information.</p>
 <h3>2. Preview: semantics changed during the markdown round-trip</h3>
-<figure class="blog-figure"><img src="https://raw.githubusercontent.com/nathanjohnpayne/friends-and-family-billing/issue/invoice-rendering-bug-screenshots/.github/screenshots/invoice-bug-02-preview-view.png" alt="Preview Screenshot" loading="lazy" /><figcaption>Preview Screenshot</figcaption></figure>
+<figure class="blog-figure"><img src="https://raw.githubusercontent.com/nathanjohnpayne/friends-and-family-billing/issue/invoice-rendering-bug-screenshots/.github/screenshots/invoice-bug-02-preview-view.png" alt="Preview Screenshot" loading="lazy" /><figcaption><strong>Figure 2:</strong> Preview Screenshot</figcaption></figure>
 <p>Preview was not rendering the editor document directly. It serialized the document into markdown-like text and reparsed that text with CommonMark. Separator lines like <code>---</code> were being interpreted differently across surfaces, and list content was picking up paragraph wrappers with default margins. That is why the Preview screenshot looks heavier and more spread out than the editor even though the author never changed the template content.</p>
 <h3>3. Sent email: a second parser created a third version of reality</h3>
-<figure class="blog-figure"><img src="https://raw.githubusercontent.com/nathanjohnpayne/friends-and-family-billing/issue/invoice-rendering-bug-screenshots/.github/screenshots/invoice-bug-03-broken-sent-email.png" alt="Sent Email Screenshot" loading="lazy" /><figcaption>Sent Email Screenshot</figcaption></figure>
+<figure class="blog-figure"><img src="https://raw.githubusercontent.com/nathanjohnpayne/friends-and-family-billing/issue/invoice-rendering-bug-screenshots/.github/screenshots/invoice-bug-03-broken-sent-email.png" alt="Sent Email Screenshot" loading="lazy" /><figcaption><strong>Figure 3:</strong> Sent Email Screenshot</figcaption></figure>
 <p>The sent email did not use the Preview renderer. It took the same flattened text and pushed it through a separate regex-based markdown renderer in the Cloud Function. So by the time the email reached a customer inbox, the system had already turned one source document into three different interpretations: editor, preview, and email.</p>
 <h3>4. The target was concrete, not hypothetical</h3>
 <p>This detail in the issue mattered: there was a known-good email from <strong>April 2, 2026 at 5:05 PM</strong>. The bug was not &quot;make Preview look a little nicer.&quot; The bug was &quot;restore parity with a real output that previously existed.&quot;</p>
@@ -116,13 +124,13 @@ Email:   TipTap / ProseMirror document -&gt; docToPlainTextWithTokens() -&gt; Re
 <h2>What I actually said to the agent</h2>
 <p>I have the full session transcript. Here is how I described the bug across four separate prompts:</p>
 <p><strong>Prompt 6</strong> (first report, two screenshots):</p>
-<p>&gt; The text shows bold in preview, but not in the editor.</p>
+<blockquote>The text shows bold in preview, but not in the editor.</blockquote>
 <p><strong>Prompt 7</strong> (second report, two screenshots):</p>
-<p>&gt; The bold issue is still there. It does not get fixed by bolding and unbolding, it doesn&#39;t work at all. To add insult to injury, the app is now loading slowly or failing to reload, even after restarting the browser. Look hard this time, you keep missing something.</p>
+<blockquote>The bold issue is still there. It does not get fixed by bolding and unbolding, it doesn&#39;t work at all. To add insult to injury, the app is now loading slowly or failing to reload, even after restarting the browser. Look hard this time, you keep missing something.</blockquote>
 <p><strong>Prompt 9</strong> (third report, five screenshots of a full reload cycle):</p>
 <p>The same message, verbatim. I had already run out of new ways to describe the problem. The only thing that changed was the evidence: two screenshots became five, showing the full reload cycle from dashboard to editor to preview, proving the bug survived a hard refresh. The words were identical because the bug was identical. The agent had changed code between these prompts. The output had not changed.</p>
 <p><strong>Prompt 11</strong> (desperation):</p>
-<p>&gt; Given this is a simply single email template, maybe it is okay to sacrifice to get it right?</p>
+<blockquote>Given this is a simply single email template, maybe it is okay to sacrifice to get it right?</blockquote>
 <p>By prompt 11, I was offering to throw away the template rather than keep watching the agent fail. Every developer who has used an agent for more than ten minutes will recognize this arc: you start by describing a bug, escalate to &quot;you keep missing something,&quot; send the same message twice because the bug is the same, and end by questioning your own requirements.</p>
 <p>Notice what I never said in any of those prompts. I never said &quot;Preview and email must use the same rendering path.&quot; I never said &quot;the markdown bridge is the wrong architecture.&quot; I never said &quot;audit your previous fixes before trying again.&quot; I described the symptom each time, more urgently, and expected the agent to promote the symptom into a structural diagnosis.</p>
 <p>It did not.</p>
@@ -133,7 +141,7 @@ Email:   TipTap / ProseMirror document -&gt; docToPlainTextWithTokens() -&gt; Re
 <p>The crucial idea in the PR description was: keep <code>docToPlainTextWithTokens()</code> as the bridge and leave the old invoice body builder in place.</p>
 <p>That decision made the rest of the bug almost inevitable. The app now had a rich-text editor as the authoring surface, but Preview and send still depended on a lossy intermediate format. The structured document was treated as temporary.</p>
 <p>My kickoff prompt for the session was:</p>
-<p>&gt; Read /Users/nathanpayne/GitHub/docs/projects/friends-and-family-billing/invoicing-tab-redesign.md and implement the plan.</p>
+<blockquote>Read /Users/nathanpayne/GitHub/docs/projects/friends-and-family-billing/invoicing-tab-redesign.md and implement the plan.</blockquote>
 <p>The design spec described what the invoicing tab should look like. It did not describe what architectural invariants the rendering pipeline should preserve. So the agent picked the fastest path to a working UI: keep the old pipeline, bolt a new editor on top.</p>
 <h3>PR #146: the agent got better at regex, not closer to the invariant</h3>
 <p><a href="https://github.com/nathanjohnpayne/friends-and-family-billing/pull/146">PR #146</a> fixed bold-token round-tripping by making the serializer emit bold-wrapped token markers and tightening the token regex:</p>
@@ -145,7 +153,7 @@ const tokenPattern = /\*\*%([a-z_]+)%\*\*|%([a-z_]+)%/g;</code></pre>
 <p>This is a perfectly reasonable patch if you assume the markdown bridge is the right architecture and the problem is only that the bridge is slightly lossy.</p>
 <p>But that assumption was the bug.</p>
 <p>Here is the part that makes the session log valuable: my automated code review agent, nathanpayne-codex, flagged exactly this problem in its review of PR #146:</p>
-<p>&gt; Exact bold-wrapped tokens are not round-trip safe. <code>plainTextToDoc(&quot;<strong>%first_name%</strong>&quot;)</code> creates a bold-marked token node, but <code>docToPlainTextWithTokens()</code> serializes it back to <code>%first_name%</code>.</p>
+<blockquote>Exact bold-wrapped tokens are not round-trip safe. <code>plainTextToDoc(&quot;<strong>%first_name%</strong>&quot;)</code> creates a bold-marked token node, but <code>docToPlainTextWithTokens()</code> serializes it back to <code>%first_name%</code>.</blockquote>
 <p>The review identified the round-trip lossiness. The agent fixed the specific regex. It did not ask why the round-trip existed.</p>
 <h3>PR #153: one part semantic patch, one part visual patch</h3>
 <p><a href="https://github.com/nathanjohnpayne/friends-and-family-billing/pull/153">PR #153</a> contains two different kinds of reasonable fix in one diff, which is why it is my favorite example.</p>
@@ -162,7 +170,7 @@ if (marks.some(m =&gt; m.type === &#39;italic&#39;)) result = &#39;*&#39; + resu
 <p>The review feedback on PR #155 is telling. The nathanpayne-codex reviewer flagged three separate round-trip safety issues: link parsing that stopped at the first <code>)</code> in a URL, italic-wrapped links that did not survive serialization, and marked token forms that were not covered. Three findings, all pointing at the same structural problem, the intermediate format was lossy, and the agent addressed each one as a scoped regex fix.</p>
 <h3>PR #158: the bridge got cleaner, and the system stayed wrong</h3>
 <p><a href="https://github.com/nathanjohnpayne/friends-and-family-billing/pull/158">PR #158</a> is where sunk cost becomes obvious. The serializer logic was extracted into a lightweight <code>template-doc.js</code>, and adjacent marked segments were merged so TipTap would not emit markdown like this:</p>
-<pre class="blog-code-block"><code class="language-text">**word1****word2**</code></pre>
+<pre class="blog-code-block blog-code-block--light"><code class="language-text">**word1****word2**</code></pre>
 <p>The new module even documented the behavior carefully:</p>
 <pre class="blog-code-block"><code class="language-js">// Merge adjacent TEXT segments with the same non-link marks.
 // This prevents **text1****text2** when TipTap splits text at boundaries.</code></pre>
@@ -170,7 +178,7 @@ if (marks.some(m =&gt; m.type === &#39;italic&#39;)) result = &#39;*&#39; + resu
 <p>Still the wrong system.</p>
 <p>The review caught it again. nathanpayne-codex flagged that &quot;the new adjacent-mark merge logic is lossy across token boundaries&quot;—a bold token followed immediately by bold text was serializing as <code><strong>%first_name% owes</strong></code>. That is the third time in three PRs that a review round identified a round-trip safety failure in the serializer. Three times the feedback pointed at the architecture. Three times the agent patched the implementation.</p>
 <p>By this point the agent had invested significant effort in making the intermediate serializer smarter and cheaper, which made it even harder to ask the more uncomfortable question:</p>
-<pre class="blog-code-block"><code class="language-text">Why does this serializer exist at all?</code></pre>
+<pre class="blog-code-block blog-code-block--light"><code class="language-text">Why does this serializer exist at all?</code></pre>
 <h2>The automated guardrails saw it too</h2>
 <p>The session included three automated stop-hook interventions, system-level checks that fire between prompts. Two of them are relevant:</p>
 <p><strong>Hook 2</strong> flagged that the plaintext fallback was being derived from <code>editor.getText()</code> instead of the invoice renderer. With the TipTap schema, <code>getText()</code> was adding extra blank lines around block tokens and dropping list markers. This is the divergent-render-path problem stated as an automated finding: the system was generating plaintext from a method that did not match the rendering pipeline.</p>
@@ -179,12 +187,20 @@ if (marks.some(m =&gt; m.type === &#39;italic&#39;)) result = &#39;*&#39; + resu
 <h2>What I gave the second agent</h2>
 <p>The prompt that produced <a href="https://github.com/nathanjohnpayne/friends-and-family-billing/pull/161">PR #161</a> was structurally different from anything I said during the first session. It was not a bug report. It was a task document titled &quot;Codex Task—Investigate Failed Fixes (Issue #159).&quot;</p>
 <p>It opened with this framing:</p>
-<p>&gt; Multiple fixes have already been attempted by Claude Code and <strong>did not resolve the issue</strong>. You MUST treat this as a <strong>failed-fix investigation</strong>, not a greenfield implementation.</p>
+<blockquote>Multiple fixes have already been attempted by Claude Code and <strong>did not resolve the issue</strong>. You MUST treat this as a <strong>failed-fix investigation</strong>, not a greenfield implementation.</blockquote>
 <p>Then it listed all six failed PRs and required the agent to audit each one before writing a single line of code. The task was organized into eight steps. Steps 1 through 3 were pure reading: understand the issue, audit the failed fixes, identify the root cause. No code until step 4.</p>
 <p>It stated the invariant as a non-negotiable requirement:</p>
-<p>&gt; There must be <strong>one canonical rendering pipeline</strong>. At minimum, <strong>Preview and Sent Email must be generated from the exact same rendering path</strong>.</p>
+<blockquote>There must be <strong>one canonical rendering pipeline</strong>. At minimum, <strong>Preview and Sent Email must be generated from the exact same rendering path</strong>.</blockquote>
 <p>And it included a constraints section that explicitly banned the exact moves Claude Code had made across six PRs:</p>
-<p>&gt; - Do NOT add another layer of transformation &gt; - Do NOT &quot;fix&quot; by overriding CSS only &gt; - Do NOT leave multiple rendering paths in place &gt; - Do NOT rely on regex to fix formatting &gt; - Do NOT optimize for minimal diff over correctness</p>
+<blockquote>
+<ul>
+<li>Do NOT add another layer of transformation</li>
+<li>Do NOT &quot;fix&quot; by overriding CSS only</li>
+<li>Do NOT leave multiple rendering paths in place</li>
+<li>Do NOT rely on regex to fix formatting</li>
+<li>Do NOT optimize for minimal diff over correctness</li>
+</ul>
+</blockquote>
 <p>Every constraint corresponds to something the first agent actually did. The CSS patch in PR #153. The regex improvements in #146 and #155. The additional transformation layer in #158. The minimal-diff optimization throughout. This was not a generic best-practices list. It was a list of specific mistakes extracted from the session history.</p>
 <p>The task document also required the agent to deliver an audit of the prior fixes as part of the PR, not just the code, but an explanation of which assumptions were wrong and which abstractions made the problem worse. And it required regression tests proving that Preview output and email output were structurally equivalent.</p>
 <h2>What finally worked</h2>
@@ -211,31 +227,15 @@ await queueEmail({
           </article>
         </div>
 
-        <aside class="project-sidebar">
-          <section class="project-card" aria-labelledby="post-meta">
-            <h2 id="post-meta">Post details</h2>
-            <dl class="project-facts">
-              <div>
-                <dt>Published</dt>
-                <dd>April 4, 2026</dd>
-              </div>
-              <div>
-                <dt>Author</dt>
-                <dd>Nathan Payne</dd>
-              </div>
-              <div>
-                <dt>Reading time</dt>
-                <dd>11 min read</dd>
-              </div>
-              <div>
-                <dt>Tags</dt>
-                <dd>AI · Engineering · Product · Systems · Debugging</dd>
-              </div>
-            </dl>
-          </section>
-
-        </aside>
       </div>
+
+      <footer class="blog-footer">
+        <p class="blog-footer-attribution">Nathan Payne · San Francisco</p>
+        <nav class="blog-footer-nav">
+          <a class="project-action" href="/blog/">&larr; Back to Blog</a>
+          <a class="project-action" href="/">Back to Homepage &rarr;</a>
+        </nav>
+      </footer>
     </article>
   </main>
 </body>

--- a/style.css
+++ b/style.css
@@ -980,7 +980,21 @@ body.project-page {
 }
 
 .blog-index-layout {
-  grid-template-columns: minmax(0, 1.2fr) minmax(15rem, 0.72fr);
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.blog-index-copy {
+  max-width: 52rem;
+}
+
+.blog-index-aside {
+  max-width: 38rem;
+  margin-top: calc(var(--su) * 0.8);
+  padding-left: clamp(1rem, 2.2vw, 1.6rem);
+  font-size: clamp(0.95rem, 0.9rem + 0.28vw, 1.18rem);
+  line-height: 1.45;
+  font-family: "Cormorant Garamond", Garamond, serif;
+  color: rgba(17, 16, 13, 0.62);
 }
 
 .blog-layout {
@@ -992,6 +1006,32 @@ body.project-page {
 .blog-copy {
   width: var(--blog-content-width);
   justify-self: center;
+}
+
+.blog-meta-bar {
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 0.85rem;
+  margin-bottom: 0.5rem;
+}
+
+.blog-meta-bar dl {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin: 0;
+}
+
+.blog-meta-bar dt {
+  margin-bottom: 0.18rem;
+  font-size: clamp(0.68rem, 0.82vw, 0.78rem);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(17, 16, 13, 0.58);
+}
+
+.blog-meta-bar dd {
+  font-size: clamp(0.9rem, 0.9rem + 0.08vw, 0.98rem);
+  line-height: 1.55;
 }
 
 .blog-meta-card {
@@ -1040,8 +1080,15 @@ body.project-page {
 }
 
 .blog-card {
-  padding: 1rem 0 0;
+  position: relative;
+  padding: 1rem 0 0 0.85rem;
   border-top: 1px solid var(--rule);
+  border-left: 3px solid transparent;
+  transition: border-left-color var(--motion-hover) var(--ease-standard);
+}
+
+.blog-card:hover {
+  border-left-color: var(--project-accent);
 }
 
 .blog-card:first-child {
@@ -1070,6 +1117,12 @@ body.project-page {
 .blog-card-link {
   color: inherit;
   text-decoration: none;
+}
+
+.blog-card-link::after {
+  content: "";
+  position: absolute;
+  inset: 0;
 }
 
 .blog-card-link:hover,
@@ -1107,7 +1160,9 @@ body.project-page {
 }
 
 .blog-prose > h2:not(.blog-prose-title) {
-  margin-top: 2rem;
+  margin-top: 2.5rem;
+  padding-top: 1.8rem;
+  border-top: 1px solid var(--rule);
 }
 
 .blog-prose > h3 {
@@ -1134,6 +1189,37 @@ body.project-page {
 .blog-prose code {
   font-family: "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
   font-size: 0.94em;
+}
+
+.blog-prose blockquote {
+  border-left: 3px solid var(--project-accent);
+  padding: 0.75rem 1rem 0.75rem 1.1rem;
+  margin: 1rem 0 1.2rem;
+  background: rgba(255, 255, 255, 0.52);
+  color: rgba(17, 16, 13, 0.82);
+}
+
+.blog-prose blockquote ul {
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.blog-prose blockquote li {
+  position: relative;
+  padding-left: 1rem;
+}
+
+.blog-prose blockquote li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.72em;
+  width: 0.4rem;
+  height: 0.4rem;
+  background: var(--project-accent);
 }
 
 .blog-prose a {
@@ -1174,6 +1260,7 @@ body.project-page {
   margin: 1rem 0 1.25rem;
   padding: 0.85rem;
   border: 1px solid var(--rule);
+  border-top: 3px solid var(--project-accent);
   background: rgba(255, 255, 255, 0.82);
 }
 
@@ -1199,10 +1286,39 @@ body.project-page {
   border: 1px solid rgba(17, 16, 13, 0.2);
 }
 
+.blog-code-block--light {
+  background: rgba(17, 16, 13, 0.06);
+  color: var(--ink);
+  border: 1px solid var(--rule);
+}
+
 .blog-code-block code {
   display: block;
   white-space: pre;
   line-height: 1.65;
+}
+
+.blog-footer {
+  padding: clamp(1.15rem, 2.5vw, 2rem) clamp(1.15rem, 3vw, 2.5rem);
+  border-top: 1px solid var(--rule);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.blog-footer-attribution {
+  font-size: clamp(0.7rem, 0.88vw, 0.82rem);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(17, 16, 13, 0.58);
+}
+
+.blog-footer-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
 .blog-diagram {
@@ -1399,8 +1515,19 @@ a:focus-visible {
     order: -1;
   }
 
-  .blog-index-layout {
-    grid-template-columns: 1fr;
+  .blog-meta-bar dl {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+
+  .blog-footer {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .blog-footer-nav {
+    justify-content: center;
   }
 
   .blog-diagram-fanout-row {


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

- Convert plain-text `>` prompt quotes to semantic `<blockquote>` elements with accent left-border styling
- Replace two-column sidebar layouts with single-column on both blog index and blog post pages
- Add horizontal metadata bar (Published/Author/Reading time/Tags) above blog post prose
- Move blog index sidebar content ("What lives here") into the hero section
- Add footers with attribution and navigation links to both pages
- Add thin horizontal rules above `<h2>` section breaks for visual cadence
- Add accent-colored top border to figures with numbered captions (Figure 1, 2, 3)
- Add lighter code-block variant (`.blog-code-block--light`) for conceptual/diagrammatic text
- Add left-border accent hover and full-card clickability on blog index cards

## Self-Review

- **Correctness**: All 9 specified items implemented per the ticket requirements. No `&gt;` characters remain in rendered body text. All CSS uses design system tokens (`--rule`, `--project-accent`, `--motion-hover`, `--ease-standard`).
- **Regression risk**: Low. Changes are scoped to blog pages only (blog index HTML, blog post HTML, and blog-specific CSS rules in style.css). Homepage and project pages are untouched. All 45 existing tests pass.
- **Style**: CSS follows existing patterns—clamp() for responsive sizing, design system variables for colors/motion, mobile breakpoint at 920px consistent with existing media queries.
- **Test coverage**: All 45 tests pass including the 5 blog-specific tests in `blog-pages.test.js`.
- **Security/dependency hygiene**: No new dependencies. No JavaScript added. Pure HTML/CSS changes.

## Test plan

- [ ] Verify blog post blockquotes render with red accent left border (all 8 quotes)
- [ ] Verify constraints list renders as `<blockquote><ul>` with styled list items
- [ ] Verify blog post sidebar is gone; horizontal metadata bar shows above prose
- [ ] Verify blog index sidebar is gone; "What lives here" text appears in hero
- [ ] Verify blog index is single-column at all viewport widths
- [ ] Verify blog card hover shows blue left-border accent; full card is clickable
- [ ] Verify footers appear at bottom of both pages with correct links
- [ ] Verify `<h2>` sections have thin rule separators (except first "Essay" heading)
- [ ] Verify figures have red top accent border and numbered captions
- [ ] Verify light code blocks (4 conceptual diagrams) use light background; JS/CSS blocks stay dark
- [ ] Verify mobile layout (< 920px): metadata bar wraps to 2 columns, footers stack vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)