### PR TITLE
Address CodeRabbit findings from responsive layout PR

### DIFF
--- a/style.css
+++ b/style.css
@@ -1284,6 +1284,7 @@ body.project-page {
 .blog-code-block {
   margin: 1rem 0 1.2rem;
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   padding: 0.95rem 1rem;
   background: #15120e;
   color: #f5f0e4;
@@ -1455,7 +1456,6 @@ a:focus-visible {
   }
 
   .blog-tag-row {
-    flex-wrap: wrap;
     gap: 0.25rem 0.5rem;
   }
 }

--- a/tests/blog-responsive.test.js
+++ b/tests/blog-responsive.test.js
@@ -1,10 +1,17 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { readFileSync } from 'fs';
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
 import { resolve } from 'path';
 
 const css = readFileSync(resolve(__dirname, '../style.css'), 'utf-8');
-const blogPostHtml = readFileSync(resolve(__dirname, '../blog/six-prs-one-bug-agent-failure-modes/index.html'), 'utf-8');
 const blogIndexHtml = readFileSync(resolve(__dirname, '../blog/index.html'), 'utf-8');
+
+const blogRoot = resolve(__dirname, '../blog');
+const blogPostPaths = readdirSync(blogRoot)
+  .filter((name) => {
+    const dir = resolve(blogRoot, name);
+    return statSync(dir).isDirectory() && statSync(resolve(dir, 'index.html')).isFile();
+  })
+  .map((name) => ({ slug: name, html: readFileSync(resolve(blogRoot, name, 'index.html'), 'utf-8') }));
 
 function setupDOM(html) {
   document.documentElement.innerHTML = '';
@@ -14,18 +21,22 @@ function setupDOM(html) {
 
 describe('Blog Responsive Layout', () => {
   describe('viewport meta tag', () => {
-    it('blog post page has viewport meta tag with width=device-width', () => {
-      setupDOM(blogPostHtml);
-      const viewport = document.querySelector('meta[name="viewport"]');
-      expect(viewport).not.toBeNull();
-      expect(viewport.getAttribute('content')).toContain('width=device-width');
+    it('blog post pages have viewport meta tag with width=device-width and initial-scale=1', () => {
+      for (const post of blogPostPaths) {
+        setupDOM(post.html);
+        const viewport = document.querySelector('meta[name="viewport"]');
+        expect(viewport, `${post.slug}: missing viewport meta`).not.toBeNull();
+        expect(viewport.getAttribute('content')).toContain('width=device-width');
+        expect(viewport.getAttribute('content')).toMatch(/initial-scale\s*=\s*1(\.0)?/);
+      }
     });
 
-    it('blog index page has viewport meta tag with width=device-width', () => {
+    it('blog index page has viewport meta tag with width=device-width and initial-scale=1', () => {
       setupDOM(blogIndexHtml);
       const viewport = document.querySelector('meta[name="viewport"]');
       expect(viewport).not.toBeNull();
       expect(viewport.getAttribute('content')).toContain('width=device-width');
+      expect(viewport.getAttribute('content')).toMatch(/initial-scale\s*=\s*1(\.0)?/);
     });
   });
 
@@ -50,6 +61,10 @@ describe('Blog Responsive Layout', () => {
       expect(css).toMatch(/\.blog-code-block\s*\{[^}]*overflow-x:\s*auto/);
     });
 
+    it('blog code blocks have -webkit-overflow-scrolling: touch', () => {
+      expect(css).toMatch(/\.blog-code-block\s*\{[^}]*-webkit-overflow-scrolling:\s*touch/);
+    });
+
     it('blog figure images have width: 100% and height: auto', () => {
       expect(css).toMatch(/\.blog-figure\s+img\s*\{[^}]*width:\s*100%/);
       expect(css).toMatch(/\.blog-figure\s+img\s*\{[^}]*height:\s*auto/);
@@ -58,18 +73,23 @@ describe('Blog Responsive Layout', () => {
 
   describe('blog post image markup', () => {
     it('no blog post images have inline width attributes', () => {
-      setupDOM(blogPostHtml);
-      const images = document.querySelectorAll('.blog-figure img');
-      for (const img of images) {
-        expect(img.hasAttribute('width')).toBe(false);
+      for (const post of blogPostPaths) {
+        setupDOM(post.html);
+        const images = document.querySelectorAll('.blog-figure img');
+        for (const img of images) {
+          expect(img.hasAttribute('width'), `${post.slug}: image has inline width`).toBe(false);
+        }
       }
     });
 
     it('all blog post images are inside figure elements', () => {
-      setupDOM(blogPostHtml);
-      const figures = document.querySelectorAll('.blog-figure');
-      const figureImages = document.querySelectorAll('.blog-figure img');
-      expect(figureImages.length).toBe(figures.length);
+      for (const post of blogPostPaths) {
+        setupDOM(post.html);
+        const allImages = document.querySelectorAll('main img');
+        for (const img of allImages) {
+          expect(img.closest('.blog-figure'), `${post.slug}: image not in .blog-figure`).not.toBeNull();
+        }
+      }
     });
   });
 });


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

- Add `-webkit-overflow-scrolling: touch` to `.blog-code-block` for iOS momentum scrolling
- Remove redundant `flex-wrap: wrap` from 480px breakpoint (already set in base `.blog-tag-row` rule at line 1145)
- Strengthen viewport meta tag tests to also assert `initial-scale=1`
- Make image markup tests iterate over all blog posts dynamically instead of hardcoding one post slug
- Add test for `-webkit-overflow-scrolling` CSS property

Addresses CodeRabbit review comments from #30.

## Self-Review

**Correctness:** All 4 CodeRabbit findings are addressed. The `__dirname` ESM finding was already dismissed as a false positive (vitest injects it).

**Regression risk:** Minimal. `-webkit-overflow-scrolling: touch` is a progressive enhancement (no-op in non-WebKit browsers). Removing the redundant `flex-wrap` declaration has no visual effect since the base rule already sets it. Test changes make coverage broader, not narrower.

**Style:** Consistent with existing patterns.

**Test coverage:** 56 tests pass (up from 55 — new `-webkit-overflow-scrolling` test). Image tests now iterate all blog posts. Viewport tests now check both `width=device-width` and `initial-scale=1`.

**Security/dependency hygiene:** No new dependencies. CSS-only change plus test improvements.

## Test plan

- [x] `npm test` — all 56 tests pass
- [ ] Verify `-webkit-overflow-scrolling: touch` on iOS Safari (code blocks should have smooth momentum scroll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll handling for code blocks on iOS and WebKit browsers
  * Adjusted tag layout behavior on small screens for enhanced responsive design

<!-- end of auto-generated comment: release notes by coderabbit.ai -->