### PR TITLE
Upgrade Astro from v5 to v6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@astrojs/rss": "^4.0.0",
     "@astrojs/sitemap": "^3.0.0",
     "@playwright/test": "^1.59.1",
-    "astro": "^5.0.0",
+    "astro": "^6.1.0",
     "jsdom": "^25.0.0",
     "unist-util-visit": "^5.1.0",
     "vitest": "^3.0.0"

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,7 +1,8 @@
 import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
 
 const blog = defineCollection({
-  type: 'content',
+  loader: glob({ pattern: '**/*.md', base: './src/content/blog' }),
   schema: z.object({
     title: z.string(),
     description: z.string(),

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,17 +1,17 @@
 ---
-import { getCollection } from 'astro:content';
+import { getCollection, render } from 'astro:content';
 import BlogPost from '../../layouts/BlogPost.astro';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog', ({ data }) => !data.draft);
   return posts.map((post) => ({
-    params: { slug: post.id.replace(/\.md$/, '') },
+    params: { slug: post.id },
     props: { post },
   }));
 }
 
 const { post } = Astro.props;
-const { Content } = await post.render();
+const { Content } = await render(post);
 
 // Calculate reading time (avg 225 words per minute)
 const words = post.body?.split(/\s+/).length ?? 0;

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -71,7 +71,7 @@ function readingTime(body: string | undefined): string {
               {posts.map((post) => (
                 <article class="blog-card">
                   <p class="blog-card-meta">{formatDate(post.data.date)} · {readingTime(post.body)}</p>
-                  <h3><a class="blog-card-link" href={`/blog/${post.id.replace(/\.md$/, '')}/`}>{post.data.title}</a></h3>
+                  <h3><a class="blog-card-link" href={`/blog/${post.id}/`}>{post.data.title}</a></h3>
                   <p class="blog-card-desc">{post.data.description}</p>
                   <div class="blog-tag-row">
                     {post.data.tags.map((tag) => (

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -14,7 +14,7 @@ export async function GET(context: APIContext) {
       title: post.data.title,
       pubDate: post.data.date,
       description: post.data.description,
-      link: `/blog/${post.id.replace(/\.md$/, '')}/`,
+      link: `/blog/${post.id}/`,
     })),
   });
 }

--- a/tests/content-schema.test.js
+++ b/tests/content-schema.test.js
@@ -30,7 +30,7 @@ function parseFrontmatter(content) {
 describe('Content Schema', () => {
   it('content.config.ts exists and defines a blog collection', () => {
     expect(configSource).toContain('defineCollection');
-    expect(configSource).toContain("type: 'content'");
+    expect(configSource).toContain('glob(');
     expect(configSource).toMatch(/const\s+blog\s*=/);
     expect(configSource).toContain('collections');
   });


### PR DESCRIPTION
## Summary

Upgrade Astro from 5.18.1 to 6.1.5. Three breaking changes required code updates:

1. **Content Collections glob loader** — v6 removed `type: 'content'` shorthand. Replaced with explicit `glob({ pattern: '**/*.md', base: './src/content/blog' })` from `astro/loaders`.
2. **`render()` function** — `post.render()` method removed. Replaced with `render(post)` imported from `astro:content`.
3. **`post.id` is now a slug** — v6 returns the slug directly (no `.md` extension). Removed all `.replace(/\.md$/, '')` calls from blog index, blog route, and RSS feed.

### Playwright overflow test results (no visual regressions)

All 32 Playwright tests pass across 4 viewports:
- **iPhone SE (375px):** 7 routes + scrollbar — all pass, no overflow
- **iPhone 14 (393px):** 7 routes + scrollbar — all pass, no overflow
- **iPad Mini (768px):** 7 routes + scrollbar — all pass, no overflow
- **Desktop 1440:** 7 routes + scrollbar — all pass, no overflow

The Astro v6 upgrade produces identical HTML output structure. No layout shifts, no missing elements, no overflow regressions at any breakpoint.

Authoring-Agent: claude

Closes #65

## Self-Review

**Correctness:** 7 pages build, all routes generate correct HTML. Content collection loads and validates. Blog post renders with all content. 96 tests pass (64 unit + 32 Playwright).

**Regression risk:** Medium — major version upgrade touching the content pipeline. All three breaking changes are addressed. The glob loader, render function, and slug ID changes are well-documented in the [Astro v6 migration guide](https://docs.astro.build/en/guides/upgrade-to/v6/).

**Style:** Net +1 line (added glob import, removed `.replace()` calls). Minimal diff.

**Test coverage:** Content-schema test updated for v6 API. All Playwright overflow tests pass — no visual regressions.

**Security/dependency hygiene:** Astro 6.1.5 is current stable. No new dependencies beyond the Astro version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Astro framework from version 5.0.0 to 6.1.0
  * Updated blog content loading configuration and URL routing

* **Tests**
  * Updated content configuration validation tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->