### PR TITLE
Bump style.css cache-bust version to 20260408a

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -52,7 +52,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css?v=20260404e" />
+  <link rel="stylesheet" href="/style.css?v=20260408a" />
 </head>
 <body class="project-page project-page--blue blog-index-page">
   <main class="project-shell">

--- a/blog/six-prs-one-bug-agent-failure-modes/index.html
+++ b/blog/six-prs-one-bug-agent-failure-modes/index.html
@@ -59,7 +59,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css?v=20260404e" />
+  <link rel="stylesheet" href="/style.css?v=20260408a" />
 </head>
 <body class="project-page project-page--red blog-page">
   <main class="project-shell">

--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="style.css?v=20260404e" />
+  <link rel="stylesheet" href="style.css?v=20260408a" />
 </head>
 <body>
   <main class="stage">

--- a/projects/device-source-of-truth/index.html
+++ b/projects/device-source-of-truth/index.html
@@ -104,7 +104,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css?v=20260404e" />
+  <link rel="stylesheet" href="/style.css?v=20260408a" />
 </head>
 <body class="project-page project-page--red">
   <main class="project-shell">

--- a/projects/friends-and-family-billing/index.html
+++ b/projects/friends-and-family-billing/index.html
@@ -104,7 +104,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css?v=20260404e" />
+  <link rel="stylesheet" href="/style.css?v=20260408a" />
 </head>
 <body class="project-page project-page--black">
   <main class="project-shell">

--- a/projects/override/index.html
+++ b/projects/override/index.html
@@ -104,7 +104,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css?v=20260404e" />
+  <link rel="stylesheet" href="/style.css?v=20260408a" />
 </head>
 <body class="project-page project-page--yellow">
   <main class="project-shell">

--- a/projects/swipe-watch/index.html
+++ b/projects/swipe-watch/index.html
@@ -104,7 +104,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css?v=20260404e" />
+  <link rel="stylesheet" href="/style.css?v=20260408a" />
 </head>
 <body class="project-page project-page--blue">
   <main class="project-shell">

--- a/scripts/generate-blog.js
+++ b/scripts/generate-blog.js
@@ -9,7 +9,7 @@ const ROOT = path.resolve(__dirname, '..');
 const CONTENT_DIR = path.join(ROOT, 'content', 'blog');
 const BLOG_DIR = path.join(ROOT, 'blog');
 const SITE_URL = 'https://nathanpayne.com';
-const STYLE_VERSION = '20260404e';
+const STYLE_VERSION = '20260408a';
 
 function main() {
   const posts = loadPosts().sort((left, right) => right.date.localeCompare(left.date));


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

- Bump `style.css?v=` from `20260404e` to `20260408a` across all HTML pages and the blog generator script
- Required because PRs #30 and #31 changed CSS (responsive layout fixes)
- No content changes — version string bump only

## Self-Review

**Correctness:** All 8 files with style references updated. No old version strings remain. Blog HTML files were NOT regenerated (the generator produces different output than committed — see note below).

**Regression risk:** Zero — this is a cache-bust version bump only. No CSS or HTML content changes.

**Note:** `node scripts/generate-blog.js` produces output that differs from the committed blog HTML. The committed HTML appears to have post-generation hand-edits (meta-bar layout, link formatting, code block classes). The blog pages were updated via `sed` to avoid content loss. This generator drift should be investigated separately.

## Test plan

- [x] `npm test` — all 56 tests pass
- [x] No `20260404e` version strings remain in any HTML or JS file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated stylesheet versions across multiple pages to ensure latest CSS is loaded by browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->