### PR TITLE
Fix blog post responsive layout for mobile viewports

### DIFF
--- a/specs/blog-responsive.md
+++ b/specs/blog-responsive.md
@@ -1,0 +1,25 @@
+---
+spec_id: blog-responsive
+title: Blog Responsive Layout
+---
+
+# Blog Responsive Layout
+
+## Overview
+
+Blog pages must be fully readable at all viewport widths from 320px to 1920px with no horizontal overflow.
+
+## Layout Invariant
+
+No rendered element's bounding rect may extend beyond `document.documentElement.clientWidth`. No horizontal scrollbar may appear at any viewport width in the range 320px–1920px.
+
+## Requirements
+
+1. The viewport meta tag `<meta name="viewport" content="width=device-width, initial-scale=1">` is present on all blog pages.
+2. `.project-copy` uses `min-width: 0` to prevent the grid item from expanding beyond its grid track.
+3. `.project-detail` uses `overflow-x: hidden` as a safety net against child overflow.
+4. Blog prose paragraphs and list items use `overflow-wrap: break-word` to prevent long words or URLs from overflowing.
+5. Blog code blocks (`.blog-code-block`) use `overflow-x: auto` to scroll horizontally within their container.
+6. Blog figure images (`.blog-figure img`) use `width: 100%` and `height: auto` for fluid sizing.
+7. A phone breakpoint at `max-width: 480px` adjusts typography, padding, and button layout for small screens.
+8. No blog post `<img>` element uses an inline `width` attribute that could override CSS fluid sizing.

--- a/style.css
+++ b/style.css
@@ -890,6 +890,7 @@ body.project-page {
   padding: 1rem 1.1rem 1.1rem;
   border: 1px solid var(--rule);
   background: linear-gradient(180deg, var(--project-accent-soft), rgba(255, 255, 255, 0));
+  min-width: 0;
 }
 
 .project-section h2 {

--- a/style.css
+++ b/style.css
@@ -778,6 +778,7 @@ body.project-page {
   margin: 0 auto;
   background: rgba(244, 239, 229, 0.96);
   border: var(--line) solid var(--ink);
+  overflow-x: hidden;
   box-shadow: 14px 14px 0 rgba(17, 16, 13, 0.12);
 }
 
@@ -882,6 +883,7 @@ body.project-page {
 .project-copy {
   display: grid;
   gap: 1.2rem;
+  min-width: 0;
 }
 
 .project-section {
@@ -1176,6 +1178,7 @@ body.project-page {
 .blog-prose li {
   font-size: clamp(0.98rem, 0.94rem + 0.16vw, 1.08rem);
   line-height: 1.72;
+  overflow-wrap: break-word;
 }
 
 .blog-prose > p + p {
@@ -1406,6 +1409,54 @@ body.project-page {
 a:focus-visible {
   outline: 2px solid currentColor;
   outline-offset: 2px;
+}
+
+@media (max-width: 480px) {
+  .project-hero {
+    padding: 1rem 1rem 1.15rem;
+  }
+
+  .project-breadcrumbs {
+    padding-left: 0.5rem;
+    font-size: 0.68rem;
+  }
+
+  .project-kicker {
+    padding-left: 0.5rem;
+  }
+
+  .project-hero h1 {
+    padding-left: 0.5rem;
+    font-size: 1.75rem;
+  }
+
+  .project-deck {
+    padding-left: 0.5rem;
+  }
+
+  .project-actions {
+    padding-left: 0.5rem;
+    flex-direction: column;
+  }
+
+  .project-action {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .project-layout {
+    padding: 1rem;
+  }
+
+  .blog-code-block {
+    font-size: 0.75rem;
+    padding: 0.75rem 0.85rem;
+  }
+
+  .blog-tag-row {
+    flex-wrap: wrap;
+    gap: 0.25rem 0.5rem;
+  }
 }
 
 @media (max-width: 920px) {

--- a/tests/blog-responsive.test.js
+++ b/tests/blog-responsive.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const css = readFileSync(resolve(__dirname, '../style.css'), 'utf-8');
+const blogPostHtml = readFileSync(resolve(__dirname, '../blog/six-prs-one-bug-agent-failure-modes/index.html'), 'utf-8');
+const blogIndexHtml = readFileSync(resolve(__dirname, '../blog/index.html'), 'utf-8');
+
+function setupDOM(html) {
+  document.documentElement.innerHTML = '';
+  document.write(html);
+  document.close();
+}
+
+describe('Blog Responsive Layout', () => {
+  describe('viewport meta tag', () => {
+    it('blog post page has viewport meta tag with width=device-width', () => {
+      setupDOM(blogPostHtml);
+      const viewport = document.querySelector('meta[name="viewport"]');
+      expect(viewport).not.toBeNull();
+      expect(viewport.getAttribute('content')).toContain('width=device-width');
+    });
+
+    it('blog index page has viewport meta tag with width=device-width', () => {
+      setupDOM(blogIndexHtml);
+      const viewport = document.querySelector('meta[name="viewport"]');
+      expect(viewport).not.toBeNull();
+      expect(viewport.getAttribute('content')).toContain('width=device-width');
+    });
+  });
+
+  describe('CSS responsive rules', () => {
+    it('contains the 480px phone breakpoint', () => {
+      expect(css).toMatch(/@media\s*\(\s*max-width:\s*480px\s*\)/);
+    });
+
+    it('project-copy has min-width: 0 to prevent grid overflow', () => {
+      expect(css).toMatch(/\.project-copy\s*\{[^}]*min-width:\s*0/);
+    });
+
+    it('blog prose uses overflow-wrap: break-word', () => {
+      expect(css).toMatch(/\.blog-prose\s*>\s*p[\s\S]*?overflow-wrap:\s*break-word/);
+    });
+
+    it('project-detail has overflow-x: hidden as safety net', () => {
+      expect(css).toMatch(/\.project-detail\s*\{[^}]*overflow-x:\s*hidden/);
+    });
+
+    it('blog code blocks have overflow-x: auto', () => {
+      expect(css).toMatch(/\.blog-code-block\s*\{[^}]*overflow-x:\s*auto/);
+    });
+
+    it('blog figure images have width: 100% and height: auto', () => {
+      expect(css).toMatch(/\.blog-figure\s+img\s*\{[^}]*width:\s*100%/);
+      expect(css).toMatch(/\.blog-figure\s+img\s*\{[^}]*height:\s*auto/);
+    });
+  });
+
+  describe('blog post image markup', () => {
+    it('no blog post images have inline width attributes', () => {
+      setupDOM(blogPostHtml);
+      const images = document.querySelectorAll('.blog-figure img');
+      for (const img of images) {
+        expect(img.hasAttribute('width')).toBe(false);
+      }
+    });
+
+    it('all blog post images are inside figure elements', () => {
+      setupDOM(blogPostHtml);
+      const figures = document.querySelectorAll('.blog-figure');
+      const figureImages = document.querySelectorAll('.blog-figure img');
+      expect(figureImages.length).toBe(figures.length);
+    });
+  });
+});


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

- Fix horizontal overflow on blog post pages at mobile viewport widths (320–480px)
- Add `min-width: 0` to `.project-copy` grid item to prevent content from expanding beyond the grid track
- Add `overflow-wrap: break-word` to blog prose paragraphs and list items
- Add `overflow-x: hidden` safety net on `.project-detail`
- Add new `@media (max-width: 480px)` phone breakpoint for typography scaling, tighter padding, full-width CTA buttons, and tag pill wrapping
- Add spec file and vitest structural smoke tests for all responsive CSS rules
- Playwright visual regression tests deferred to follow-up issue #29

Closes #28

## Self-Review

**Correctness:** The root cause is `min-width: auto` (CSS grid default) on `.project-copy`, which prevents the grid item from shrinking below its content width. Adding `min-width: 0` is the standard fix. The phone breakpoint values are conservative and consistent with existing `clamp()` patterns.

**Regression risk:** Low. The `min-width: 0` change only affects behavior when content would otherwise overflow — desktop layouts are unaffected. The phone breakpoint only activates at ≤480px. The `overflow-x: hidden` on `.project-detail` is a safety net that only clips if overflow still occurs.

**Style:** CSS follows existing patterns — no new custom properties, no bare motion values, all padding/sizing consistent with existing `clamp()` and `rem` usage.

**Test coverage:** 10 new vitest tests verify all responsive CSS rules exist (viewport meta, min-width, overflow-wrap, overflow-x, phone breakpoint, code block scroll, image fluidity). All 55 tests pass.

**Security/dependency hygiene:** No new dependencies. CSS-only changes. No generated HTML changes.

## Test plan

- [x] `npm test` — all 55 tests pass (8 test files)
- [ ] Visual check: open `/blog/six-prs-one-bug-agent-failure-modes/` at 393px, 375px, 320px in Chrome DevTools
- [ ] Verify no horizontal scrollbar at any width from 320px to 1920px
- [ ] Verify desktop layout at 1440px is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a responsive design specification for blog layouts.

* **Bug Fixes**
  * Improved layout responsiveness across 320px–1920px and prevented horizontal overflow/scrollbars.
  * Ensured viewport meta behavior, reliable text wrapping, scrollable code blocks, and fluid image sizing.
  * Adjusted mobile typography, spacing, and action/button layouts at a small-screen breakpoint.

* **Tests**
  * Added automated checks to validate responsive rules and blog image/figure markup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->