### PR TITLE
Derive canonical URL from Astro.url instead of manual prop

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,7 +4,7 @@ import '../styles/global.css';
 interface Props {
   title: string;
   description: string;
-  canonical: string;
+  canonical?: string;
   ogDescription?: string;
   ogImage?: string;
   ogImageWidth?: string;
@@ -23,7 +23,7 @@ interface Props {
 const {
   title,
   description,
-  canonical,
+  canonical: canonicalProp,
   ogDescription,
   ogImage = 'https://nathanpayne.com/og-image.png?v=20260303a',
   ogImageWidth = '2400',
@@ -35,6 +35,7 @@ const {
   articleMeta,
 } = Astro.props;
 
+const canonical = canonicalProp || new URL(Astro.url.pathname, Astro.site).href;
 const socialDescription = ogDescription || description;
 ---
 

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -9,7 +9,6 @@ interface Props {
   tags: string[];
   image: string;
   readingTime: string;
-  slug: string;
 }
 
 const {
@@ -20,10 +19,9 @@ const {
   tags,
   image,
   readingTime,
-  slug,
 } = Astro.props;
 
-const canonical = `https://nathanpayne.com/blog/${slug}/`;
+const canonical = new URL(Astro.url.pathname, Astro.site).href;
 const fullTitle = `${title} | Nathan Payne`;
 const kicker = tags.join(' · ');
 const publishedDate = date.toLocaleDateString('en-US', {
@@ -83,7 +81,6 @@ const jsonLd = {
 <BaseLayout
   title={fullTitle}
   description={description}
-  canonical={canonical}
   ogType="article"
   ogImage={`https://nathanpayne.com${image}`}
   ogImageWidth="1200"

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -81,6 +81,7 @@ const jsonLd = {
 <BaseLayout
   title={fullTitle}
   description={description}
+  canonical={canonical}
   ogType="article"
   ogImage={`https://nathanpayne.com${image}`}
   ogImageWidth="1200"

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -10,7 +10,6 @@ interface Action {
 interface Props {
   title: string;
   description: string;
-  canonical: string;
   ogDescription?: string;
   kicker: string;
   headline: string;
@@ -28,7 +27,6 @@ interface Props {
 const {
   title,
   description,
-  canonical,
   ogDescription,
   kicker,
   headline,
@@ -47,7 +45,6 @@ const {
 <BaseLayout
   title={title}
   description={description}
-  canonical={canonical}
   ogDescription={ogDescription}
   bodyClass={`project-page ${accentColorClass}`}
   jsonLd={jsonLd}

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -27,7 +27,6 @@ const readingTime = `${minutes} min read`;
   tags={post.data.tags}
   image={post.data.image}
   readingTime={readingTime}
-  slug={post.id.replace(/\.md$/, '')}
 >
   <Content />
 </BlogPost>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -40,7 +40,6 @@ function readingTime(body: string | undefined): string {
 <BaseLayout
   title="Blog | Nathan Payne"
   description="Essays and notes from Nathan Payne on AI, systems, product, engineering, and debugging."
-  canonical="https://nathanpayne.com/blog/"
   ogImage="https://nathanpayne.com/og/six-prs-one-bug.png"
   ogImageWidth="1200"
   ogImageHeight="630"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -57,7 +57,6 @@ const homepageJsonLd = {
 <BaseLayout
   title="Nathan Payne | Product Manager for Disney+, Hulu, and ESPN"
   description="Nathan Payne is a systems-minded product leader at The Walt Disney Company, overseeing partner-platform experiences for Disney+, Hulu, and ESPN and building software across streaming, finance, and design."
-  canonical="https://nathanpayne.com/"
   jsonLd={homepageJsonLd}
 >
   <main class="stage">

--- a/src/pages/projects/device-source-of-truth/index.astro
+++ b/src/pages/projects/device-source-of-truth/index.astro
@@ -60,7 +60,6 @@ const jsonLd = {
   title="Device Source of Truth | Nathan Payne"
   description="Device Source of Truth is a React and Firebase web app by Nathan Payne that consolidates partner-device specs, DRM requirements, codec support, and operational metadata into a single source of truth."
   ogDescription="A React and Firebase web app that consolidates partner-device specs, DRM requirements, codec support, and operational metadata into a single source of truth."
-  canonical="https://nathanpayne.com/projects/device-source-of-truth/"
   kicker="Enterprise × Data"
   headline="Device Source of Truth"
   deck="A single web application for understanding partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN."

--- a/src/pages/projects/friends-and-family-billing/index.astro
+++ b/src/pages/projects/friends-and-family-billing/index.astro
@@ -60,7 +60,6 @@ const jsonLd = {
   title="Friends &amp; Family Billing | Nathan Payne"
   description="Friends &amp; Family Billing is a cloud-synced billing tool by Nathan Payne for families and friend groups that turns recurring shared costs into clear invoices, payment tracking, and shareable summaries."
   ogDescription="A cloud-synced billing tool for families and friend groups that turns recurring shared costs into clear invoices, payment tracking, and shareable summaries."
-  canonical="https://nathanpayne.com/projects/friends-and-family-billing/"
   kicker="Utility × Finance"
   headline="Friends &amp; Family Billing"
   deck="A cloud-synced billing tool that turns recurring shared costs into clear invoices, payment tracking, and shareable summaries for families and friend groups."

--- a/src/pages/projects/override/index.astro
+++ b/src/pages/projects/override/index.astro
@@ -60,7 +60,6 @@ const jsonLd = {
   title="Override | Nathan Payne"
   description="Override is a Broadway-focused financial operating system by Nathan Payne for structuring capitalization, modeling investor returns, managing ownership, and sharing live deals without spreadsheet or PDF workflows."
   ogDescription="A Broadway-focused financial operating system for structuring capitalization, modeling investor returns, managing ownership, and sharing live deals without spreadsheet or PDF workflows."
-  canonical="https://nathanpayne.com/projects/override/"
   kicker="Finance × Theater"
   headline="Override"
   deck="A Broadway-focused financial operating system for structuring capitalization, modeling investor returns, managing ownership, and sharing live deals without spreadsheet or PDF workflows."

--- a/src/pages/projects/swipe-watch/index.astro
+++ b/src/pages/projects/swipe-watch/index.astro
@@ -60,7 +60,6 @@ const jsonLd = {
   title="Swipe Watch | Nathan Payne"
   description="Swipe Watch is a vanilla JavaScript recommendation experiment by Nathan Payne that explores swipe-based streaming discovery for Disney+ and Hulu with coins, watchlists, and rapid interaction loops."
   ogDescription="A vanilla JavaScript recommendation experiment that explores swipe-based streaming discovery for Disney+ and Hulu with coins, watchlists, and rapid interaction loops."
-  canonical="https://nathanpayne.com/projects/swipe-watch/"
   kicker="Consumer × Streaming"
   headline="Swipe Watch"
   deck="A swipe-based discovery experiment for Disney+ and Hulu that turns taste signals into a faster, more active recommendation loop."


### PR DESCRIPTION
## Summary

Make `canonical` optional in `BaseLayout.astro` — when not provided, derive it from `Astro.url.pathname` + `Astro.site`. Remove explicit `canonical` props from all 10 files that passed them manually.

**Files changed (10):**
- `src/layouts/BaseLayout.astro` — canonical optional, derivation fallback
- `src/layouts/BlogPost.astro` — use `Astro.url` instead of constructing from slug, remove slug prop
- `src/layouts/ProjectLayout.astro` — remove canonical from props and passthrough
- `src/pages/index.astro` — remove canonical prop
- `src/pages/blog/index.astro` — remove canonical prop
- `src/pages/blog/[slug].astro` — remove slug prop
- `src/pages/projects/*/index.astro` (×4) — remove canonical prop

**Key behaviors preserved:**
- All 7 routes produce identical canonical URLs to before
- JSON-LD in BlogPost still uses the canonical for `@id` and `url` fields
- The prop still works as an override for edge cases (e.g., paginated pages)

Authoring-Agent: claude

Closes #50

## Self-Review

**Correctness:** Verified all 7 canonical URLs in built output match the previous manual values. JSON-LD URLs are correct. 96 tests pass (64 unit + 32 Playwright).

**Regression risk:** Medium — this touches 10 files and changes how canonical is determined for every page. The derivation relies on `Astro.site` being set in `astro.config.mjs` (it is: `https://nathanpayne.com`). If `Astro.site` were ever removed, canonicals would break.

**Style:** Net deletion of 12 lines. Eliminates a class of copy-paste bugs where canonical URL doesn't match the actual route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Canonical URL handling now derives the canonical link from each page’s path and site settings automatically, removing the need to specify canonical values on pages and layouts.
  * Blog post routing no longer requires a manual slug prop; structured data and meta URLs are generated from the page URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->