### PR TITLE
Phases 6+7: Mermaid diagrams and figure captions

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,8 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
+import remarkMermaid from './src/plugins/remark-mermaid.mjs';
+import rehypeFigureCaptions from './src/plugins/rehype-figure-captions.mjs';
 
 // https://astro.build/config
 export default defineConfig({
@@ -11,6 +13,8 @@ export default defineConfig({
     format: 'directory',
   },
   markdown: {
+    remarkPlugins: [remarkMermaid],
+    rehypePlugins: [rehypeFigureCaptions],
     shikiConfig: {
       theme: 'vitesse-dark',
       transformers: [

--- a/specs/mermaid-diagrams.md
+++ b/specs/mermaid-diagrams.md
@@ -1,0 +1,21 @@
+# Mermaid Diagram Support
+
+## Summary
+
+A remark plugin converts fenced code blocks with `lang: mermaid` into static HTML
+diagrams during Markdown processing. No client-side Mermaid JS is loaded.
+
+## Acceptance Criteria
+
+1. Code blocks with language `mermaid` are replaced with `<div class="blog-diagram">` HTML.
+2. Fanout layout: a root node with out-degree > 1 renders as root node, branch line,
+   and a row of child nodes. Container has class `blog-diagram--fanout`.
+3. Chain layout: a linear sequence of nodes renders vertically with arrow separators.
+   Container has class `blog-diagram--chain`.
+4. Chain layout with loop-back: when the last node has an edge back to the first node,
+   a loop indicator is appended instead of a trailing arrow.
+5. All diagram containers have `aria-label="Diagram"`.
+6. Decorative arrows and branch elements have `aria-hidden="true"`.
+7. Node labels containing HTML special characters are escaped.
+8. Non-mermaid code blocks are not affected by the plugin.
+9. The Astro build completes successfully with the plugin registered.

--- a/src/content/blog/six-prs-one-bug-agent-failure-modes.md
+++ b/src/content/blog/six-prs-one-bug-agent-failure-modes.md
@@ -43,23 +43,25 @@ The screenshots in [issue #159](https://github.com/nathanjohnpayne/friends-and-f
 
 ### 1. Editor: the structured document still looked sane
 
-![Editor Screenshot](https://raw.githubusercontent.com/nathanjohnpayne/friends-and-family-billing/issue/invoice-rendering-bug-screenshots/.github/screenshots/invoice-bug-01-editor-view.png)
+![Editor Screenshot](/blog/six-prs-one-bug-agent-failure-modes/img/invoice-bug-01-editor-view.png)
 
 In Edit mode, the intro paragraph is ordinary body text. The billing-summary link, payment options block, divider, and signature are all in the expected order. At this point the content still lives as structured TipTap / ProseMirror JSON, so the system has not yet lost information.
 
 ### 2. Preview: semantics changed during the markdown round-trip
 
-![Preview Screenshot](https://raw.githubusercontent.com/nathanjohnpayne/friends-and-family-billing/issue/invoice-rendering-bug-screenshots/.github/screenshots/invoice-bug-02-preview-view.png)
+![Preview Screenshot](/blog/six-prs-one-bug-agent-failure-modes/img/invoice-bug-02-preview-view.png)
 
 Preview was not rendering the editor document directly. It serialized the document into markdown-like text and reparsed that text with CommonMark. Separator lines like `---` were being interpreted differently across surfaces, and list content was picking up paragraph wrappers with default margins. That is why the Preview screenshot looks heavier and more spread out than the editor even though the author never changed the template content.
 
 ### 3. Sent email: a second parser created a third version of reality
 
-![Sent Email Screenshot](https://raw.githubusercontent.com/nathanjohnpayne/friends-and-family-billing/issue/invoice-rendering-bug-screenshots/.github/screenshots/invoice-bug-03-broken-sent-email.png)
+![Sent Email Screenshot](/blog/six-prs-one-bug-agent-failure-modes/img/invoice-bug-03-broken-sent-email.png)
 
 The sent email did not use the Preview renderer. It took the same flattened text and pushed it through a separate regex-based markdown renderer in the Cloud Function. So by the time the email reached a customer inbox, the system had already turned one source document into three different interpretations: editor, preview, and email.
 
 ### 4. The target was concrete, not hypothetical
+
+![Correct Intended Email Screenshot](/blog/six-prs-one-bug-agent-failure-modes/img/invoice-bug-04-correct-sent-email.png)
 
 This detail in the issue mattered: there was a known-good email from **April 2, 2026 at 5:05 PM**. The bug was not "make Preview look a little nicer." The bug was "restore parity with a real output that previously existed."
 

--- a/src/plugins/rehype-figure-captions.mjs
+++ b/src/plugins/rehype-figure-captions.mjs
@@ -1,0 +1,69 @@
+import { visit } from 'unist-util-visit';
+
+/**
+ * Rehype plugin that wraps standalone images in <figure> elements
+ * with auto-numbered captions derived from alt text.
+ *
+ * Transforms:
+ *   <p><img src="..." alt="Alt text" /></p>
+ * Into:
+ *   <figure class="blog-figure">
+ *     <img src="..." alt="Alt text" loading="lazy" />
+ *     <figcaption><strong>Figure N:</strong> Alt text</figcaption>
+ *   </figure>
+ */
+export default function rehypeFigureCaptions() {
+  return (tree) => {
+    let figureCount = 0;
+
+    visit(tree, 'element', (node, index, parent) => {
+      if (!parent || index === undefined) return;
+
+      // Match <p> elements that contain exactly one child: an <img>
+      if (node.tagName !== 'p') return;
+
+      const children = node.children.filter(
+        (child) => !(child.type === 'text' && child.value.trim() === ''),
+      );
+
+      if (children.length !== 1) return;
+      if (children[0].type !== 'element' || children[0].tagName !== 'img') return;
+
+      const img = children[0];
+      const alt = img.properties?.alt || '';
+
+      figureCount++;
+
+      // Add loading="lazy" to the image
+      img.properties = img.properties || {};
+      img.properties.loading = 'lazy';
+
+      // Build the <figure> element that replaces the <p>
+      const figure = {
+        type: 'element',
+        tagName: 'figure',
+        properties: { className: ['blog-figure'] },
+        children: [
+          img,
+          {
+            type: 'element',
+            tagName: 'figcaption',
+            properties: {},
+            children: [
+              {
+                type: 'element',
+                tagName: 'strong',
+                properties: {},
+                children: [{ type: 'text', value: `Figure ${figureCount}:` }],
+              },
+              { type: 'text', value: ` ${alt}` },
+            ],
+          },
+        ],
+      };
+
+      // Replace the <p> with the <figure> in the parent's children
+      parent.children[index] = figure;
+    });
+  };
+}

--- a/src/plugins/remark-mermaid.mjs
+++ b/src/plugins/remark-mermaid.mjs
@@ -65,9 +65,18 @@ function renderMermaidDiagram(code) {
     }
 
     const normalizedLine = line.replace(/\["[^"]+"\]/g, '');
-    const edgeMatch = normalizedLine.match(/([A-Za-z0-9_]+)\s*-->\s*([A-Za-z0-9_]+)/);
-    if (edgeMatch) {
-      edges.push([edgeMatch[1], edgeMatch[2]]);
+    const nodeIds = [...normalizedLine.matchAll(/([A-Za-z0-9_]+)/g)].map((m) => m[1]);
+    const arrows = [...normalizedLine.matchAll(/-->/g)];
+    if (arrows.length > 0) {
+      // Extract node IDs between --> separators to handle chains like A --> B --> C
+      const parts = normalizedLine.split(/\s*-->\s*/).map((p) => p.trim()).filter(Boolean);
+      for (let i = 0; i < parts.length - 1; i++) {
+        const from = parts[i].match(/([A-Za-z0-9_]+)/)?.[1];
+        const to = parts[i + 1].match(/([A-Za-z0-9_]+)/)?.[1];
+        if (from && to) {
+          edges.push([from, to]);
+        }
+      }
     }
   }
 

--- a/src/plugins/remark-mermaid.mjs
+++ b/src/plugins/remark-mermaid.mjs
@@ -1,0 +1,125 @@
+import { visit } from 'unist-util-visit';
+
+/**
+ * Remark plugin that converts ```mermaid code fences into static HTML diagrams.
+ *
+ * Produces the same <div class="blog-diagram ..."> structure as the legacy
+ * generate-blog.js renderer. Two layout patterns are supported:
+ *
+ * - Fanout: a root node with out-degree > 1, rendered as root -> branch -> row of children
+ * - Chain: a linear sequence of nodes with arrows, optional loop-back arrow
+ *
+ * No client-side Mermaid JS is loaded; the output is pure HTML styled by global.css.
+ */
+export default function remarkMermaid() {
+  return (tree) => {
+    visit(tree, 'code', (node, index, parent) => {
+      if (node.lang !== 'mermaid' || parent == null || index == null) {
+        return;
+      }
+
+      const html = renderMermaidDiagram(node.value);
+
+      parent.children[index] = {
+        type: 'html',
+        value: html,
+      };
+    });
+  };
+}
+
+/**
+ * Escape HTML special characters in text content.
+ * Matches the legacy escapeHtml() from generate-blog.js.
+ */
+function escapeHtml(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Parse a Mermaid graph definition and render it as static HTML.
+ *
+ * This is a direct port of renderMermaidDiagram() from scripts/generate-blog.js
+ * (lines 254-333). It handles two layout patterns:
+ *
+ * 1. Fanout: when any node has out-degree > 1, that node becomes the root of a
+ *    fanout layout with a branch line and a row of child nodes.
+ *
+ * 2. Chain: a linear sequence of nodes connected by arrows, with an optional
+ *    loop-back indicator when the last node points back to the first.
+ */
+function renderMermaidDiagram(code) {
+  const lines = code.split('\n').map((line) => line.trim()).filter(Boolean);
+  const labels = new Map();
+  const edges = [];
+
+  for (const line of lines.slice(1)) {
+    const nodeMatches = [...line.matchAll(/([A-Za-z0-9_]+)\["([^"]+)"\]/g)];
+    for (const match of nodeMatches) {
+      labels.set(match[1], match[2]);
+    }
+
+    const normalizedLine = line.replace(/\["[^"]+"\]/g, '');
+    const edgeMatch = normalizedLine.match(/([A-Za-z0-9_]+)\s*-->\s*([A-Za-z0-9_]+)/);
+    if (edgeMatch) {
+      edges.push([edgeMatch[1], edgeMatch[2]]);
+    }
+  }
+
+  const outDegree = new Map();
+  const inDegree = new Map();
+  const adjacency = new Map();
+
+  for (const [from, to] of edges) {
+    outDegree.set(from, (outDegree.get(from) || 0) + 1);
+    inDegree.set(to, (inDegree.get(to) || 0) + 1);
+    if (!adjacency.has(from)) {
+      adjacency.set(from, []);
+    }
+    adjacency.get(from).push(to);
+    if (!inDegree.has(from)) {
+      inDegree.set(from, inDegree.get(from) || 0);
+    }
+    if (!outDegree.has(to)) {
+      outDegree.set(to, outDegree.get(to) || 0);
+    }
+  }
+
+  const fanoutRoot = [...outDegree.entries()].find(([, count]) => count > 1);
+  if (fanoutRoot) {
+    const root = fanoutRoot[0];
+    const children = edges.filter(([from]) => from === root).map(([, to]) => to);
+    return `<div class="blog-diagram blog-diagram--fanout" aria-label="Diagram"><div class="blog-diagram-node">${escapeHtml(labels.get(root) || root)}</div><div class="blog-diagram-branch" aria-hidden="true"></div><div class="blog-diagram-fanout-row">${children.map((child) => `<div class="blog-diagram-node">${escapeHtml(labels.get(child) || child)}</div>`).join('')}</div></div>`;
+  }
+
+  const start = [...labels.keys()].find((id) => (inDegree.get(id) || 0) === 0) || edges[0][0];
+  const sequence = [];
+  const visited = new Set();
+  let current = start;
+
+  while (current && !visited.has(current)) {
+    visited.add(current);
+    sequence.push(current);
+    const next = (adjacency.get(current) || []).find((candidate) => !visited.has(candidate));
+    current = next || null;
+  }
+
+  const loopBack = edges.some(([from, to]) => from === sequence[sequence.length - 1] && to === sequence[0]);
+
+  return `<div class="blog-diagram blog-diagram--chain" aria-label="Diagram">${sequence.map((node, nodeIndex) => {
+    const nodeHtml = `<div class="blog-diagram-node">${escapeHtml(labels.get(node) || node)}</div>`;
+    if (nodeIndex === sequence.length - 1) {
+      return loopBack
+        ? `${nodeHtml}<div class="blog-diagram-loop" aria-hidden="true">\u21ba</div>`
+        : nodeHtml;
+    }
+    return `${nodeHtml}<div class="blog-diagram-arrow" aria-hidden="true">\u2193</div>`;
+  }).join('')}</div>`;
+}
+
+export { renderMermaidDiagram as _renderMermaidDiagram };

--- a/src/plugins/remark-mermaid.mjs
+++ b/src/plugins/remark-mermaid.mjs
@@ -90,6 +90,10 @@ function renderMermaidDiagram(code) {
     }
   }
 
+  if (edges.length === 0) {
+    return '<div class="blog-diagram" aria-label="Diagram"></div>';
+  }
+
   const fanoutRoot = [...outDegree.entries()].find(([, count]) => count > 1);
   if (fanoutRoot) {
     const root = fanoutRoot[0];

--- a/src/plugins/remark-mermaid.mjs
+++ b/src/plugins/remark-mermaid.mjs
@@ -90,8 +90,15 @@ function renderMermaidDiagram(code) {
     }
   }
 
-  if (edges.length === 0) {
+  if (edges.length === 0 && labels.size === 0) {
     return '<div class="blog-diagram" aria-label="Diagram"></div>';
+  }
+
+  if (edges.length === 0 && labels.size > 0) {
+    const nodes = [...labels.entries()].map(([id, label]) =>
+      `<div class="blog-diagram-node">${escapeHtml(label)}</div>`
+    ).join('');
+    return `<div class="blog-diagram blog-diagram--chain" aria-label="Diagram">${nodes}</div>`;
   }
 
   const fanoutRoot = [...outDegree.entries()].find(([, count]) => count > 1);

--- a/tests/mermaid-diagrams.test.js
+++ b/tests/mermaid-diagrams.test.js
@@ -152,6 +152,14 @@ describe('remark-mermaid: renderMermaidDiagram', () => {
       const html = renderMermaidDiagram(code);
       expect(html).toContain('blog-diagram');
     });
+
+    it('renders label-only nodes without edges', () => {
+      const code = 'graph TD\nA["Solo Node"]';
+      const html = renderMermaidDiagram(code);
+      expect(html).toContain('blog-diagram--chain');
+      expect(html).toContain('Solo Node');
+      expect(html).toContain('blog-diagram-node');
+    });
   });
 
   describe('non-mermaid code blocks', () => {

--- a/tests/mermaid-diagrams.test.js
+++ b/tests/mermaid-diagrams.test.js
@@ -139,6 +139,21 @@ describe('remark-mermaid: renderMermaidDiagram', () => {
     });
   });
 
+  describe('edge cases', () => {
+    it('handles empty mermaid block without crashing', () => {
+      const code = 'graph TD';
+      const html = renderMermaidDiagram(code);
+      expect(html).toContain('blog-diagram');
+      expect(html).toContain('aria-label="Diagram"');
+    });
+
+    it('handles mermaid block with only whitespace after header', () => {
+      const code = 'graph TD\n  \n  ';
+      const html = renderMermaidDiagram(code);
+      expect(html).toContain('blog-diagram');
+    });
+  });
+
   describe('non-mermaid code blocks', () => {
     it('does not process non-mermaid code (plugin function identity)', async () => {
       // The remark plugin only visits code nodes with lang=mermaid.

--- a/tests/mermaid-diagrams.test.js
+++ b/tests/mermaid-diagrams.test.js
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { _renderMermaidDiagram as renderMermaidDiagram } from '../src/plugins/remark-mermaid.mjs';
+
+describe('remark-mermaid: renderMermaidDiagram', () => {
+  describe('fanout layout', () => {
+    it('renders a root node with multiple children as fanout', () => {
+      const code = [
+        'graph TD',
+        'A["Root"] --> B["Child 1"]',
+        'A --> C["Child 2"]',
+        'A --> D["Child 3"]',
+      ].join('\n');
+
+      const html = renderMermaidDiagram(code);
+
+      expect(html).toContain('blog-diagram--fanout');
+      expect(html).toContain('aria-label="Diagram"');
+      expect(html).toContain('>Root</div>');
+      expect(html).toContain('blog-diagram-branch');
+      expect(html).toContain('blog-diagram-fanout-row');
+      expect(html).toContain('>Child 1</div>');
+      expect(html).toContain('>Child 2</div>');
+      expect(html).toContain('>Child 3</div>');
+    });
+
+    it('adds aria-hidden to branch element', () => {
+      const code = [
+        'graph TD',
+        'A["Root"] --> B["Left"]',
+        'A --> C["Right"]',
+      ].join('\n');
+
+      const html = renderMermaidDiagram(code);
+      expect(html).toContain('blog-diagram-branch" aria-hidden="true"');
+    });
+
+    it('uses node ID as fallback when no label is defined', () => {
+      const code = [
+        'graph TD',
+        'A --> B',
+        'A --> C',
+      ].join('\n');
+
+      const html = renderMermaidDiagram(code);
+      expect(html).toContain('>A</div>');
+      expect(html).toContain('>B</div>');
+      expect(html).toContain('>C</div>');
+    });
+  });
+
+  describe('chain layout', () => {
+    it('renders a linear sequence with arrows', () => {
+      const code = [
+        'graph TD',
+        'A["Step 1"] --> B["Step 2"]',
+        'B --> C["Step 3"]',
+      ].join('\n');
+
+      const html = renderMermaidDiagram(code);
+
+      expect(html).toContain('blog-diagram--chain');
+      expect(html).toContain('aria-label="Diagram"');
+      expect(html).toContain('>Step 1</div>');
+      expect(html).toContain('blog-diagram-arrow');
+      expect(html).toContain('>Step 2</div>');
+      expect(html).toContain('>Step 3</div>');
+    });
+
+    it('adds aria-hidden to arrow elements', () => {
+      const code = [
+        'graph TD',
+        'A["First"] --> B["Second"]',
+      ].join('\n');
+
+      const html = renderMermaidDiagram(code);
+      expect(html).toContain('blog-diagram-arrow" aria-hidden="true"');
+    });
+
+    it('does not include a loop indicator when there is no loop-back', () => {
+      const code = [
+        'graph TD',
+        'A["Start"] --> B["End"]',
+      ].join('\n');
+
+      const html = renderMermaidDiagram(code);
+      expect(html).not.toContain('blog-diagram-loop');
+    });
+  });
+
+  describe('chain layout with loop-back', () => {
+    it('renders a loop indicator when last node points to first', () => {
+      const code = [
+        'graph TD',
+        'A["Plan"] --> B["Build"]',
+        'B --> C["Review"]',
+        'C --> A',
+      ].join('\n');
+
+      const html = renderMermaidDiagram(code);
+
+      expect(html).toContain('blog-diagram--chain');
+      expect(html).toContain('blog-diagram-loop');
+      expect(html).toContain('\u21ba');
+    });
+
+    it('adds aria-hidden to loop indicator', () => {
+      const code = [
+        'graph TD',
+        'A["Plan"] --> B["Build"]',
+        'B --> A',
+      ].join('\n');
+
+      const html = renderMermaidDiagram(code);
+      expect(html).toContain('blog-diagram-loop" aria-hidden="true"');
+    });
+  });
+
+  describe('HTML escaping', () => {
+    it('escapes HTML special characters in labels', () => {
+      const code = [
+        'graph TD',
+        'A["<script>alert(1)</script>"] --> B["Tom & Jerry"]',
+      ].join('\n');
+
+      const html = renderMermaidDiagram(code);
+      expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+      expect(html).toContain('Tom &amp; Jerry');
+      expect(html).not.toContain('<script>');
+    });
+
+    it('escapes quotes in labels', () => {
+      const code = [
+        'graph TD',
+        'A["She said \'hello\'"] --> B["End"]',
+      ].join('\n');
+
+      const html = renderMermaidDiagram(code);
+      expect(html).toContain('She said &#39;hello&#39;');
+    });
+  });
+
+  describe('non-mermaid code blocks', () => {
+    it('does not process non-mermaid code (plugin function identity)', async () => {
+      // The remark plugin only visits code nodes with lang=mermaid.
+      // This is tested at the AST level by importing the plugin function itself.
+      const { default: remarkMermaid } = await import('../src/plugins/remark-mermaid.mjs');
+
+      const jsCodeNode = { type: 'code', lang: 'javascript', value: 'const x = 1;' };
+      const tree = { type: 'root', children: [jsCodeNode] };
+
+      remarkMermaid()(tree);
+
+      // The node should remain unchanged (still type: 'code', not 'html')
+      expect(tree.children[0].type).toBe('code');
+      expect(tree.children[0].lang).toBe('javascript');
+    });
+  });
+});

--- a/tests/mermaid-diagrams.test.js
+++ b/tests/mermaid-diagrams.test.js
@@ -153,6 +153,20 @@ describe('remark-mermaid: renderMermaidDiagram', () => {
       expect(html).toContain('blog-diagram');
     });
 
+    it('handles same-line chained edges like A --> B --> C', () => {
+      const code = 'graph TD\nA["Step 1"] --> B["Step 2"] --> C["Step 3"]';
+      const html = renderMermaidDiagram(code);
+      expect(html).toContain('blog-diagram--chain');
+      expect(html).toContain('Step 1');
+      expect(html).toContain('Step 2');
+      expect(html).toContain('Step 3');
+      // Should have 3 nodes and 2 arrows
+      const nodeCount = (html.match(/blog-diagram-node/g) || []).length;
+      const arrowCount = (html.match(/blog-diagram-arrow/g) || []).length;
+      expect(nodeCount).toBe(3);
+      expect(arrowCount).toBe(2);
+    });
+
     it('renders label-only nodes without edges', () => {
       const code = 'graph TD\nA["Solo Node"]';
       const html = renderMermaidDiagram(code);


### PR DESCRIPTION
## Summary

### Phase 6: Mermaid diagram support (#41)
- Create `src/plugins/remark-mermaid.mjs` — remark plugin porting fanout/chain diagram rendering from `generate-blog.js`
- Supports fanout layout (root → branch → row of children) and chain layout (linear sequence with arrows, optional loop-back)
- Accessibility: `aria-label="Diagram"` on containers, `aria-hidden="true"` on decorative elements
- No client-side Mermaid JS — pure static HTML
- 11 new tests + spec file

### Phase 7: Image handling and figure captions (#42)
- Create `src/plugins/rehype-figure-captions.mjs` — rehype plugin wrapping standalone images in `<figure class="blog-figure">` with auto-numbered `<figcaption><strong>Figure N:</strong> alt text</figcaption>`
- Adds `loading="lazy"` to all matched images
- Replace 3 external `raw.githubusercontent.com` URLs with local `/blog/*/img/` paths
- Add missing 4th image (drift item #8)

### Drift items resolved from #33
| # | Category | Resolution |
|---|---|---|
| 3 | External image URLs | Replaced with local paths |
| 4 | Figure captions lack numbering | rehype plugin auto-numbers |
| 8 | Missing 4th image | Added to markdown source |

Authoring-Agent: claude

Closes #41, closes #42
Parent: #33

## Self-Review

**Correctness:** Build produces 4 `<figure class="blog-figure">` elements with Figure 1-4 captions. Zero external image URLs. All images have `loading="lazy"`. Mermaid plugin handles both layout patterns (tested with 11 unit tests).

**Regression risk:** Low. Remark plugin only activates on `mermaid` code fences (none in current content). Rehype plugin only wraps `<p>` elements containing a sole `<img>` — won't affect code blocks, inline images, or other content.

**Style:** Both plugins follow the same pattern (unist-util-visit, hast manipulation). Mermaid rendering logic is a direct port from the legacy generator.

**Test coverage:** 67 tests pass (11 new mermaid tests). Spec file added for mermaid diagrams.

**Security/dependency hygiene:** No new dependencies (unist-util-visit already installed). External image URLs removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mermaid diagrams in markdown code blocks are rendered as static HTML visualizations in blog posts, with fanout and chain layouts and accessibility labels.
  * Images in blog content now render inside figure elements with captions derived from alt text.
  * Several blog screenshots updated to use local site-relative image paths.

* **Documentation**
  * Added Mermaid diagram specification covering layout and accessibility requirements.

* **Tests**
  * Added tests for diagram rendering, escaping, layouts, and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->