### PR TITLE
Fix missing homepage JSON-LD structured data

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,11 +1,64 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+
+const homepageJsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": "https://nathanpayne.com/#website",
+      "url": "https://nathanpayne.com/",
+      "name": "Nathan Payne",
+      "description": "Nathan Payne is a systems-minded product leader at The Walt Disney Company, overseeing partner-platform experiences for Disney+, Hulu, and ESPN and building software across streaming, finance, and design.",
+      "publisher": {
+        "@id": "https://nathanpayne.com/#person"
+      }
+    },
+    {
+      "@type": "ProfilePage",
+      "@id": "https://nathanpayne.com/#webpage",
+      "url": "https://nathanpayne.com/",
+      "name": "Nathan Payne | Product Manager for Disney+, Hulu, and ESPN",
+      "description": "Nathan Payne is a systems-minded product leader at The Walt Disney Company, overseeing partner-platform experiences for Disney+, Hulu, and ESPN and building software across streaming, finance, and design.",
+      "isPartOf": {
+        "@id": "https://nathanpayne.com/#website"
+      },
+      "mainEntity": {
+        "@id": "https://nathanpayne.com/#person"
+      }
+    },
+    {
+      "@type": "Person",
+      "@id": "https://nathanpayne.com/#person",
+      "name": "Nathan Payne",
+      "url": "https://nathanpayne.com/",
+      "description": "Nathan Payne oversees product for Disney+, Hulu, and ESPN across partner platforms at The Walt Disney Company and builds software projects across streaming, finance, and design.",
+      "worksFor": {
+        "@type": "Organization",
+        "name": "The Walt Disney Company"
+      },
+      "homeLocation": {
+        "@type": "Place",
+        "name": "San Francisco, California, United States"
+      },
+      "sameAs": [
+        "https://www.linkedin.com/in/nathanpayne/",
+        "https://github.com/nathanjohnpayne",
+        "https://bsky.app/profile/nathanpayne.bsky.social",
+        "https://www.instagram.com/nathanpayne/",
+        "https://www.threads.com/@nathanpayne",
+        "https://x.com/nathanpayne"
+      ]
+    }
+  ]
+};
 ---
 
 <BaseLayout
   title="Nathan Payne | Product Manager for Disney+, Hulu, and ESPN"
   description="Nathan Payne is a systems-minded product leader at The Walt Disney Company, overseeing partner-platform experiences for Disney+, Hulu, and ESPN and building software across streaming, finance, and design."
   canonical="https://nathanpayne.com/"
+  jsonLd={homepageJsonLd}
 >
   <h1>Nathan Payne</h1>
   <p>Site under construction — Astro migration in progress.</p>


### PR DESCRIPTION
## Summary

- Pass the homepage WebSite/ProfilePage/Person JSON-LD graph to `BaseLayout` via the `jsonLd` prop
- Restores structured data parity with the original `index.html`

This was flagged as a P2 regression by external review of PR #49.

Authoring-Agent: claude

Fixes #52

## Self-Review

**Correctness:** Built output now contains `<script type="application/ld+json">` with the full `@graph` array (WebSite, ProfilePage, Person). Verified in both `dist/index.html` and the dev server DOM.

**Regression risk:** None. This adds data that was missing — no existing behavior changes.

**Style:** The JSON-LD object is defined in the Astro frontmatter, matching the pattern that will be used by project pages and blog posts in later phases.

**Test coverage:** All 56 tests pass. The test coverage gap (#51) is a separate concern tracked for Phase 8 — these tests validate the legacy static files, not the Astro output.

**Security/dependency hygiene:** No changes. Structured data contains only public information already present in the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured data to the homepage for improved search engine optimization and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->