### PR TITLE
Phase 3: Port project pages

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,6 +5,7 @@ interface Props {
   title: string;
   description: string;
   canonical: string;
+  ogDescription?: string;
   ogImage?: string;
   ogImageWidth?: string;
   ogImageHeight?: string;
@@ -23,6 +24,7 @@ const {
   title,
   description,
   canonical,
+  ogDescription,
   ogImage = 'https://nathanpayne.com/og-image.png?v=20260303a',
   ogImageWidth = '2400',
   ogImageHeight = '1260',
@@ -32,6 +34,8 @@ const {
   jsonLd,
   articleMeta,
 } = Astro.props;
+
+const socialDescription = ogDescription || description;
 ---
 
 <!DOCTYPE html>
@@ -57,7 +61,7 @@ const {
   <meta property="og:locale" content="en_US" />
   <meta property="og:site_name" content="Nathan Payne" />
   <meta property="og:title" content={title} />
-  <meta property="og:description" content={description} />
+  <meta property="og:description" content={socialDescription} />
   <meta property="og:url" content={canonical} />
   <meta property="og:image" content={ogImage} />
   <meta property="og:image:secure_url" content={ogImage} />
@@ -79,7 +83,7 @@ const {
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content={title} />
-  <meta name="twitter:description" content={description} />
+  <meta name="twitter:description" content={socialDescription} />
   <meta name="twitter:url" content={canonical} />
   <meta name="twitter:image" content={ogImage} />
   <meta name="twitter:image:width" content={ogImageWidth} />

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -1,0 +1,92 @@
+---
+import BaseLayout from './BaseLayout.astro';
+
+interface Action {
+  label: string;
+  href: string;
+  external?: boolean;
+}
+
+interface Props {
+  title: string;
+  description: string;
+  canonical: string;
+  ogDescription?: string;
+  kicker: string;
+  headline: string;
+  deck: string;
+  breadcrumbLabel: string;
+  accentColorClass: string;
+  actions: Action[];
+  jsonLd: object;
+  ogImage?: string;
+  ogImageWidth?: string;
+  ogImageHeight?: string;
+  ogImageAlt?: string;
+}
+
+const {
+  title,
+  description,
+  canonical,
+  ogDescription,
+  kicker,
+  headline,
+  deck,
+  breadcrumbLabel,
+  accentColorClass,
+  actions,
+  jsonLd,
+  ogImage,
+  ogImageWidth,
+  ogImageHeight,
+  ogImageAlt,
+} = Astro.props;
+---
+
+<BaseLayout
+  title={title}
+  description={description}
+  canonical={canonical}
+  ogDescription={ogDescription}
+  bodyClass={`project-page ${accentColorClass}`}
+  jsonLd={jsonLd}
+  ogImage={ogImage}
+  ogImageWidth={ogImageWidth}
+  ogImageHeight={ogImageHeight}
+  ogImageAlt={ogImageAlt}
+>
+  <main class="project-shell">
+    <article class="project-detail">
+      <header class="project-hero">
+        <nav class="project-breadcrumbs" aria-label="Breadcrumb">
+          <a href="/">Nathan Payne</a>
+          <span>/</span>
+          <span>Projects</span>
+          <span>/</span>
+          <span set:html={breadcrumbLabel} />
+        </nav>
+        <p class="project-kicker">{kicker}</p>
+        <h1 set:html={headline} />
+        <p class="project-deck">{deck}</p>
+        <div class="project-actions">
+          {actions.map((action) => (
+            action.external
+              ? <a class="project-action" href={action.href} target="_blank" rel="noopener">{action.label}</a>
+              : <a class="project-action" href={action.href}>{action.label}</a>
+          ))}
+        </div>
+      </header>
+
+      <div class="project-layout">
+        <div class="project-copy">
+          <slot />
+        </div>
+
+        <aside class="project-sidebar">
+          <slot name="sidebar" />
+        </aside>
+      </div>
+    </article>
+  </main>
+</BaseLayout>

--- a/src/pages/projects/device-source-of-truth/index.astro
+++ b/src/pages/projects/device-source-of-truth/index.astro
@@ -1,0 +1,129 @@
+---
+import ProjectLayout from '../../../layouts/ProjectLayout.astro';
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      "@id": "https://nathanpayne.com/projects/device-source-of-truth/#webpage",
+      "url": "https://nathanpayne.com/projects/device-source-of-truth/",
+      "name": "Device Source of Truth | Nathan Payne",
+      "description": "Device Source of Truth is a React and Firebase web app by Nathan Payne that consolidates partner-device specs, DRM requirements, codec support, and operational metadata into a single source of truth.",
+      "isPartOf": {
+        "@id": "https://nathanpayne.com/#website"
+      },
+      "breadcrumb": {
+        "@id": "https://nathanpayne.com/projects/device-source-of-truth/#breadcrumb"
+      },
+      "mainEntity": {
+        "@id": "https://nathanpayne.com/projects/device-source-of-truth/#app"
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "https://nathanpayne.com/projects/device-source-of-truth/#breadcrumb",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Nathan Payne",
+          "item": "https://nathanpayne.com/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Device Source of Truth",
+          "item": "https://nathanpayne.com/projects/device-source-of-truth/"
+        }
+      ]
+    },
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://nathanpayne.com/projects/device-source-of-truth/#app",
+      "name": "Device Source of Truth",
+      "applicationCategory": "BusinessApplication",
+      "operatingSystem": "Web",
+      "url": "https://device-source-of-truth.web.app",
+      "creator": {
+        "@type": "Person",
+        "name": "Nathan Payne",
+        "url": "https://nathanpayne.com/"
+      },
+      "description": "A React and Firebase web app that consolidates partner-device specs, DRM requirements, codec support, and operational metadata into a single source of truth."
+    }
+  ]
+};
+---
+
+<ProjectLayout
+  title="Device Source of Truth | Nathan Payne"
+  description="Device Source of Truth is a React and Firebase web app by Nathan Payne that consolidates partner-device specs, DRM requirements, codec support, and operational metadata into a single source of truth."
+  ogDescription="A React and Firebase web app that consolidates partner-device specs, DRM requirements, codec support, and operational metadata into a single source of truth."
+  canonical="https://nathanpayne.com/projects/device-source-of-truth/"
+  kicker="Enterprise × Data"
+  headline="Device Source of Truth"
+  deck="A single web application for understanding partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN."
+  breadcrumbLabel="Device Source of Truth"
+  accentColorClass="project-page--red"
+  actions={[
+    { label: "View Live Product", href: "https://device-source-of-truth.web.app", external: true },
+    { label: "Back to Homepage", href: "/" },
+  ]}
+  jsonLd={jsonLd}
+>
+  <section class="project-section" aria-labelledby="dst-overview">
+    <h2 id="dst-overview">Overview</h2>
+    <p>Device Source of Truth brings together the partner-device information that usually ends up scattered across Airtable, Datadog, and spreadsheets. The goal is simple: give teams one place to understand the hardware, DRM, and codec realities behind Disney+, Hulu, and ESPN device support.</p>
+    <p>Instead of treating device knowledge as loose operational memory, the product turns it into a structured system that can be reviewed, updated, and shared with confidence.</p>
+  </section>
+
+  <section class="project-section" aria-labelledby="dst-capabilities">
+    <h2 id="dst-capabilities">What the product does</h2>
+    <ul class="project-checklist">
+      <li>Consolidates fragmented partner-device records into one inventory.</li>
+      <li>Tracks hardware specifications, DRM requirements, and codec support in a single model.</li>
+      <li>Applies rules-based device scoring to make prioritization and compatibility easier to reason about.</li>
+      <li>Creates a shared reference point for partner-platform conversations that would otherwise depend on scattered spreadsheets.</li>
+    </ul>
+  </section>
+
+  <section class="project-section" aria-labelledby="dst-context">
+    <h2 id="dst-context">Why it matters</h2>
+    <p>This project was built for the partner-engineering world I work in. When a platform question comes up, the cost of uncertainty is immediate: support burden grows, launch conversations slow down, and decision quality drops. Device Source of Truth treats that ambiguity as a product problem instead of an inevitable operational tax.</p>
+  </section>
+
+  <section class="project-section" aria-labelledby="dst-build">
+    <h2 id="dst-build">Build notes</h2>
+    <p>The application is built with React and Firebase. The emphasis is not just on storing data, but on turning device knowledge into something navigable and durable enough to support real product and platform decisions.</p>
+  </section>
+
+  <Fragment slot="sidebar">
+    <section class="project-card" aria-labelledby="dst-facts">
+      <h2 id="dst-facts">Project facts</h2>
+      <dl class="project-facts">
+        <div>
+          <dt>Domain</dt>
+          <dd>Enterprise × Data</dd>
+        </div>
+        <div>
+          <dt>Format</dt>
+          <dd>React + Firebase web app</dd>
+        </div>
+        <div>
+          <dt>Focus</dt>
+          <dd>Partner platforms and device support systems</dd>
+        </div>
+        <div>
+          <dt>Status</dt>
+          <dd>Live product</dd>
+        </div>
+      </dl>
+    </section>
+
+    <section class="project-card" aria-labelledby="dst-note">
+      <h2 id="dst-note">Live link</h2>
+      <p class="project-note"><a href="https://device-source-of-truth.web.app" target="_blank" rel="noopener">device-source-of-truth.web.app</a></p>
+    </section>
+  </Fragment>
+</ProjectLayout>

--- a/src/pages/projects/friends-and-family-billing/index.astro
+++ b/src/pages/projects/friends-and-family-billing/index.astro
@@ -1,0 +1,129 @@
+---
+import ProjectLayout from '../../../layouts/ProjectLayout.astro';
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      "@id": "https://nathanpayne.com/projects/friends-and-family-billing/#webpage",
+      "url": "https://nathanpayne.com/projects/friends-and-family-billing/",
+      "name": "Friends & Family Billing | Nathan Payne",
+      "description": "Friends & Family Billing is a cloud-synced billing tool by Nathan Payne for families and friend groups that turns recurring shared costs into clear invoices, payment tracking, and shareable summaries.",
+      "isPartOf": {
+        "@id": "https://nathanpayne.com/#website"
+      },
+      "breadcrumb": {
+        "@id": "https://nathanpayne.com/projects/friends-and-family-billing/#breadcrumb"
+      },
+      "mainEntity": {
+        "@id": "https://nathanpayne.com/projects/friends-and-family-billing/#app"
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "https://nathanpayne.com/projects/friends-and-family-billing/#breadcrumb",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Nathan Payne",
+          "item": "https://nathanpayne.com/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Friends & Family Billing",
+          "item": "https://nathanpayne.com/projects/friends-and-family-billing/"
+        }
+      ]
+    },
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://nathanpayne.com/projects/friends-and-family-billing/#app",
+      "name": "Friends & Family Billing",
+      "applicationCategory": "FinanceApplication",
+      "operatingSystem": "Web",
+      "url": "https://friends-and-family-billing.web.app",
+      "creator": {
+        "@type": "Person",
+        "name": "Nathan Payne",
+        "url": "https://nathanpayne.com/"
+      },
+      "description": "A cloud-synced billing tool for families and friend groups that turns recurring shared costs into clear invoices, payment tracking, and shareable summaries."
+    }
+  ]
+};
+---
+
+<ProjectLayout
+  title="Friends &amp; Family Billing | Nathan Payne"
+  description="Friends &amp; Family Billing is a cloud-synced billing tool by Nathan Payne for families and friend groups that turns recurring shared costs into clear invoices, payment tracking, and shareable summaries."
+  ogDescription="A cloud-synced billing tool for families and friend groups that turns recurring shared costs into clear invoices, payment tracking, and shareable summaries."
+  canonical="https://nathanpayne.com/projects/friends-and-family-billing/"
+  kicker="Utility × Finance"
+  headline="Friends &amp; Family Billing"
+  deck="A cloud-synced billing tool that turns recurring shared costs into clear invoices, payment tracking, and shareable summaries for families and friend groups."
+  breadcrumbLabel="Friends &amp; Family Billing"
+  accentColorClass="project-page--black"
+  actions={[
+    { label: "View Live Product", href: "https://friends-and-family-billing.web.app", external: true },
+    { label: "Back to Homepage", href: "/" },
+  ]}
+  jsonLd={jsonLd}
+>
+  <section class="project-section" aria-labelledby="ffb-overview">
+    <h2 id="ffb-overview">Overview</h2>
+    <p>Friends &amp; Family Billing is built around a familiar problem: shared subscriptions and recurring group expenses are easy to agree to and surprisingly messy to settle. Costs renew on different cadences, responsibilities drift over time, and nobody wants to manually rebuild the math every billing cycle.</p>
+    <p>The product turns that recurring coordination into a clearer annual workflow.</p>
+  </section>
+
+  <section class="project-section" aria-labelledby="ffb-capabilities">
+    <h2 id="ffb-capabilities">What the product does</h2>
+    <ul class="project-checklist">
+      <li>Organizes monthly and annual shared costs for households and friend groups.</li>
+      <li>Converts those recurring expenses into clear annual invoices.</li>
+      <li>Tracks who has paid, what is still outstanding, and what each person owes.</li>
+      <li>Generates shareable summaries so payment status is easy to communicate.</li>
+    </ul>
+  </section>
+
+  <section class="project-section" aria-labelledby="ffb-why">
+    <h2 id="ffb-why">Why it matters</h2>
+    <p>The product is less about accounting complexity and more about social clarity. Shared money can create friction even when the amounts are small. Friends &amp; Family Billing reframes that awkwardness as a straightforward coordination workflow.</p>
+  </section>
+
+  <section class="project-section" aria-labelledby="ffb-build">
+    <h2 id="ffb-build">Build notes</h2>
+    <p>Cloud sync is central to the idea. The value of the tool comes from keeping everyone aligned on the same current record, not from emailing around static summaries or rebuilding the numbers in a spreadsheet.</p>
+  </section>
+
+  <Fragment slot="sidebar">
+    <section class="project-card" aria-labelledby="ffb-facts">
+      <h2 id="ffb-facts">Project facts</h2>
+      <dl class="project-facts">
+        <div>
+          <dt>Domain</dt>
+          <dd>Utility × Finance</dd>
+        </div>
+        <div>
+          <dt>Format</dt>
+          <dd>Cloud-synced web application</dd>
+        </div>
+        <div>
+          <dt>Focus</dt>
+          <dd>Shared subscriptions and recurring group expenses</dd>
+        </div>
+        <div>
+          <dt>Status</dt>
+          <dd>Live product</dd>
+        </div>
+      </dl>
+    </section>
+
+    <section class="project-card" aria-labelledby="ffb-note">
+      <h2 id="ffb-note">Live link</h2>
+      <p class="project-note"><a href="https://friends-and-family-billing.web.app" target="_blank" rel="noopener">friends-and-family-billing.web.app</a></p>
+    </section>
+  </Fragment>
+</ProjectLayout>

--- a/src/pages/projects/override/index.astro
+++ b/src/pages/projects/override/index.astro
@@ -1,0 +1,129 @@
+---
+import ProjectLayout from '../../../layouts/ProjectLayout.astro';
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      "@id": "https://nathanpayne.com/projects/override/#webpage",
+      "url": "https://nathanpayne.com/projects/override/",
+      "name": "Override | Nathan Payne",
+      "description": "Override is a Broadway-focused financial operating system by Nathan Payne for structuring capitalization, modeling investor returns, managing ownership, and sharing live deals without spreadsheet or PDF workflows.",
+      "isPartOf": {
+        "@id": "https://nathanpayne.com/#website"
+      },
+      "breadcrumb": {
+        "@id": "https://nathanpayne.com/projects/override/#breadcrumb"
+      },
+      "mainEntity": {
+        "@id": "https://nathanpayne.com/projects/override/#app"
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "https://nathanpayne.com/projects/override/#breadcrumb",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Nathan Payne",
+          "item": "https://nathanpayne.com/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Override",
+          "item": "https://nathanpayne.com/projects/override/"
+        }
+      ]
+    },
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://nathanpayne.com/projects/override/#app",
+      "name": "Override",
+      "applicationCategory": "FinanceApplication",
+      "operatingSystem": "Web",
+      "url": "https://overridebroadway.com",
+      "creator": {
+        "@type": "Person",
+        "name": "Nathan Payne",
+        "url": "https://nathanpayne.com/"
+      },
+      "description": "A Broadway-focused financial operating system for structuring capitalization, modeling investor returns, managing ownership, and sharing live deals without spreadsheet or PDF workflows."
+    }
+  ]
+};
+---
+
+<ProjectLayout
+  title="Override | Nathan Payne"
+  description="Override is a Broadway-focused financial operating system by Nathan Payne for structuring capitalization, modeling investor returns, managing ownership, and sharing live deals without spreadsheet or PDF workflows."
+  ogDescription="A Broadway-focused financial operating system for structuring capitalization, modeling investor returns, managing ownership, and sharing live deals without spreadsheet or PDF workflows."
+  canonical="https://nathanpayne.com/projects/override/"
+  kicker="Finance × Theater"
+  headline="Override"
+  deck="A Broadway-focused financial operating system for structuring capitalization, modeling investor returns, managing ownership, and sharing live deals without spreadsheet or PDF workflows."
+  breadcrumbLabel="Override"
+  accentColorClass="project-page--yellow"
+  actions={[
+    { label: "View Live Product", href: "https://overridebroadway.com", external: true },
+    { label: "Back to Homepage", href: "/" },
+  ]}
+  jsonLd={jsonLd}
+>
+  <section class="project-section" aria-labelledby="override-overview">
+    <h2 id="override-overview">Overview</h2>
+    <p>Override applies product thinking to one of the most document-heavy operating environments I know: Broadway finance. Capitalization plans, ownership details, investor updates, and deal materials often move through spreadsheets and PDFs that are difficult to maintain once a production is live.</p>
+    <p>The project reframes that work as a product workflow instead of a file-management problem.</p>
+  </section>
+
+  <section class="project-section" aria-labelledby="override-capabilities">
+    <h2 id="override-capabilities">What the product does</h2>
+    <ul class="project-checklist">
+      <li>Structures a production&#39;s capitalization in a dedicated web workflow.</li>
+      <li>Models investor returns against live deal terms instead of static spreadsheet snapshots.</li>
+      <li>Tracks ownership information in a format that can be maintained over time.</li>
+      <li>Shares live deals with backers without relying on PDF-based handoffs.</li>
+    </ul>
+  </section>
+
+  <section class="project-section" aria-labelledby="override-why">
+    <h2 id="override-why">Why it matters</h2>
+    <p>Broadway is a relationship-driven business, but the operating layer is still full of brittle document workflows. Override is built around the idea that trust-sensitive financial work should still feel legible, structured, and up to date.</p>
+  </section>
+
+  <section class="project-section" aria-labelledby="override-lens">
+    <h2 id="override-lens">Product lens</h2>
+    <p>The interesting part of this project is not just the finance domain. It is the translation exercise: taking highly specific theatrical financing mechanics and turning them into interfaces that are easier to work with, share, and reason about.</p>
+  </section>
+
+  <Fragment slot="sidebar">
+    <section class="project-card" aria-labelledby="override-facts">
+      <h2 id="override-facts">Project facts</h2>
+      <dl class="project-facts">
+        <div>
+          <dt>Domain</dt>
+          <dd>Finance × Theater</dd>
+        </div>
+        <div>
+          <dt>Format</dt>
+          <dd>Broadway finance web application</dd>
+        </div>
+        <div>
+          <dt>Focus</dt>
+          <dd>Capitalization, ownership, and investor workflows</dd>
+        </div>
+        <div>
+          <dt>Status</dt>
+          <dd>Live product</dd>
+        </div>
+      </dl>
+    </section>
+
+    <section class="project-card" aria-labelledby="override-note">
+      <h2 id="override-note">Live link</h2>
+      <p class="project-note"><a href="https://overridebroadway.com" target="_blank" rel="noopener">overridebroadway.com</a></p>
+    </section>
+  </Fragment>
+</ProjectLayout>

--- a/src/pages/projects/swipe-watch/index.astro
+++ b/src/pages/projects/swipe-watch/index.astro
@@ -1,0 +1,129 @@
+---
+import ProjectLayout from '../../../layouts/ProjectLayout.astro';
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      "@id": "https://nathanpayne.com/projects/swipe-watch/#webpage",
+      "url": "https://nathanpayne.com/projects/swipe-watch/",
+      "name": "Swipe Watch | Nathan Payne",
+      "description": "Swipe Watch is a vanilla JavaScript recommendation experiment by Nathan Payne that explores swipe-based streaming discovery for Disney+ and Hulu with coins, watchlists, and rapid interaction loops.",
+      "isPartOf": {
+        "@id": "https://nathanpayne.com/#website"
+      },
+      "breadcrumb": {
+        "@id": "https://nathanpayne.com/projects/swipe-watch/#breadcrumb"
+      },
+      "mainEntity": {
+        "@id": "https://nathanpayne.com/projects/swipe-watch/#app"
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "https://nathanpayne.com/projects/swipe-watch/#breadcrumb",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Nathan Payne",
+          "item": "https://nathanpayne.com/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Swipe Watch",
+          "item": "https://nathanpayne.com/projects/swipe-watch/"
+        }
+      ]
+    },
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://nathanpayne.com/projects/swipe-watch/#app",
+      "name": "Swipe Watch",
+      "applicationCategory": "EntertainmentApplication",
+      "operatingSystem": "Web",
+      "url": "https://swipewatch.web.app",
+      "creator": {
+        "@type": "Person",
+        "name": "Nathan Payne",
+        "url": "https://nathanpayne.com/"
+      },
+      "description": "A vanilla JavaScript recommendation experiment that explores swipe-based streaming discovery for Disney+ and Hulu with coins, watchlists, and rapid interaction loops."
+    }
+  ]
+};
+---
+
+<ProjectLayout
+  title="Swipe Watch | Nathan Payne"
+  description="Swipe Watch is a vanilla JavaScript recommendation experiment by Nathan Payne that explores swipe-based streaming discovery for Disney+ and Hulu with coins, watchlists, and rapid interaction loops."
+  ogDescription="A vanilla JavaScript recommendation experiment that explores swipe-based streaming discovery for Disney+ and Hulu with coins, watchlists, and rapid interaction loops."
+  canonical="https://nathanpayne.com/projects/swipe-watch/"
+  kicker="Consumer × Streaming"
+  headline="Swipe Watch"
+  deck="A swipe-based discovery experiment for Disney+ and Hulu that turns taste signals into a faster, more active recommendation loop."
+  breadcrumbLabel="Swipe Watch"
+  accentColorClass="project-page--blue"
+  actions={[
+    { label: "View Live Product", href: "https://swipewatch.web.app", external: true },
+    { label: "Back to Homepage", href: "/" },
+  ]}
+  jsonLd={jsonLd}
+>
+  <section class="project-section" aria-labelledby="swipe-overview">
+    <h2 id="swipe-overview">Overview</h2>
+    <p>Swipe Watch explores a simple question: what happens when streaming discovery feels active instead of passive? Rather than browsing endless shelves, the product uses a swipe interaction to let users react quickly, train their recommendations, and shape what the system learns.</p>
+    <p>It is a lightweight concept, but it is aimed at a real product problem: helping people express taste faster than a conventional streaming interface usually allows.</p>
+  </section>
+
+  <section class="project-section" aria-labelledby="swipe-capabilities">
+    <h2 id="swipe-capabilities">What the product does</h2>
+    <ul class="project-checklist">
+      <li>Presents streaming choices through a rapid swipe-based interface.</li>
+      <li>Turns user reactions into recommendation signals.</li>
+      <li>Adds coins and watchlist building as lightweight feedback loops.</li>
+      <li>Tests whether a faster interaction model can make discovery feel less static.</li>
+    </ul>
+  </section>
+
+  <section class="project-section" aria-labelledby="swipe-build">
+    <h2 id="swipe-build">Build notes</h2>
+    <p>Swipe Watch was built over a weekend in vanilla JavaScript. The speed of the prototype matters: it is a deliberately lightweight way to test the interaction idea without the overhead of a larger stack.</p>
+  </section>
+
+  <section class="project-section" aria-labelledby="swipe-why">
+    <h2 id="swipe-why">Why it matters</h2>
+    <p>Recommendation systems are often evaluated on model quality alone, but the interface that gathers preference signals matters too. Swipe Watch focuses on that front-end layer: the mechanics of how people tell a product what they want to watch next.</p>
+  </section>
+
+  <Fragment slot="sidebar">
+    <section class="project-card" aria-labelledby="swipe-facts">
+      <h2 id="swipe-facts">Project facts</h2>
+      <dl class="project-facts">
+        <div>
+          <dt>Domain</dt>
+          <dd>Consumer × Streaming</dd>
+        </div>
+        <div>
+          <dt>Format</dt>
+          <dd>Vanilla JavaScript prototype</dd>
+        </div>
+        <div>
+          <dt>Focus</dt>
+          <dd>Discovery, recommendations, and interaction design</dd>
+        </div>
+        <div>
+          <dt>Status</dt>
+          <dd>Live experiment</dd>
+        </div>
+      </dl>
+    </section>
+
+    <section class="project-card" aria-labelledby="swipe-note">
+      <h2 id="swipe-note">Live link</h2>
+      <p class="project-note"><a href="https://swipewatch.web.app" target="_blank" rel="noopener">swipewatch.web.app</a></p>
+    </section>
+  </Fragment>
+</ProjectLayout>


### PR DESCRIPTION
## Summary

- Create `src/layouts/ProjectLayout.astro` — shared project-page shell with breadcrumbs, hero, two-column layout
- Create 4 project pages under `src/pages/projects/*/index.astro`
- Add `ogDescription` prop to `BaseLayout.astro` for shorter social meta descriptions (falls back to `description`)
- All body content, JSON-LD (SoftwareApplication + BreadcrumbList), and OG tags ported verbatim from original HTML

| Route | Accent |
|---|---|
| `/projects/device-source-of-truth/` | red |
| `/projects/friends-and-family-billing/` | black |
| `/projects/override/` | yellow |
| `/projects/swipe-watch/` | blue |

Authoring-Agent: claude

Closes #38
Parent: #33

## Self-Review

**Correctness:** All 5 pages build (4 project + homepage). Dev server renders Device Source of Truth correctly with breadcrumbs, hero, sidebar, and accent color. No console errors.

**Regression risk:** Low-medium. The `ogDescription` addition to BaseLayout is backwards-compatible (falls back to `description`). Project pages are new routes that don't affect existing pages.

**Style:** ProjectLayout extracts shared markup — no duplication across 4 pages. Props interface covers all project-specific variations.

**Test coverage:** All 56 tests pass. Project page tests will come in Phase 8.

**Security/dependency hygiene:** No new dependencies. All external links use `rel="noopener"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new project showcase pages with detailed case studies, overviews, and structured navigation.
  * Enhanced social media sharing support with improved Open Graph metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->