### PR TITLE
Pre-deploy fixes: blog content, code colors, mermaid diagrams

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,7 +16,7 @@ export default defineConfig({
     remarkPlugins: [remarkMermaid],
     rehypePlugins: [rehypeFigureCaptions],
     shikiConfig: {
-      theme: 'vitesse-dark',
+      theme: 'css-variables',
       transformers: [
         {
           pre(node) {

--- a/specs/mermaid-diagrams.md
+++ b/specs/mermaid-diagrams.md
@@ -2,20 +2,19 @@
 
 ## Summary
 
-A remark plugin converts fenced code blocks with `lang: mermaid` into static HTML
-diagrams during Markdown processing. No client-side Mermaid JS is loaded.
+Mermaid diagrams are rendered client-side by Mermaid.js loaded from CDN.
+A remark plugin converts fenced code blocks with `lang: mermaid` into
+`<pre class="mermaid">` elements with HTML-escaped content. The BlogPost
+layout loads Mermaid.js which renders them as SVGs in the browser.
 
 ## Acceptance Criteria
 
-1. Code blocks with language `mermaid` are replaced with `<div class="blog-diagram">` HTML.
-2. Fanout layout: a root node with out-degree > 1 renders as root node, branch line,
-   and a row of child nodes. Container has class `blog-diagram--fanout`.
-3. Chain layout: a linear sequence of nodes renders vertically with arrow separators.
-   Container has class `blog-diagram--chain`.
-4. Chain layout with loop-back: when the last node has an edge back to the first node,
-   a loop indicator is appended instead of a trailing arrow.
-5. All diagram containers have `aria-label="Diagram"`.
-6. Decorative arrows and branch elements have `aria-hidden="true"`.
-7. Node labels containing HTML special characters are escaped.
-8. Non-mermaid code blocks are not affected by the plugin.
-9. The Astro build completes successfully with the plugin registered.
+1. Mermaid code fences in blog posts render as SVG diagrams.
+2. Diagrams support full Mermaid syntax: `graph LR`, `graph TD`, `style`
+   directives, dotted arrows (`-.->` with labels), `<br/>` in labels,
+   subgraphs, and colored nodes.
+3. Non-mermaid code blocks are not affected by the plugin.
+4. HTML special characters in mermaid content are escaped.
+5. Mermaid.js only loads on blog post pages (not homepage, project pages,
+   or blog index).
+6. The Astro build completes successfully with the plugin registered.

--- a/src/content/blog/six-prs-one-bug-agent-failure-modes.md
+++ b/src/content/blog/six-prs-one-bug-agent-failure-modes.md
@@ -11,9 +11,9 @@ On April 4, 2026, I opened [issue #159](https://github.com/nathanjohnpayne/frien
 
 That framing turned out to be wrong.
 
-This was not a styling bug. It was a systems bug wearing a styling-bug costume. Over roughly twenty hours, one agent opened six PRs trying to resolve it: [#144](https://github.com/nathanjohnpayne/friends-and-family-billing/pull/144), [#146](https://github.com/nathanjohnpayne/friends-and-family-billing/pull/146), [#153](https://github.com/nathanjohnpayne/friends-and-family-billing/pull/153), [#154](https://github.com/nathanjohnpayne/friends-and-family-billing/pull/154), [#155](https://github.com/nathanjohnpayne/friends-and-family-billing/pull/155), and [#158](https://github.com/nathanjohnpayne/friends-and-family-billing/pull/158). None fixed the user-facing problem. [PR #161](https://github.com/nathanjohnpayne/friends-and-family-billing/pull/161) finally did, but only after a different agent, given a fundamentally different kind of prompt, treated the whole thing as a failed-fix investigation instead of another incremental patch.
+This was not a styling bug. It was a systems bug wearing a styling-bug costume. Over roughly twenty hours, one agent opened six PRs trying to resolve it: [#144](https://github.com/nathanjohnpayne/friends-and-family-billing/pull/144), [#146](https://github.com/nathanjohnpayne/friends-and-family-billing/pull/146), [#153](https://github.com/nathanjohnpayne/friends-and-family-billing/pull/153), [#154](https://github.com/nathanjohnpayne/friends-and-family-billing/pull/154), [#155](https://github.com/nathanjohnpayne/friends-and-family-billing/pull/155), and [#158](https://github.com/nathanjohnpayne/friends-and-family-billing/pull/158). None fixed the user-facing problem. [PR #161](https://github.com/nathanjohnpayne/friends-and-family-billing/pull/161) finally did—but only after a different agent, given a fundamentally different kind of prompt, treated the whole thing as a failed-fix investigation instead of another incremental patch.
 
-The lesson is not "AI is bad at formatting." The lesson is that agents are very good at making local progress inside the wrong model, and that the difference between six failed fixes and one successful one was not a smarter agent. It was a different supervision structure.
+The lesson is not "AI is bad at formatting." The lesson is that agents are very good at making local progress inside the wrong model—and that the difference between six failed fixes and one successful one was not a smarter agent. It was a different supervision structure.
 
 I have the full session log: eighteen user prompts, nine external code review rounds, three automated stop-hook interventions, and the task document that finally produced the fix. This post is about what that record shows.
 
@@ -25,15 +25,27 @@ If a template editor is going to be trustworthy, it has to preserve one basic in
 Editor = Preview = Sent email
 ```
 
-Here is what the actual pipeline looked like after the TipTap migration:
+**The rendering pipeline after the TipTap migration:**
 
-```text
-Editor:  TipTap / ProseMirror document -> Editor DOM
-Preview: TipTap / ProseMirror document -> docToPlainTextWithTokens() -> CommonMark renderer -> Preview HTML
-Email:   TipTap / ProseMirror document -> docToPlainTextWithTokens() -> Regex-based renderer -> Sent email HTML
+```mermaid
+graph LR
+    A["TipTap / ProseMirror<br/>Document"] --> B["Editor DOM"]
+    A --> C["docToPlainTextWithTokens()"]
+    C --> D["CommonMark<br/>Renderer"]
+    C --> E["Regex-based<br/>Renderer"]
+    D --> F["Preview HTML"]
+    E --> G["Sent Email HTML"]
+
+    style A fill:#4a90d9,stroke:#2c5f8a,color:#fff
+    style B fill:#7bc67e,stroke:#4a8a4d,color:#fff
+    style C fill:#e07c5a,stroke:#b35937,color:#fff
+    style D fill:#d4a84b,stroke:#a07830,color:#fff
+    style E fill:#d4a84b,stroke:#a07830,color:#fff
+    style F fill:#c75c5c,stroke:#993d3d,color:#fff
+    style G fill:#c75c5c,stroke:#993d3d,color:#fff
 ```
 
-The editor rendered structured content directly. Preview and send did not. They first flattened that structured document back into markdown-like plain text, then reparsed it through two different HTML pipelines.
+Three paths, three outputs. The editor rendered structured content directly. Preview and send did not—they first flattened that structured document back into markdown-like plain text through `docToPlainTextWithTokens()`, then reparsed it through two *different* HTML pipelines.
 
 Once that happened, "WYSIWYG editor" stopped being true in any meaningful sense. The same content was no longer guaranteed to produce the same semantics.
 
@@ -95,6 +107,26 @@ It did not.
 
 ## Why six PRs still did not fix it
 
+**The six failed PRs and the one that worked:**
+
+```mermaid
+graph TD
+    PR144["#144: Preserved markdown bridge"] --> PR146["#146: Improved regex"]
+    PR146 --> PR153["#153: CSS patch + mark serialization"]
+    PR153 --> PR154["#154: Editor lifecycle fix"]
+    PR154 --> PR155["#155: Legacy migration fix"]
+    PR155 --> PR158["#158: Cleaner bridge module"]
+    PR158 -.->|"Reframed as failed-fix investigation"| PR161["#161: Removed the bridge entirely"]
+
+    style PR144 fill:#e8b4b4,stroke:#993d3d,color:#333
+    style PR146 fill:#e8b4b4,stroke:#993d3d,color:#333
+    style PR153 fill:#e8b4b4,stroke:#993d3d,color:#333
+    style PR154 fill:#e8b4b4,stroke:#993d3d,color:#333
+    style PR155 fill:#e8b4b4,stroke:#993d3d,color:#333
+    style PR158 fill:#e8b4b4,stroke:#993d3d,color:#333
+    style PR161 fill:#7bc67e,stroke:#4a8a4d,color:#fff
+```
+
 The failed PRs show how an agent can keep doing competent work without ever repairing the invariant. This was Claude Code on the failed attempts and OpenAI Codex on the successful one, but I do not think this is mainly a vendor story. The session log makes clear that the difference was in the prompt structure, not the model.
 
 ### PR #144: the migration preserved the old assumption
@@ -107,9 +139,21 @@ That decision made the rest of the bug almost inevitable. The app now had a rich
 
 My kickoff prompt for the session was:
 
-> Read /Users/nathanpayne/GitHub/docs/projects/friends-and-family-billing/invoicing-tab-redesign.md and implement the plan.
+> Read [invoicing-tab-redesign.md](https://github.com/nathanjohnpayne/friends-and-family-billing/blob/main/docs/invoicing-tab-redesign.md) and implement the plan.
 
-The design spec described what the invoicing tab should look like. It did not describe what architectural invariants the rendering pipeline should preserve. So the agent picked the fastest path to a working UI: keep the old pipeline, bolt a new editor on top.
+Here is the part that makes this harder to dismiss as "bad prompting": that [design spec](https://github.com/nathanjohnpayne/friends-and-family-billing/blob/main/docs/invoicing-tab-redesign.md) was good. It was a 520-line document that explicitly chose TipTap JSON as the canonical storage format, explained why ("persisting HTML would require round-tripping through TipTap's HTML parser/serializer on every load/save cycle, which is lossy"), and described the derived output model clearly: "HTML is generated from JSON for Preview rendering. Email-safe HTML is generated from JSON for final outbound email rendering."
+
+That last sentence is essentially the invariant. The spec described a system where JSON is the source of truth and both Preview and email are derived from it through HTML generation.
+
+But the spec also included a backward-compatibility requirement:
+
+> `buildInvoiceBody` in `invoice.js` must handle: (1) Legacy plain-text templates containing `%token%` syntax (read from `settings.emailMessage`), (2) The new TipTap JSON document format (read from `settings.emailMessageDocument`)
+
+That requirement created the bridge. The agent had to keep the old plaintext pipeline working alongside the new JSON format. PR #144's decision to flatten the structured document back into plaintext via `docToPlainTextWithTokens()` and run it through the existing `buildInvoiceBody` was a reasonable interpretation of "handle both formats"—convert the new format into the old one and reuse the existing pipeline. It is the lazy interpretation, but it is not an unreasonable one. The spec did not say "you must create a new email renderer that operates directly on the JSON document." It said the old function must handle both formats, and the simplest way to handle both is to convert the new one into the old one.
+
+This matters because it means the failure was not "the agent had bad instructions." The spec implied the right architecture. The agent read the spec and made a locally rational decision that violated the spec's intent without violating its letter. Even well-written specs can leave enough room for an agent to choose the path of least resistance, and the path of least resistance is almost always "preserve the existing pipeline."
+
+The takeaway is subtler than "state your invariant explicitly." It is: when a spec describes a new architecture but also requires backward compatibility with the old one, the agent will optimize for the compatibility constraint and sacrifice the architectural one. The invariant needs to be stated as a constraint that outranks backward compatibility, not implied by the storage format choice.
 
 ### PR #146: the agent got better at regex, not closer to the invariant
 
@@ -159,7 +203,7 @@ Both changes are locally valid. They probably improved the experience. They also
 
 Those were both good fixes. They were also orthogonal to editor/preview/email parity. This is another failure mode worth noticing: an agent working on the right issue can still accumulate adjacent wins that make everyone feel progress is happening while the core invariant remains broken.
 
-The review feedback on PR #155 is telling. The nathanpayne-codex reviewer flagged three separate round-trip safety issues: link parsing that stopped at the first `)` in a URL, italic-wrapped links that did not survive serialization, and marked token forms that were not covered. Three findings, all pointing at the same structural problem, the intermediate format was lossy, and the agent addressed each one as a scoped regex fix.
+The review feedback on PR #155 is telling. The nathanpayne-codex reviewer flagged three separate round-trip safety issues: link parsing that stopped at the first `)` in a URL, italic-wrapped links that did not survive serialization, and marked token forms that were not covered. Three findings, all pointing at the same structural problem—the intermediate format was lossy—and the agent addressed each one as a scoped regex fix.
 
 ### PR #158: the bridge got cleaner, and the system stayed wrong
 
@@ -190,7 +234,30 @@ Why does this serializer exist at all?
 
 ## The automated guardrails saw it too
 
-The session included three automated stop-hook interventions, system-level checks that fire between prompts. Two of them are relevant:
+**The closed feedback loop:**
+
+```mermaid
+graph TD
+    BUG["Bug reported"] --> AGENT["Agent receives symptom"]
+    AGENT --> PATCH["Patches nearest code path"]
+    PATCH --> REVIEW["Code review flags\nround-trip failure"]
+    PATCH --> HOOK["Stop-hook flags\ndata consistency issue"]
+    PATCH --> USER["User reports\nsame symptom again"]
+    REVIEW --> AGENT
+    HOOK --> AGENT
+    USER --> AGENT
+
+    style BUG fill:#e07c5a,stroke:#b35937,color:#fff
+    style AGENT fill:#4a90d9,stroke:#2c5f8a,color:#fff
+    style PATCH fill:#d4a84b,stroke:#a07830,color:#fff
+    style REVIEW fill:#c75c5c,stroke:#993d3d,color:#fff
+    style HOOK fill:#c75c5c,stroke:#993d3d,color:#fff
+    style USER fill:#c75c5c,stroke:#993d3d,color:#fff
+```
+
+Three signal sources, one agent, zero escalation. The loop never opened.
+
+The session included three automated stop-hook interventions—system-level checks that fire between prompts. Two of them are relevant:
 
 **Hook 2** flagged that the plaintext fallback was being derived from `editor.getText()` instead of the invoice renderer. With the TipTap schema, `getText()` was adding extra blank lines around block tokens and dropping list markers. This is the divergent-render-path problem stated as an automated finding: the system was generating plaintext from a method that did not match the rendering pipeline.
 
@@ -222,7 +289,7 @@ And it included a constraints section that explicitly banned the exact moves Cla
 
 Every constraint corresponds to something the first agent actually did. The CSS patch in PR #153. The regex improvements in #146 and #155. The additional transformation layer in #158. The minimal-diff optimization throughout. This was not a generic best-practices list. It was a list of specific mistakes extracted from the session history.
 
-The task document also required the agent to deliver an audit of the prior fixes as part of the PR, not just the code, but an explanation of which assumptions were wrong and which abstractions made the problem worse. And it required regression tests proving that Preview output and email output were structurally equivalent.
+The task document also required the agent to deliver an audit of the prior fixes as part of the PR—not just the code, but an explanation of which assumptions were wrong and which abstractions made the problem worse. And it required regression tests proving that Preview output and email output were structurally equivalent.
 
 ## What finally worked
 
@@ -255,3 +322,86 @@ await queueEmail({
 ```
 
 The Cloud Function was updated to send trusted app-generated HTML when it was provided instead of reparsing markdown again. The winning fix did not become more sophisticated about formatting. It became simpler about boundaries.
+
+**The architecture after the fix:**
+
+```mermaid
+graph LR
+    A["TipTap / ProseMirror<br/>Document"] --> B["Editor DOM"]
+    A --> C["Canonical Template<br/>Renderer"]
+    C --> D["Preview HTML"]
+    C --> E["Sent Email HTML"]
+
+    style A fill:#4a90d9,stroke:#2c5f8a,color:#fff
+    style B fill:#7bc67e,stroke:#4a8a4d,color:#fff
+    style C fill:#7bc67e,stroke:#4a8a4d,color:#fff
+    style D fill:#7bc67e,stroke:#4a8a4d,color:#fff
+    style E fill:#7bc67e,stroke:#4a8a4d,color:#fff
+```
+
+One source document, one semantic rendering path, multiple consumers.
+
+## The difference was not the model
+
+**Symptom-driven vs. invariant-driven supervision:**
+
+```mermaid
+graph TD
+    S1["'This looks wrong'"] --> S2["Find nearest code path"]
+    S2 --> S3["Patch it"]
+    S3 --> S4["Same symptom reappears"]
+    S4 --> S2
+
+    I1["'Why have six fixes failed?'"] --> I2["Audit prior assumptions"]
+    I2 --> I3["Identify shared wrong assumption"]
+    I3 --> I4["Remove the wrong abstraction"]
+
+    style S1 fill:#e8b4b4,stroke:#993d3d,color:#333
+    style S2 fill:#e8b4b4,stroke:#993d3d,color:#333
+    style S3 fill:#e8b4b4,stroke:#993d3d,color:#333
+    style S4 fill:#c75c5c,stroke:#993d3d,color:#fff
+    style I1 fill:#b8ddb8,stroke:#4a8a4d,color:#333
+    style I2 fill:#b8ddb8,stroke:#4a8a4d,color:#333
+    style I3 fill:#b8ddb8,stroke:#4a8a4d,color:#333
+    style I4 fill:#7bc67e,stroke:#4a8a4d,color:#fff
+```
+
+It would be easy to read this as "Codex is better than Claude Code at architecture." I do not think that is the right conclusion.
+
+Claude Code received eighteen prompts over twenty hours. In that time, it also received nine rounds of code review feedback from an automated reviewer that correctly identified round-trip safety failures three separate times. It received three stop-hook interventions that flagged data consistency problems in the rendering pipeline. It had more information about what was wrong than the Codex agent ever did.
+
+The difference was in what the prompt asked the agent to do with that information.
+
+Every prompt I gave Claude Code described the current symptom: "bold in preview but not editor." Each time, the agent did what a competent developer would do if you walked up to their desk and said "this looks wrong"—it found the nearest code path that could explain the symptom and patched it. That is not a failure of intelligence. It is a failure of framing.
+
+The Codex task document did not describe the current symptom at all. It described a pattern of failed fixes and asked the agent to explain why they failed before proposing anything new. It stated the system invariant explicitly. It banned specific classes of patches. It required an audit as a deliverable.
+
+That is a different kind of work. It is not "fix this bug." It is "explain why this bug has survived six attempts to fix it, and address the underlying cause." Any agent—Claude, Codex, Gemini, a future model—will behave differently when the task is framed that way.
+
+## What I changed after this
+
+After this issue, I turned the lesson into repo policy. Three rules:
+
+**The two-strike rule.** If an agent has already made two failed fix attempts on the same problem, the third attempt must begin with an audit of the previous PRs. The agent has to explain what each prior fix assumed and why the assumption was wrong before it proposes a new fix. This prevents the patch-accumulation loop that produced PRs #146 through #158.
+
+**The serialization checklist.** If a bug involves serialization or deserialization—content crossing a format boundary—the code review now asks three questions:
+
+- Is the round-trip lossless?
+- Do all consumers of the format produce equivalent output?
+- Is the intermediate format even necessary?
+
+Those three questions would have caught this bug at PR #144. They are simple, but they target the exact blind spot that agents have: they will improve a bridge indefinitely without asking whether the bridge should exist.
+
+**Constraint-driven prompts for system bugs.** When a bug touches more than one layer of the system, the prompt now includes an explicit list of banned approaches derived from prior failures. Not "best practices" in the abstract—specific things this codebase has already tried that did not work. The agent needs to know what the search space does not include.
+
+**Invariants outrank backward compatibility.** This is the lesson from the design spec. A spec can describe the right architecture and still leave room for an agent to build a bridge to the old one if it also requires backward compatibility. When both are present, the spec now states which constraint wins. "The new rendering path is the canonical path. Legacy format support is a migration concern, not an architectural peer."
+
+## What AI agents actually get wrong
+
+The agent was not failing because it could not write code. Every PR compiled, passed tests, and improved something locally. The serializer got more faithful. The CSS got tighter. The module boundaries got cleaner. If you looked at any individual diff, you would approve it.
+
+The agent was failing because it did not, on its own, promote a repeated local failure into a structural question. It received the same class of bug report four times. It received code review feedback identifying round-trip safety failures three times. It received automated hook interventions flagging data consistency problems twice. At no point did it step back and say: the problem is not that the serializer is slightly wrong. The problem is that the serializer exists.
+
+The moment the work was reframed around the invariant instead of the symptom, the fix became straightforward.
+
+That is the gap teams need to close as they hand more of their codebase to agents. Not better models. Better supervision. The question is not whether your agent can write a regex. The question is whether your process tells the agent when to stop writing regexes and start questioning the architecture.

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -138,4 +138,16 @@ const jsonLd = {
       </footer>
     </article>
   </main>
+
+  <script is:inline type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+    mermaid.initialize({
+      startOnLoad: true,
+      theme: 'base',
+      themeVariables: {
+        fontFamily: 'Inter, sans-serif',
+        fontSize: '14px',
+      },
+    });
+  </script>
 </BaseLayout>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -139,8 +139,13 @@ const jsonLd = {
     </article>
   </main>
 
+  <!-- Mermaid.js for diagram rendering — pinned to exact version.
+       Degrades gracefully: raw mermaid source is readable if CDN is unavailable.
+       To upgrade: update the version here and verify diagrams render correctly.
+       To self-host: install mermaid as npm dep and bundle, or use @mermaid-js/mermaid-cli
+       for build-time SVG rendering (see issue #67). -->
   <script is:inline type="module">
-    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.esm.min.mjs';
     mermaid.initialize({
       startOnLoad: true,
       theme: 'base',

--- a/src/plugins/remark-mermaid.mjs
+++ b/src/plugins/remark-mermaid.mjs
@@ -1,15 +1,11 @@
 import { visit } from 'unist-util-visit';
 
 /**
- * Remark plugin that converts ```mermaid code fences into static HTML diagrams.
+ * Remark plugin that converts ```mermaid code fences into <pre class="mermaid">
+ * elements for client-side rendering by Mermaid.js.
  *
- * Produces the same <div class="blog-diagram ..."> structure as the legacy
- * generate-blog.js renderer. Two layout patterns are supported:
- *
- * - Fanout: a root node with out-degree > 1, rendered as root -> branch -> row of children
- * - Chain: a linear sequence of nodes with arrows, optional loop-back arrow
- *
- * No client-side Mermaid JS is loaded; the output is pure HTML styled by global.css.
+ * The mermaid code is passed through as-is — the Mermaid.js library handles
+ * parsing, layout, and SVG rendering in the browser.
  */
 export default function remarkMermaid() {
   return (tree) => {
@@ -18,20 +14,14 @@ export default function remarkMermaid() {
         return;
       }
 
-      const html = renderMermaidDiagram(node.value);
-
       parent.children[index] = {
         type: 'html',
-        value: html,
+        value: `<pre class="mermaid">${escapeHtml(node.value)}</pre>`,
       };
     });
   };
 }
 
-/**
- * Escape HTML special characters in text content.
- * Matches the legacy escapeHtml() from generate-blog.js.
- */
 function escapeHtml(value) {
   return value
     .replace(/&/g, '&amp;')
@@ -40,106 +30,3 @@ function escapeHtml(value) {
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
 }
-
-/**
- * Parse a Mermaid graph definition and render it as static HTML.
- *
- * This is a direct port of renderMermaidDiagram() from scripts/generate-blog.js
- * (lines 254-333). It handles two layout patterns:
- *
- * 1. Fanout: when any node has out-degree > 1, that node becomes the root of a
- *    fanout layout with a branch line and a row of child nodes.
- *
- * 2. Chain: a linear sequence of nodes connected by arrows, with an optional
- *    loop-back indicator when the last node points back to the first.
- */
-function renderMermaidDiagram(code) {
-  const lines = code.split('\n').map((line) => line.trim()).filter(Boolean);
-  const labels = new Map();
-  const edges = [];
-
-  for (const line of lines.slice(1)) {
-    const nodeMatches = [...line.matchAll(/([A-Za-z0-9_]+)\["([^"]+)"\]/g)];
-    for (const match of nodeMatches) {
-      labels.set(match[1], match[2]);
-    }
-
-    const normalizedLine = line.replace(/\["[^"]+"\]/g, '');
-    const nodeIds = [...normalizedLine.matchAll(/([A-Za-z0-9_]+)/g)].map((m) => m[1]);
-    const arrows = [...normalizedLine.matchAll(/-->/g)];
-    if (arrows.length > 0) {
-      // Extract node IDs between --> separators to handle chains like A --> B --> C
-      const parts = normalizedLine.split(/\s*-->\s*/).map((p) => p.trim()).filter(Boolean);
-      for (let i = 0; i < parts.length - 1; i++) {
-        const from = parts[i].match(/([A-Za-z0-9_]+)/)?.[1];
-        const to = parts[i + 1].match(/([A-Za-z0-9_]+)/)?.[1];
-        if (from && to) {
-          edges.push([from, to]);
-        }
-      }
-    }
-  }
-
-  const outDegree = new Map();
-  const inDegree = new Map();
-  const adjacency = new Map();
-
-  for (const [from, to] of edges) {
-    outDegree.set(from, (outDegree.get(from) || 0) + 1);
-    inDegree.set(to, (inDegree.get(to) || 0) + 1);
-    if (!adjacency.has(from)) {
-      adjacency.set(from, []);
-    }
-    adjacency.get(from).push(to);
-    if (!inDegree.has(from)) {
-      inDegree.set(from, inDegree.get(from) || 0);
-    }
-    if (!outDegree.has(to)) {
-      outDegree.set(to, outDegree.get(to) || 0);
-    }
-  }
-
-  if (edges.length === 0 && labels.size === 0) {
-    return '<div class="blog-diagram" aria-label="Diagram"></div>';
-  }
-
-  if (edges.length === 0 && labels.size > 0) {
-    const nodes = [...labels.entries()].map(([id, label]) =>
-      `<div class="blog-diagram-node">${escapeHtml(label)}</div>`
-    ).join('');
-    return `<div class="blog-diagram blog-diagram--chain" aria-label="Diagram">${nodes}</div>`;
-  }
-
-  const fanoutRoot = [...outDegree.entries()].find(([, count]) => count > 1);
-  if (fanoutRoot) {
-    const root = fanoutRoot[0];
-    const children = edges.filter(([from]) => from === root).map(([, to]) => to);
-    return `<div class="blog-diagram blog-diagram--fanout" aria-label="Diagram"><div class="blog-diagram-node">${escapeHtml(labels.get(root) || root)}</div><div class="blog-diagram-branch" aria-hidden="true"></div><div class="blog-diagram-fanout-row">${children.map((child) => `<div class="blog-diagram-node">${escapeHtml(labels.get(child) || child)}</div>`).join('')}</div></div>`;
-  }
-
-  const start = [...labels.keys()].find((id) => (inDegree.get(id) || 0) === 0) || edges[0][0];
-  const sequence = [];
-  const visited = new Set();
-  let current = start;
-
-  while (current && !visited.has(current)) {
-    visited.add(current);
-    sequence.push(current);
-    const next = (adjacency.get(current) || []).find((candidate) => !visited.has(candidate));
-    current = next || null;
-  }
-
-  const loopBack = edges.some(([from, to]) => from === sequence[sequence.length - 1] && to === sequence[0]);
-
-  return `<div class="blog-diagram blog-diagram--chain" aria-label="Diagram">${sequence.map((node, nodeIndex) => {
-    const nodeHtml = `<div class="blog-diagram-node">${escapeHtml(labels.get(node) || node)}</div>`;
-    if (nodeIndex === sequence.length - 1) {
-      return loopBack
-        ? `${nodeHtml}<div class="blog-diagram-loop" aria-hidden="true">\u21ba</div>`
-        : nodeHtml;
-    }
-    return `${nodeHtml}<div class="blog-diagram-arrow" aria-hidden="true">\u2193</div>`;
-  }).join('')}</div>`;
-}
-
-export { renderMermaidDiagram as _renderMermaidDiagram };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1303,38 +1303,35 @@ body.project-page {
   line-height: 1.65;
 }
 
-/* Syntax highlighting — dark code blocks */
-.blog-code-block code .hljs-keyword,
-.blog-code-block code .hljs-selector-tag,
-.blog-code-block code .hljs-built_in { color: #e8a466; }
+/* Syntax highlighting — Astro/Shiki css-variables mapped to original warm palette */
+.blog-code-block {
+  --astro-code-foreground: #f5f0e4;
+  --astro-code-background: #15120e;
+  --astro-code-token-constant: #d4a5b0;
+  --astro-code-token-string: #a3c493;
+  --astro-code-token-comment: #8a8272;
+  --astro-code-token-keyword: #e8a466;
+  --astro-code-token-parameter: #b8a9d4;
+  --astro-code-token-function: #c9b97a;
+  --astro-code-token-string-expression: #a3c493;
+  --astro-code-token-punctuation: #c4b99a;
+  --astro-code-token-link: #a3c493;
+}
 
-.blog-code-block code .hljs-string,
-.blog-code-block code .hljs-template-tag,
-.blog-code-block code .hljs-addition { color: #a3c493; }
-
-.blog-code-block code .hljs-comment,
-.blog-code-block code .hljs-quote { color: #8a8272; font-style: italic; }
-
-.blog-code-block code .hljs-number,
-.blog-code-block code .hljs-literal,
-.blog-code-block code .hljs-type { color: #d4a5b0; }
-
-.blog-code-block code .hljs-title,
-.blog-code-block code .hljs-title.function_ { color: #c9b97a; }
-
-.blog-code-block code .hljs-attr,
-.blog-code-block code .hljs-property,
-.blog-code-block code .hljs-variable { color: #b8a9d4; }
-
-.blog-code-block code .hljs-regexp,
-.blog-code-block code .hljs-symbol { color: #d4a5b0; }
-
-.blog-code-block code .hljs-meta,
-.blog-code-block code .hljs-selector-class,
-.blog-code-block code .hljs-selector-id { color: #c9b97a; }
-
-.blog-code-block code .hljs-emphasis { font-style: italic; }
-.blog-code-block code .hljs-strong { font-weight: 700; }
+/* Light code blocks — muted warm palette */
+.blog-code-block--light {
+  --astro-code-foreground: var(--ink);
+  --astro-code-background: rgba(17, 16, 13, 0.06);
+  --astro-code-token-constant: #7a5c28;
+  --astro-code-token-string: #4a7a3a;
+  --astro-code-token-comment: #6b6458;
+  --astro-code-token-keyword: #7a5c28;
+  --astro-code-token-parameter: #5a4a7a;
+  --astro-code-token-function: #6b5c28;
+  --astro-code-token-string-expression: #4a7a3a;
+  --astro-code-token-punctuation: var(--ink);
+  --astro-code-token-link: #4a7a3a;
+}
 
 /* Light code blocks — muted syntax colors */
 .blog-code-block--light code .hljs-keyword,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1333,14 +1333,6 @@ body.project-page {
   --astro-code-token-link: #4a7a3a;
 }
 
-/* Light code blocks — muted syntax colors */
-.blog-code-block--light code .hljs-keyword,
-.blog-code-block--light code .hljs-built_in { color: #7a5c28; }
-
-.blog-code-block--light code .hljs-string { color: #4a7a3a; }
-
-.blog-code-block--light code .hljs-comment,
-.blog-code-block--light code .hljs-quote { color: #8a8272; font-style: italic; }
 
 .blog-footer {
   padding: clamp(1.15rem, 2.5vw, 2rem) clamp(1.15rem, 3vw, 2.5rem);

--- a/tests/mermaid-diagrams.test.js
+++ b/tests/mermaid-diagrams.test.js
@@ -1,195 +1,53 @@
 import { describe, it, expect } from 'vitest';
-import { _renderMermaidDiagram as renderMermaidDiagram } from '../src/plugins/remark-mermaid.mjs';
 
-describe('remark-mermaid: renderMermaidDiagram', () => {
-  describe('fanout layout', () => {
-    it('renders a root node with multiple children as fanout', () => {
-      const code = [
-        'graph TD',
-        'A["Root"] --> B["Child 1"]',
-        'A --> C["Child 2"]',
-        'A --> D["Child 3"]',
-      ].join('\n');
+describe('remark-mermaid plugin', () => {
+  it('converts mermaid code fences to pre.mermaid elements', async () => {
+    const { default: remarkMermaid } = await import('../src/plugins/remark-mermaid.mjs');
 
-      const html = renderMermaidDiagram(code);
+    const tree = {
+      type: 'root',
+      children: [
+        { type: 'code', lang: 'mermaid', value: 'graph TD\nA --> B' },
+      ],
+    };
 
-      expect(html).toContain('blog-diagram--fanout');
-      expect(html).toContain('aria-label="Diagram"');
-      expect(html).toContain('>Root</div>');
-      expect(html).toContain('blog-diagram-branch');
-      expect(html).toContain('blog-diagram-fanout-row');
-      expect(html).toContain('>Child 1</div>');
-      expect(html).toContain('>Child 2</div>');
-      expect(html).toContain('>Child 3</div>');
-    });
+    remarkMermaid()(tree);
 
-    it('adds aria-hidden to branch element', () => {
-      const code = [
-        'graph TD',
-        'A["Root"] --> B["Left"]',
-        'A --> C["Right"]',
-      ].join('\n');
-
-      const html = renderMermaidDiagram(code);
-      expect(html).toContain('blog-diagram-branch" aria-hidden="true"');
-    });
-
-    it('uses node ID as fallback when no label is defined', () => {
-      const code = [
-        'graph TD',
-        'A --> B',
-        'A --> C',
-      ].join('\n');
-
-      const html = renderMermaidDiagram(code);
-      expect(html).toContain('>A</div>');
-      expect(html).toContain('>B</div>');
-      expect(html).toContain('>C</div>');
-    });
+    expect(tree.children[0].type).toBe('html');
+    expect(tree.children[0].value).toContain('class="mermaid"');
+    expect(tree.children[0].value).toContain('graph TD');
+    expect(tree.children[0].value).toContain('A --&gt; B');
   });
 
-  describe('chain layout', () => {
-    it('renders a linear sequence with arrows', () => {
-      const code = [
-        'graph TD',
-        'A["Step 1"] --> B["Step 2"]',
-        'B --> C["Step 3"]',
-      ].join('\n');
+  it('does not process non-mermaid code blocks', async () => {
+    const { default: remarkMermaid } = await import('../src/plugins/remark-mermaid.mjs');
 
-      const html = renderMermaidDiagram(code);
+    const tree = {
+      type: 'root',
+      children: [
+        { type: 'code', lang: 'javascript', value: 'const x = 1;' },
+      ],
+    };
 
-      expect(html).toContain('blog-diagram--chain');
-      expect(html).toContain('aria-label="Diagram"');
-      expect(html).toContain('>Step 1</div>');
-      expect(html).toContain('blog-diagram-arrow');
-      expect(html).toContain('>Step 2</div>');
-      expect(html).toContain('>Step 3</div>');
-    });
+    remarkMermaid()(tree);
 
-    it('adds aria-hidden to arrow elements', () => {
-      const code = [
-        'graph TD',
-        'A["First"] --> B["Second"]',
-      ].join('\n');
-
-      const html = renderMermaidDiagram(code);
-      expect(html).toContain('blog-diagram-arrow" aria-hidden="true"');
-    });
-
-    it('does not include a loop indicator when there is no loop-back', () => {
-      const code = [
-        'graph TD',
-        'A["Start"] --> B["End"]',
-      ].join('\n');
-
-      const html = renderMermaidDiagram(code);
-      expect(html).not.toContain('blog-diagram-loop');
-    });
+    expect(tree.children[0].type).toBe('code');
+    expect(tree.children[0].lang).toBe('javascript');
   });
 
-  describe('chain layout with loop-back', () => {
-    it('renders a loop indicator when last node points to first', () => {
-      const code = [
-        'graph TD',
-        'A["Plan"] --> B["Build"]',
-        'B --> C["Review"]',
-        'C --> A',
-      ].join('\n');
+  it('escapes HTML in mermaid content', async () => {
+    const { default: remarkMermaid } = await import('../src/plugins/remark-mermaid.mjs');
 
-      const html = renderMermaidDiagram(code);
+    const tree = {
+      type: 'root',
+      children: [
+        { type: 'code', lang: 'mermaid', value: 'graph TD\nA["<script>alert(1)</script>"]' },
+      ],
+    };
 
-      expect(html).toContain('blog-diagram--chain');
-      expect(html).toContain('blog-diagram-loop');
-      expect(html).toContain('\u21ba');
-    });
+    remarkMermaid()(tree);
 
-    it('adds aria-hidden to loop indicator', () => {
-      const code = [
-        'graph TD',
-        'A["Plan"] --> B["Build"]',
-        'B --> A',
-      ].join('\n');
-
-      const html = renderMermaidDiagram(code);
-      expect(html).toContain('blog-diagram-loop" aria-hidden="true"');
-    });
-  });
-
-  describe('HTML escaping', () => {
-    it('escapes HTML special characters in labels', () => {
-      const code = [
-        'graph TD',
-        'A["<script>alert(1)</script>"] --> B["Tom & Jerry"]',
-      ].join('\n');
-
-      const html = renderMermaidDiagram(code);
-      expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
-      expect(html).toContain('Tom &amp; Jerry');
-      expect(html).not.toContain('<script>');
-    });
-
-    it('escapes quotes in labels', () => {
-      const code = [
-        'graph TD',
-        'A["She said \'hello\'"] --> B["End"]',
-      ].join('\n');
-
-      const html = renderMermaidDiagram(code);
-      expect(html).toContain('She said &#39;hello&#39;');
-    });
-  });
-
-  describe('edge cases', () => {
-    it('handles empty mermaid block without crashing', () => {
-      const code = 'graph TD';
-      const html = renderMermaidDiagram(code);
-      expect(html).toContain('blog-diagram');
-      expect(html).toContain('aria-label="Diagram"');
-    });
-
-    it('handles mermaid block with only whitespace after header', () => {
-      const code = 'graph TD\n  \n  ';
-      const html = renderMermaidDiagram(code);
-      expect(html).toContain('blog-diagram');
-    });
-
-    it('handles same-line chained edges like A --> B --> C', () => {
-      const code = 'graph TD\nA["Step 1"] --> B["Step 2"] --> C["Step 3"]';
-      const html = renderMermaidDiagram(code);
-      expect(html).toContain('blog-diagram--chain');
-      expect(html).toContain('Step 1');
-      expect(html).toContain('Step 2');
-      expect(html).toContain('Step 3');
-      // Should have 3 nodes and 2 arrows
-      const nodeCount = (html.match(/blog-diagram-node/g) || []).length;
-      const arrowCount = (html.match(/blog-diagram-arrow/g) || []).length;
-      expect(nodeCount).toBe(3);
-      expect(arrowCount).toBe(2);
-    });
-
-    it('renders label-only nodes without edges', () => {
-      const code = 'graph TD\nA["Solo Node"]';
-      const html = renderMermaidDiagram(code);
-      expect(html).toContain('blog-diagram--chain');
-      expect(html).toContain('Solo Node');
-      expect(html).toContain('blog-diagram-node');
-    });
-  });
-
-  describe('non-mermaid code blocks', () => {
-    it('does not process non-mermaid code (plugin function identity)', async () => {
-      // The remark plugin only visits code nodes with lang=mermaid.
-      // This is tested at the AST level by importing the plugin function itself.
-      const { default: remarkMermaid } = await import('../src/plugins/remark-mermaid.mjs');
-
-      const jsCodeNode = { type: 'code', lang: 'javascript', value: 'const x = 1;' };
-      const tree = { type: 'root', children: [jsCodeNode] };
-
-      remarkMermaid()(tree);
-
-      // The node should remain unchanged (still type: 'code', not 'html')
-      expect(tree.children[0].type).toBe('code');
-      expect(tree.children[0].lang).toBe('javascript');
-    });
+    expect(tree.children[0].value).not.toContain('<script>');
+    expect(tree.children[0].value).toContain('&lt;script&gt;');
   });
 });


### PR DESCRIPTION
## Summary

Fixes from visual review before Phase 10 deploy:

1. **Broken link** — local file path `/Users/nathanpayne/GitHub/docs/...` replaced with GitHub URL
2. **Code colors too dark** — switched Shiki from `vitesse-dark` to `css-variables` theme, mapped `--astro-code-token-*` variables to the original warm hljs palette
3. **Updated blog content** — correct markdown source with full content including mermaid diagrams
4. **Mermaid diagrams** — replaced custom static HTML renderer with client-side Mermaid.js (CDN). Remark plugin now outputs `<pre class="mermaid">` elements, BlogPost layout loads `mermaid@11` via ESM import

Also created GitHub issues for follow-up items:
- #65: Upgrade Astro from v5 to v6.1 (P1, S)
- #66: RSS feed preview for local testing (P2, XS)
- #67: Mermaid rendering approach (tracked, resolved in this PR)

Authoring-Agent: claude

## Self-Review

**Correctness:** 5 mermaid diagrams render as SVGs matching the artifact reference. Code blocks use the warm original palette. All 4 images load locally. 64 tests pass.

**Regression risk:** Low-medium. The Mermaid.js CDN script only loads on blog post pages. The css-variables Shiki theme is more maintainable than inline-style themes.

**Style:** Clean separation — remark plugin handles fencing, CDN library handles rendering.

**Test coverage:** 64 tests pass. Mermaid tests updated for new approach (3 tests: passthrough, non-mermaid preservation, HTML escaping).

**Security/dependency hygiene:** Mermaid.js loaded from jsDelivr CDN (external dependency). No npm install needed. Script is scoped to blog post pages only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mermaid diagrams now render client-side on blog posts, with broader syntax support and safe escaping of diagram source.

* **Documentation**
  * Updated blog post with multiple new Mermaid diagrams and tightened narrative for clarity.

* **Style**
  * Updated code syntax highlighting theme and refreshed code-block styling for improved visual presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->