### PR TITLE
Blog post template: Mondrian composition with margins layout

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -11,6 +11,19 @@ const blog = defineCollection({
     tags: z.array(z.string()),
     image: z.string(),
     draft: z.boolean().default(false),
+
+    // Sidebar content — optional, defaults to empty arrays.
+    // Posts without these fields render the standard layout.
+    pullquotes: z.array(z.object({
+      text: z.string(),
+      label: z.string(),
+      accent: z.enum(['red', 'yellow', 'blue']),
+    })).optional().default([]),
+    sidebar: z.array(z.object({
+      type: z.enum(['mermaid', 'image']),
+      content: z.string(),
+      caption: z.string().optional(),
+    })).optional().default([]),
   }),
 });
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -16,11 +16,11 @@ const blog = defineCollection({
     // Posts without these fields render the standard layout.
     pullquotes: z.array(z.object({
       text: z.string(),
-      label: z.string(),
+      label: z.string().optional(),
       accent: z.enum(['red', 'yellow', 'blue']),
     })).optional().default([]),
     sidebar: z.array(z.object({
-      type: z.enum(['mermaid', 'image']),
+      type: z.enum(['mermaid', 'image', 'text']),
       content: z.string(),
       caption: z.string().optional(),
     })).optional().default([]),

--- a/src/content/blog/six-prs-one-bug-agent-failure-modes.md
+++ b/src/content/blog/six-prs-one-bug-agent-failure-modes.md
@@ -1,10 +1,41 @@
 ---
 title: "Six PRs, One Bug: What AI Agents Actually Get Wrong"
-description: "A billing email bug took six AI-authored PRs to diagnose—not because the agent couldn't write code, but because it never promoted a repeated local failure into a structural question. The full session log shows exactly how it happened."
+description: "A billing email bug took six AI-authored PRs to diagnose—not because the agent couldn't write code, but because it never promoted a repeated local failure into a structural question."
 author: "Nathan Payne"
 date: 2026-04-04
 tags: ["AI", "Engineering", "Product", "Systems", "Debugging"]
 image: "/og/six-prs-one-bug.png"
+pullquotes:
+  - text: "Agents are very good at making local progress inside the wrong model."
+    label: "Key insight"
+    accent: blue
+  - text: "When a target is concrete, the work becomes a parity problem, not a taste problem."
+    label: "On debugging strategy"
+    accent: red
+  - text: "The problem is not that the serializer is slightly wrong. The problem is that the serializer exists."
+    label: "The structural question"
+    accent: blue
+  - text: "The question is not whether your agent can write a regex. The question is whether your process tells the agent when to stop writing regexes and start questioning the architecture."
+    label: "Closing argument"
+    accent: red
+sidebar:
+  - type: mermaid
+    content: |
+      graph TD
+          PR144["#144: Preserved<br/>markdown bridge"] --> PR146["#146: Improved<br/>regex"]
+          PR146 --> PR153["#153: CSS patch +<br/>serialization"]
+          PR153 --> PR154["#154: Editor<br/>lifecycle fix"]
+          PR154 --> PR155["#155: Legacy<br/>migration fix"]
+          PR155 --> PR158["#158: Cleaner<br/>bridge module"]
+          PR158 -.->|"Reframed"| PR161["#161: Removed<br/>the bridge"]
+          style PR144 fill:#e8b4b4,stroke:#993d3d,color:#333
+          style PR146 fill:#e8b4b4,stroke:#993d3d,color:#333
+          style PR153 fill:#e8b4b4,stroke:#993d3d,color:#333
+          style PR154 fill:#e8b4b4,stroke:#993d3d,color:#333
+          style PR155 fill:#e8b4b4,stroke:#993d3d,color:#333
+          style PR158 fill:#e8b4b4,stroke:#993d3d,color:#333
+          style PR161 fill:#7bc67e,stroke:#4a8a4d,color:#fff
+    caption: "The six failed PRs and the one that worked"
 ---
 
 On April 4, 2026, I opened [issue #159](https://github.com/nathanjohnpayne/friends-and-family-billing/issues/159) in my Friends & Family Billing app. The bug looked small enough to be annoying, not interesting: the invoice template editor showed one thing, Preview showed another, and the email that actually went to customers showed a third.

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -1,4 +1,24 @@
 ---
+/**
+ * BlogPost.astro — Mondrian "Composition with Margins" layout
+ *
+ * Renders a blog post inside a 3-column Mondrian CSS Grid:
+ *   - Left margin:  narrow accent blocks (red, yellow, blue) — pure decoration
+ *   - Center:       main content column (<slot /> — unchanged Markdown flow)
+ *   - Right sidebar: sticky ToC, pullquotes, sidebar items (mermaid, images)
+ *
+ * At ≤920px the grid collapses to a single column:
+ *   - Margin and sidebar hidden
+ *   - Content fills full width inside a var(--line) frame
+ *   - Matches homepage responsive collapse behavior
+ *
+ * Sidebar content is driven by frontmatter:
+ *   - ToC: extracted from Astro's built-in render() headings (no plugin needed)
+ *   - Pullquotes: frontmatter `pullquotes` array with text, label, accent color
+ *   - Sidebar items: frontmatter `sidebar` array (mermaid diagrams, images)
+ *
+ * @see Issue #74 — Blog post template: Mondrian composition with margins layout
+ */
 import BaseLayout from './BaseLayout.astro';
 
 interface Props {
@@ -9,6 +29,9 @@ interface Props {
   tags: string[];
   image: string;
   readingTime: string;
+  headings: { depth: number; slug: string; text: string }[];
+  pullquotes: { text: string; label: string; accent: string }[];
+  sidebar: { type: string; content: string; caption?: string }[];
 }
 
 const {
@@ -19,6 +42,9 @@ const {
   tags,
   image,
   readingTime,
+  headings,
+  pullquotes,
+  sidebar,
 } = Astro.props;
 
 const canonical = new URL(Astro.url.pathname, Astro.site).href;
@@ -31,6 +57,23 @@ const publishedDate = date.toLocaleDateString('en-US', {
   timeZone: 'UTC',
 });
 const isoDate = date.toISOString();
+
+// Filter headings for ToC — only h2-level entries
+const tocHeadings = headings.filter((h) => h.depth === 2);
+
+// Determine if sidebar has any content to render
+const hasSidebar = tocHeadings.length > 0 || pullquotes.length > 0 || sidebar.length > 0;
+
+// Escape HTML for mermaid content — matches remark-mermaid.mjs pattern.
+// Mermaid reads textContent which auto-unescapes entities.
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
 
 const jsonLd = {
   "@context": "https://schema.org",
@@ -92,56 +135,118 @@ const jsonLd = {
   articleMeta={{ published: isoDate, author, tags }}
 >
   <main class="project-shell">
-    <article class="project-detail blog-detail">
-      <header class="project-hero">
+    {/* ── Mondrian Canvas Grid ──────────────────────────────────
+         3-column composition: accent margin | content | sidebar
+         Grid lines are the --ink background showing through gaps.
+         ──────────────────────────────────────────────────────── */}
+    <article class="blog-canvas">
+
+      {/* ── Left margin: per-row Mondrian accent blocks ── */}
+      <div class="blog-margin blog-margin--header" aria-hidden="true"></div>
+      <div class="blog-margin blog-margin--body" aria-hidden="true"></div>
+      <div class="blog-margin blog-margin--footer" aria-hidden="true"></div>
+
+      {/* ── Header ── */}
+      <header class="blog-canvas-header">
         <nav class="project-breadcrumbs" aria-label="Breadcrumb">
           <a href="/">Nathan Payne</a>
           <span>/</span>
           <a href="/blog/">Blog</a>
           <span>/</span>
-          <span>{title}</span>
+          <span>Article</span>
         </nav>
-        <p class="project-kicker">{kicker}</p>
         <h1>{title}</h1>
         <p class="project-deck">{description}</p>
-        <div class="project-actions">
-          <a class="project-action" href="/blog/">Back to Blog</a>
-          <a class="project-action" href="/">Back to Homepage</a>
-        </div>
       </header>
 
-      <div class="project-layout blog-layout">
-        <div class="blog-meta-bar">
-          <dl>
-            <div><dt>Published</dt><dd>{publishedDate}</dd></div>
-            <div><dt>Author</dt><dd>{author}</dd></div>
-            <div><dt>Reading time</dt><dd>{readingTime}</dd></div>
-            <div><dt>Tags</dt><dd>{kicker}</dd></div>
-          </dl>
-        </div>
-        <div class="project-copy">
-          <article class="project-section blog-prose" aria-labelledby="post-body">
-            <h2 id="post-body" class="blog-prose-title">Essay</h2>
-            <slot />
-          </article>
-        </div>
+      {/* ── Sidebar: metadata panel ── */}
+      <div class="blog-sidebar-meta">
+        <dl>
+          <div><dt>Published</dt><dd>{publishedDate}</dd></div>
+          <div><dt>Author</dt><dd>{author}</dd></div>
+          <div><dt>Reading time</dt><dd>{readingTime}</dd></div>
+          <div>
+            <dt>Topics</dt>
+            <dd class="blog-sidebar-topics">
+              {tags.map((tag) => (
+                <span class="blog-sidebar-topic">{tag}</span>
+              ))}
+            </dd>
+          </div>
+        </dl>
       </div>
 
-      <footer class="blog-footer">
-        <p class="blog-footer-attribution">{author} · San Francisco</p>
-        <nav class="blog-footer-nav">
-          <a class="project-action" href="/blog/">&larr; Back to Blog</a>
-          <a class="project-action" href="/">Back to Homepage &rarr;</a>
-        </nav>
+      {/* ── Main content column ── */}
+      <div class="blog-content">
+        <article class="blog-prose">
+          <slot />
+        </article>
+      </div>
+
+      {/* ── Right sidebar ──────────────────────────────────────
+           The <aside> stretches the full grid cell height so its
+           white background covers the entire row. The inner div
+           handles sticky scrolling independently.
+           ──────────────────────────────────────────────────── */}
+      {hasSidebar && (
+        <aside class="blog-sidebar" aria-label="Article sidebar">
+          <div class="blog-sidebar-inner">
+
+            {/* Table of Contents — extracted from Astro's built-in headings */}
+            {tocHeadings.length > 0 && (
+              <nav class="blog-sidebar-section blog-sidebar-toc" aria-label="Table of contents">
+                <h2 class="blog-sidebar-heading">In this article</h2>
+                <ol class="blog-sidebar-toc-list">
+                  {tocHeadings.map((h) => (
+                    <li><a href={`#${h.slug}`}>{h.text}</a></li>
+                  ))}
+                </ol>
+              </nav>
+            )}
+
+            {/* Pullquotes — bordered cards with accent left border */}
+            {pullquotes.map((pq) => (
+              <blockquote class={`blog-sidebar-pullquote blog-sidebar-pullquote--${pq.accent}`}>
+                <p>&ldquo;{pq.text}&rdquo;</p>
+                <cite>{pq.label}</cite>
+              </blockquote>
+            ))}
+
+            {/* Sidebar items — mermaid diagrams, images from frontmatter */}
+            {sidebar.map((item) => (
+              <div class="blog-sidebar-item">
+                {item.type === 'mermaid' && (
+                  <pre class="mermaid" set:html={escapeHtml(item.content)} />
+                )}
+                {item.type === 'image' && (
+                  <img src={item.content} alt={item.caption || ''} loading="lazy" />
+                )}
+                {item.caption && (
+                  <p class="blog-sidebar-caption">{item.caption}</p>
+                )}
+              </div>
+            ))}
+
+          </div>
+        </aside>
+      )}
+
+      {/* ── Footer ── */}
+      <footer class="blog-canvas-footer">
+        <div class="blog-footer">
+          <p class="blog-footer-attribution">{author} · San Francisco</p>
+          <nav class="blog-footer-nav">
+            <a class="project-action" href="/blog/">&larr; Back to Blog</a>
+            <a class="project-action" href="/">Back to Homepage &rarr;</a>
+          </nav>
+        </div>
       </footer>
     </article>
   </main>
 
-  <!-- Mermaid.js for diagram rendering — pinned to exact version.
-       Degrades gracefully: raw mermaid source is readable if CDN is unavailable.
-       To upgrade: update the version here and verify diagrams render correctly.
-       To self-host: install mermaid as npm dep and bundle, or use @mermaid-js/mermaid-cli
-       for build-time SVG rendering (see issue #67). -->
+  {/* Mermaid.js for diagram rendering — handles both in-content diagrams
+      (from remark-mermaid.mjs) and sidebar diagrams (from frontmatter).
+      startOnLoad: true finds ALL <pre class="mermaid"> elements on the page. */}
   <script is:inline type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.esm.min.mjs';
     mermaid.initialize({

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -208,7 +208,7 @@ const jsonLd = {
             {pullquotes.map((pq) => (
               <blockquote class={`blog-sidebar-pullquote blog-sidebar-pullquote--${pq.accent}`}>
                 <p>&ldquo;{pq.text}&rdquo;</p>
-                <cite>{pq.label}</cite>
+                {pq.label && <cite>{pq.label}</cite>}
               </blockquote>
             ))}
 
@@ -220,6 +220,9 @@ const jsonLd = {
                 )}
                 {item.type === 'image' && (
                   <img src={item.content} alt={item.caption || ''} loading="lazy" />
+                )}
+                {item.type === 'text' && (
+                  <p class="blog-sidebar-text">{item.content}</p>
                 )}
                 {item.caption && (
                   <p class="blog-sidebar-caption">{item.caption}</p>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -11,7 +11,10 @@ export async function getStaticPaths() {
 }
 
 const { post } = Astro.props;
-const { Content } = await render(post);
+
+// Astro's render() provides headings built-in — no custom plugin needed.
+// headings: { depth: number; slug: string; text: string }[]
+const { Content, headings } = await render(post);
 
 // Calculate reading time (avg 225 words per minute)
 const words = post.body?.split(/\s+/).length ?? 0;
@@ -27,6 +30,9 @@ const readingTime = `${minutes} min read`;
   tags={post.data.tags}
   image={post.data.image}
   readingTime={readingTime}
+  headings={headings}
+  pullquotes={post.data.pullquotes}
+  sidebar={post.data.sidebar}
 >
   <Content />
 </BlogPost>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1000,6 +1000,314 @@ body.project-page {
   color: rgba(17, 16, 13, 0.62);
 }
 
+/* ── Blog Post: Mondrian "Composition with Margins" Canvas ────
+   Three-column grid: accent margin | content | sticky sidebar.
+   Grid lines created by --ink background showing through gaps.
+   Collapses to single column at ≤920px.
+
+   Structure:
+     blog-canvas (grid container)
+     ├── blog-margin         (col 2, row 2)    — accent decoration
+     ├── blog-canvas-header  (col 4/-2, row 2) — breadcrumb, h1, deck
+     ├── blog-sidebar-meta   (col 6, row 2)    — date, author, tags
+     ├── blog-content        (col 4, row 4)    — meta-bar + prose
+     ├── blog-sidebar        (col 6, row 4)    — sticky: ToC, pullquotes
+     └── blog-canvas-footer  (col 2/-2, row 6) — attribution, nav
+
+   @see Issue #74
+   ────────────────────────────────────────────────────────────── */
+
+.blog-canvas {
+  display: grid;
+  grid-template-columns:
+    var(--line)
+    minmax(2.5rem, 0.4fr)    /* left margin — accent blocks */
+    var(--line)
+    minmax(20rem, 3fr)        /* main content */
+    var(--line)
+    minmax(10rem, 1.3fr)      /* right sidebar */
+    var(--line);
+  grid-template-rows:
+    var(--line) auto           /* header row */
+    var(--line) 1fr            /* body row (content + sidebar) */
+    var(--line) auto           /* footer row */
+    var(--line);
+  background: var(--ink);
+  width: min(100%, 72rem);
+  margin: 0 auto;
+  border: 1px solid #1a1814;
+  overflow: hidden;
+}
+
+/* ── Left margin: per-row Mondrian accent blocks ── */
+.blog-margin {
+  grid-column: 2;
+}
+
+.blog-margin--header {
+  grid-row: 2;
+  background: var(--red);
+}
+
+.blog-margin--body {
+  grid-row: 4;
+  /* Gradient stripe: yellow → white → blue (varies by section) */
+  background: linear-gradient(
+    to bottom,
+    var(--yellow) 0%,
+    var(--yellow) 25%,
+    var(--paper) 25%,
+    var(--paper) 60%,
+    var(--blue) 60%,
+    var(--blue) 100%
+  );
+}
+
+.blog-margin--footer {
+  grid-row: 6;
+  background: rgba(244, 239, 229, 0.96);
+}
+
+/* ── Header ── */
+.blog-canvas-header {
+  grid-column: 4;
+  grid-row: 2;
+  background: var(--paper);
+  padding: clamp(1.15rem, 3vw, 2.5rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+/* Header typography — explicit rules since blog-canvas-header
+   is outside the .project-hero scope that normally provides these. */
+.blog-canvas-header .project-breadcrumbs {
+  font-weight: 500;
+  color: rgba(17, 16, 13, 0.42);
+  margin-bottom: 1.5rem;
+}
+
+.blog-canvas-header .project-breadcrumbs a {
+  color: rgba(17, 16, 13, 0.42);
+}
+
+.blog-canvas-header h1 {
+  font-family: "Cormorant Garamond", Garamond, serif;
+  font-weight: 600;
+  font-size: clamp(2rem, 3.4vw, 3.4rem);
+  line-height: 1.04;
+  letter-spacing: -0.012em;
+  margin-bottom: 0.8rem;
+}
+
+.blog-canvas-header .project-deck {
+  font-family: "Inter", system-ui, sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  font-size: clamp(0.85rem, 1vw, 1rem);
+  line-height: 1.6;
+  color: rgba(17, 16, 13, 0.62);
+  max-width: 54ch;
+}
+
+/* ── Sidebar metadata panel (top-right) ── */
+.blog-sidebar-meta {
+  grid-column: 6;
+  grid-row: 2;
+  background: rgba(244, 239, 229, 0.96);
+  padding: clamp(0.85rem, 2vw, 1.5rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+/* Topic pills in metadata panel */
+.blog-sidebar-topics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.blog-sidebar-topic {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.18rem 0.45rem;
+  background: rgba(17, 16, 13, 0.08);
+  border-radius: 2px;
+  font-family: "Inter", system-ui, sans-serif;
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(17, 16, 13, 0.62);
+}
+
+.blog-sidebar-meta dl {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  margin: 0;
+}
+
+.blog-sidebar-meta dt {
+  margin-bottom: 0.12rem;
+  font-size: clamp(0.58rem, 0.72vw, 0.68rem);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(17, 16, 13, 0.48);
+}
+
+.blog-sidebar-meta dd {
+  font-family: "Cormorant Garamond", Garamond, serif;
+  font-weight: 500;
+  font-size: clamp(0.88rem, 0.92vw, 0.98rem);
+}
+
+/* ── Main content column ── */
+.blog-content {
+  grid-column: 4;
+  grid-row: 4;
+  background: var(--paper);
+  padding: clamp(1.15rem, 3vw, 2.5rem);
+  align-self: stretch;
+}
+
+/* ── Right sidebar ──
+   The <aside> stretches the full grid cell height (align-self: stretch
+   by default) so its white background covers the entire row.
+   The inner div handles sticky scrolling independently. */
+.blog-sidebar {
+  grid-column: 6;
+  grid-row: 4;
+  background: var(--paper);
+  padding: 0;
+}
+
+.blog-sidebar-inner {
+  position: sticky;
+  top: 0;
+  max-height: 100vh;
+  overflow-y: auto;
+  padding: clamp(0.85rem, 2vw, 1.5rem);
+}
+
+/* Sidebar section dividers */
+.blog-sidebar-section {
+  padding-bottom: 1rem;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--rule);
+}
+
+.blog-sidebar-section:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+}
+
+/* Sidebar heading (e.g., "In this article") */
+.blog-sidebar-heading {
+  font-size: clamp(0.58rem, 0.72vw, 0.68rem);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(17, 16, 13, 0.48);
+  margin-bottom: 0.55rem;
+  font-family: "Inter", system-ui, sans-serif;
+  font-weight: 600;
+}
+
+/* Table of Contents */
+.blog-sidebar-toc-list {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.blog-sidebar-toc-list li {
+  font-size: clamp(0.78rem, 0.86vw, 0.88rem);
+  line-height: 1.35;
+  padding: 0.25em 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.blog-sidebar-toc-list li:last-child {
+  border-bottom: none;
+}
+
+.blog-sidebar-toc-list a {
+  color: rgba(17, 16, 13, 0.62);
+  text-decoration: none;
+  transition: color var(--motion-fast) var(--ease-standard);
+}
+
+.blog-sidebar-toc-list a:hover {
+  color: var(--project-accent);
+}
+
+/* Pullquotes — bordered cards with accent left border */
+.blog-sidebar-pullquote {
+  margin: 1rem 0;
+  padding: 0.85rem 1rem;
+  border-left: 3px solid var(--project-accent);
+  background: rgba(255, 255, 255, 0.52);
+}
+
+.blog-sidebar-pullquote--red    { border-left-color: var(--red); }
+.blog-sidebar-pullquote--yellow { border-left-color: var(--yellow); }
+.blog-sidebar-pullquote--blue   { border-left-color: var(--blue); }
+
+.blog-sidebar-pullquote p {
+  font-family: "Cormorant Garamond", Garamond, serif;
+  font-size: clamp(0.92rem, 0.98vw, 1.04rem);
+  line-height: 1.38;
+  font-style: italic;
+  margin: 0;
+}
+
+.blog-sidebar-pullquote cite {
+  display: block;
+  margin-top: 0.4rem;
+  font-size: clamp(0.58rem, 0.72vw, 0.68rem);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-style: normal;
+  color: rgba(17, 16, 13, 0.48);
+}
+
+/* Sidebar items: mermaid diagrams, images */
+.blog-sidebar-item {
+  margin: 1rem 0;
+  padding: 0.65rem;
+  border: 1px solid var(--rule);
+  background: rgba(255, 255, 255, 0.62);
+  border-radius: 4px;
+  overflow-x: auto;
+}
+
+.blog-sidebar-item .mermaid {
+  font-size: 0.65rem;
+}
+
+.blog-sidebar-item img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.blog-sidebar-caption {
+  margin-top: 0.4rem;
+  font-size: clamp(0.68rem, 0.78vw, 0.76rem);
+  color: rgba(17, 16, 13, 0.55);
+  line-height: 1.4;
+}
+
+/* ── Footer ── */
+.blog-canvas-footer {
+  grid-column: 2 / -2;
+  grid-row: 6;
+  background: rgba(244, 239, 229, 0.96);
+}
+
+/* Legacy single-column fallback (kept for backward compatibility) */
 .blog-layout {
   --blog-content-width: min(100%, 60rem);
   grid-template-columns: minmax(0, 1fr);
@@ -1163,14 +1471,20 @@ body.project-page {
 }
 
 .blog-prose > h2:not(.blog-prose-title) {
+  font-family: "Cormorant Garamond", Garamond, serif;
+  font-weight: 600;
+  font-size: clamp(1.3rem, 1.2rem + 0.4vw, 1.72rem);
+  line-height: 1.15;
   margin-top: 2.5rem;
   padding-top: 1.8rem;
   border-top: 1px solid var(--rule);
 }
 
 .blog-prose > h3 {
-  margin-top: 1.2rem;
+  margin-top: 1.8rem;
+  margin-bottom: 0.75rem;
   font-family: "Cormorant Garamond", Garamond, serif;
+  font-weight: 600;
   font-size: clamp(1.08rem, 1.45vw, 1.36rem);
   line-height: 1.1;
 }
@@ -1183,7 +1497,7 @@ body.project-page {
 }
 
 .blog-prose > p + p {
-  margin-top: 0.8rem;
+  margin-top: 1.4em;
 }
 
 .blog-prose > ul,
@@ -1198,7 +1512,10 @@ body.project-page {
 
 .blog-prose code {
   font-family: "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
-  font-size: 0.94em;
+  font-size: 0.88em;
+  background: rgba(17, 16, 13, 0.07);
+  padding: 0.15em 0.35em;
+  border-radius: 3px;
 }
 
 .blog-prose blockquote {
@@ -1652,6 +1969,49 @@ a:focus-visible {
 
   .blog-diagram-fanout-row {
     grid-template-columns: 1fr;
+  }
+
+  /* ── Blog Post canvas: collapse to single column ───────── */
+  .blog-canvas {
+    grid-template-columns: var(--line) 1fr var(--line);
+    grid-template-rows:
+      var(--line) auto       /* sidebar-meta (moves to top) */
+      var(--line) auto       /* header */
+      var(--line) auto       /* content */
+      var(--line) auto       /* footer */
+      var(--line);
+  }
+
+  .blog-margin { display: none; }
+
+  .blog-sidebar-meta {
+    grid-column: 2;
+    grid-row: 2;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: 0.8rem 1.5rem;
+    background: var(--project-accent);
+  }
+
+  .blog-sidebar-meta dt { color: rgba(255, 255, 255, 0.55); }
+  .blog-sidebar-meta dd { color: rgba(255, 255, 255, 0.95); }
+
+  .blog-canvas-header {
+    grid-column: 2;
+    grid-row: 4;
+  }
+
+  .blog-content {
+    grid-column: 2;
+    grid-row: 6;
+  }
+
+  .blog-sidebar { display: none; }
+
+  .blog-canvas-footer {
+    grid-column: 2;
+    grid-row: 8;
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1072,6 +1072,7 @@ body.project-page {
 .blog-canvas-header {
   grid-column: 4;
   grid-row: 2;
+  min-width: 0;
   background: var(--paper);
   padding: clamp(1.15rem, 3vw, 2.5rem);
   display: flex;
@@ -1114,6 +1115,7 @@ body.project-page {
 .blog-sidebar-meta {
   grid-column: 6;
   grid-row: 2;
+  min-width: 0;
   background: rgba(244, 239, 229, 0.96);
   padding: clamp(0.85rem, 2vw, 1.5rem);
   display: flex;
@@ -1167,6 +1169,7 @@ body.project-page {
 .blog-content {
   grid-column: 4;
   grid-row: 4;
+  min-width: 0;
   background: var(--paper);
   padding: clamp(1.15rem, 3vw, 2.5rem);
   align-self: stretch;
@@ -1179,6 +1182,7 @@ body.project-page {
 .blog-sidebar {
   grid-column: 6;
   grid-row: 4;
+  min-width: 0;
   background: var(--paper);
   padding: 0;
 }
@@ -1300,10 +1304,18 @@ body.project-page {
   line-height: 1.4;
 }
 
+.blog-sidebar-text {
+  margin: 0;
+  font-size: clamp(0.78rem, 0.85vw, 0.88rem);
+  line-height: 1.5;
+  color: rgba(17, 16, 13, 0.72);
+}
+
 /* ── Footer ── */
 .blog-canvas-footer {
   grid-column: 2 / -2;
   grid-row: 6;
+  min-width: 0;
   background: rgba(244, 239, 229, 0.96);
 }
 
@@ -1987,11 +1999,18 @@ a:focus-visible {
   .blog-sidebar-meta {
     grid-column: 2;
     grid-row: 2;
+    min-width: 0;
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: flex-start;
     gap: 0.8rem 1.5rem;
     background: var(--project-accent);
+  }
+
+  .blog-sidebar-meta dl {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.4rem 1.5rem;
   }
 
   .blog-sidebar-meta dt { color: rgba(255, 255, 255, 0.55); }
@@ -2000,11 +2019,13 @@ a:focus-visible {
   .blog-canvas-header {
     grid-column: 2;
     grid-row: 4;
+    min-width: 0;
   }
 
   .blog-content {
     grid-column: 2;
     grid-row: 6;
+    min-width: 0;
   }
 
   .blog-sidebar { display: none; }
@@ -2012,6 +2033,7 @@ a:focus-visible {
   .blog-canvas-footer {
     grid-column: 2;
     grid-row: 8;
+    min-width: 0;
   }
 }
 


### PR DESCRIPTION
## Summary

- Replace single-column blog post layout with a 3-column Mondrian grid canvas: left accent margin, main content, sticky right sidebar
- Add optional `pullquotes` and `sidebar` frontmatter fields to content schema (backward-compatible — existing posts without them render unchanged)
- Sidebar renders ToC (from Astro's built-in headings), pullquotes with accent borders, and mermaid diagrams from frontmatter
- Sidebar wrapper div separates background fill (stretches full grid cell) from sticky scroll behavior (viewport-height inner div)
- Responsive collapse at ≤920px: single column, margin/sidebar hidden, metadata becomes red accent bar
- Typography: Cormorant Garamond h1/h2/h3, Inter deck/body, proper fluid sizing, inline code styling

Closes #74

Authoring-Agent: claude

## Self-Review

- **Correctness**: Build passes, all 9 pages generate. Blog post renders correctly at 1440px, 920px, 480px. Blog index unchanged (Issue #75 reverted). Homepage has no regressions.
- **Regression risk**: Low — blog index template is untouched, all new CSS uses `.blog-canvas*` and `.blog-sidebar*` prefixes that don't collide with existing classes. Schema changes use `.optional().default([])` so existing posts work without modification.
- **Style**: Follows existing patterns — CSS custom properties, `clamp()` fluid sizing, 920px breakpoint, same plugin architecture as `rehype-figure-captions.mjs`.
- **Test coverage**: Visual verification at 3 viewport widths. Build verification passes.
- **Security/dependencies**: No new dependencies. Mermaid sidebar content uses `escapeHtml()` matching the existing `remark-mermaid.mjs` pattern to prevent XSS.

## Test plan

- [ ] Blog post at 1440px: 3-column layout with margin accents, content, sticky sidebar
- [ ] Blog post at 920px: single column, sidebar/margin hidden, red metadata bar
- [ ] Blog post at 480px: tighter typography, stacked metadata
- [ ] Sidebar mermaid diagram renders (not syntax error)
- [ ] ToC links scroll to correct headings
- [ ] Pullquotes display with accent left borders
- [ ] Blog index page unchanged (original layout)
- [ ] Homepage Mondrian grid unchanged
- [ ] Build passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blog posts now support pullquotes with color accents and a flexible sidebar for mermaid diagrams, images, or text.
  * Table of contents generation exposed to posts for in-article navigation.

* **Style**
  * New Mondrian-style three-column blog layout with decorative margins, sidebar UI, and responsive collapse for smaller screens.

* **Blog Post Updates**
  * Featured post updated with new pullquotes and an embedded dependency-flow diagram.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->