### PR TITLE
Add Playwright responsive test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ RIPCUT_GUIDE.md
 dist/
 .astro/
 
+# Playwright
+test-results/
+playwright-report/
+
 # Claude Code local settings
 .claude/settings.local.json
 .claude/launch.json

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "test": "astro build && vitest run"
+    "test": "astro build && vitest run",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
     "@astrojs/rss": "^4.0.0",
     "@astrojs/sitemap": "^3.0.0",
+    "@playwright/test": "^1.59.1",
     "astro": "^5.0.0",
     "jsdom": "^25.0.0",
     "unist-util-visit": "^5.1.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/responsive',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:4321',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'iPhone SE (375px)',
+      use: { viewport: { width: 375, height: 667 } },
+    },
+    {
+      name: 'iPhone 14 (393px)',
+      use: { viewport: { width: 393, height: 852 } },
+    },
+    {
+      name: 'iPad Mini (768px)',
+      use: { viewport: { width: 768, height: 1024 } },
+    },
+    {
+      name: 'Desktop 1440',
+      use: { viewport: { width: 1440, height: 900 } },
+    },
+  ],
+  webServer: {
+    command: 'npm run build && npm run preview',
+    url: 'http://localhost:4321',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30000,
+  },
+});

--- a/tests/responsive/overflow.spec.ts
+++ b/tests/responsive/overflow.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+const routes = [
+  '/',
+  '/blog/',
+  '/blog/six-prs-one-bug-agent-failure-modes/',
+  '/projects/device-source-of-truth/',
+  '/projects/friends-and-family-billing/',
+  '/projects/override/',
+  '/projects/swipe-watch/',
+];
+
+for (const route of routes) {
+  test(`no horizontal overflow on ${route}`, async ({ page }) => {
+    await page.goto(route);
+    await page.waitForLoadState('domcontentloaded');
+
+    const overflows = await page.evaluate(() => {
+      const vw = document.documentElement.clientWidth;
+
+      // Elements inside a scrollable container are allowed to exceed viewport
+      function isInsideScrollable(el: Element): boolean {
+        let parent = el.parentElement;
+        while (parent && parent !== document.documentElement) {
+          const overflow = getComputedStyle(parent).overflowX;
+          if (overflow === 'auto' || overflow === 'scroll') return true;
+          parent = parent.parentElement;
+        }
+        return false;
+      }
+
+      return Array.from(document.querySelectorAll('*'))
+        .filter((el) => {
+          // Exclude Astro dev toolbar
+          if (el.closest('astro-dev-toolbar')) return false;
+          // Exclude Mermaid SVG internals (rendered client-side, may extend)
+          if (el.closest('.mermaid') || el.closest('svg')) return false;
+          // Exclude elements inside scrollable containers (code blocks)
+          if (isInsideScrollable(el)) return false;
+          const rect = el.getBoundingClientRect();
+          return rect.right > vw + 1; // 1px tolerance for subpixel rounding
+        })
+        .map((el) => ({
+          tag: el.tagName.toLowerCase(),
+          class: el.className?.toString().slice(0, 60) || '',
+          right: Math.round(el.getBoundingClientRect().right),
+          viewportWidth: vw,
+        }));
+    });
+
+    expect(overflows, `Elements overflowing viewport on ${route}`).toEqual([]);
+  });
+}

--- a/tests/responsive/scrollbar.spec.ts
+++ b/tests/responsive/scrollbar.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test('overflowing code blocks have visible scrollbar', async ({ page }) => {
+  await page.goto('/blog/six-prs-one-bug-agent-failure-modes/');
+  await page.waitForLoadState('domcontentloaded');
+
+  const results = await page.evaluate(() => {
+    const blocks = Array.from(document.querySelectorAll('pre.blog-code-block'));
+    return blocks
+      .filter((el) => el.scrollWidth > el.clientWidth)
+      .map((el) => ({
+        overflowX: getComputedStyle(el).overflowX,
+        scrollable: el.scrollWidth > el.clientWidth,
+        // scrollbar renders if offsetHeight > clientHeight
+        scrollbarRendered: el.offsetHeight > el.clientHeight,
+      }));
+  });
+
+  for (const block of results) {
+    expect(block.overflowX).toBe('auto');
+    expect(block.scrollbarRendered).toBe(true);
+  }
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,5 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    exclude: ['tests/responsive/**', 'node_modules/**'],
   },
 });


### PR DESCRIPTION
## Summary

Add Playwright-based responsive tests that render pages in a real browser and assert no horizontal overflow at 4 viewport widths across all 7 routes.

- **28 overflow tests** — checks every element's bounding rect against viewport width at 375px (iPhone SE), 393px (iPhone 14), 768px (iPad Mini), and 1440px (desktop)
- **4 scrollbar tests** — verifies overflowing code blocks render a visible scrollbar (per @m13v feedback on #29)
- Correctly excludes children of scrollable containers (`overflow-x: auto/scroll`) and Mermaid SVG internals
- Chromium-only (avoids WebKit/Firefox install overhead; all projects use the same rendering)
- `npm run test:e2e` runs the suite; webServer config auto-builds and serves `dist/`

Authoring-Agent: claude

Closes #29

## Self-Review

**Correctness:** 32 tests pass across 4 viewports. The overflow check correctly distinguishes between page-level overflow (a bug) and content inside scrollable containers (expected behavior for code blocks).

**Regression risk:** None — this adds new tests without changing existing code. The vitest config is updated to exclude `tests/responsive/` so the two test runners don't conflict.

**Style:** Tests follow Playwright conventions. Config uses explicit viewport sizes rather than device presets (avoids needing WebKit/Firefox).

**Test coverage:** 28 overflow + 4 scrollbar = 32 new tests. All 64 existing vitest tests still pass.

**Security/dependency hygiene:** `@playwright/test` added as devDependency. Chromium browser downloaded locally (not committed).