### PR TITLE
Blog index: De Stijl Mondrian row grid from mockup

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -165,7 +165,7 @@ function readingTime(body: string | undefined): string {
                 ))}
               </div>
             </article>
-            <div class={i % 2 === 0 ? 'accent-cream' : 'accent-yellow'} aria-hidden="true"></div>
+            <div class={i % 2 === 0 ? 'accent-overflow accent-overflow--cream' : 'accent-overflow accent-overflow--yellow'} aria-hidden="true"></div>
           </div>
         ))}
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -28,12 +28,17 @@ const jsonLd = {
 };
 
 function formatDate(date: Date): string {
-  return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' });
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
 }
 
 function readingTime(body: string | undefined): string {
   const words = body?.split(/\s+/).length ?? 0;
-  return `${Math.ceil(words / 225)} min read`;
+  return `${Math.ceil(words / 225)} min`;
 }
 ---
 
@@ -44,53 +49,133 @@ function readingTime(body: string | undefined): string {
   ogImageWidth="1200"
   ogImageHeight="630"
   ogImageAlt="Six PRs, One Bug: What AI Agents Actually Get Wrong open graph image"
-  bodyClass="project-page project-page--blue blog-index-page"
+  bodyClass="project-page project-page--blue"
   jsonLd={jsonLd}
 >
-  <main class="project-shell">
-    <article class="project-detail blog-index-detail">
-      <header class="project-hero">
-        <nav class="project-breadcrumbs" aria-label="Breadcrumb">
+  <main class="shell">
+    <div class="frame">
+
+      {/* ── Hero ── */}
+      <header class="hero">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
           <a href="/">Nathan Payne</a>
           <span>/</span>
           <span>Blog</span>
         </nav>
-        <p class="project-kicker">Essays × Systems × Product</p>
+        <p class="kicker">Essays &times; Systems &times; Product</p>
         <h1>Blog</h1>
-        <p class="project-deck">Essays and notes on AI agents, product systems, debugging, and the invisible constraints that shape what people actually experience.</p>
-        <p class="blog-index-aside">Writing about system boundaries, product judgment, engineering tradeoffs, and where AI-generated code breaks when the model never forms the right mental model.</p>
-        <div class="project-actions">
-          <a class="project-action" href="/">Back to Homepage</a>
-        </div>
+        <p class="deck">Writing about how software systems actually work when they meet real users, real teams, and real deadlines.</p>
       </header>
-      <div class="project-layout blog-index-layout">
-        <section class="project-copy blog-index-copy" aria-labelledby="blog-posts">
-          <div class="project-section blog-section">
-            <h2 id="blog-posts">Posts</h2>
-            <div class="blog-card-list">
-              {posts.map((post) => (
-                <article class="blog-card">
-                  <p class="blog-card-meta">{formatDate(post.data.date)} · {readingTime(post.body)}</p>
-                  <h3><a class="blog-card-link" href={`/blog/${post.id}/`}>{post.data.title}</a></h3>
-                  <p class="blog-card-desc">{post.data.description}</p>
-                  <div class="blog-tag-row">
-                    {post.data.tags.map((tag) => (
-                      <span class="blog-tag">{tag}</span>
-                    ))}
-                  </div>
-                </article>
-              ))}
+
+      {/* ── Mondrian Blog Grid ── */}
+      <div class="blog-grid">
+
+        {/* Row 1: Featured post | Red | Blue("LATEST") */}
+        {posts[0] && (
+          <div class="grid-row--1">
+            <article class="post-card">
+              <p class="post-meta">{formatDate(posts[0].data.date)} &middot; {readingTime(posts[0].body)}</p>
+              <h2 class="post-title"><a href={`/blog/${posts[0].id}/`}>{posts[0].data.title}</a></h2>
+              <p class="post-desc">{posts[0].data.description}</p>
+              <div class="tag-row">
+                {posts[0].data.tags.map((tag) => (
+                  <span class="tag">{tag}</span>
+                ))}
+              </div>
+            </article>
+            <div class="accent-red" aria-hidden="true"></div>
+            <div class="accent-blue" aria-hidden="true">
+              <span class="accent-blue-label">Latest</span>
             </div>
           </div>
-        </section>
+        )}
+
+        {/* Row 2: Post 2 (or placeholder) | Yellow */}
+        <div class="grid-row--2">
+          {posts[1] ? (
+            <article class="post-card">
+              <p class="post-meta">{formatDate(posts[1].data.date)} &middot; {readingTime(posts[1].body)}</p>
+              <h2 class="post-title"><a href={`/blog/${posts[1].id}/`}>{posts[1].data.title}</a></h2>
+              <p class="post-desc">{posts[1].data.description}</p>
+              <div class="tag-row">
+                {posts[1].data.tags.map((tag) => (
+                  <span class="tag">{tag}</span>
+                ))}
+              </div>
+            </article>
+          ) : (
+            <div class="post-card--placeholder">
+              <p class="placeholder-text">More essays coming soon.</p>
+            </div>
+          )}
+          <div class="accent-yellow" aria-hidden="true"></div>
+        </div>
+
+        {/* Row 3: Post 3 (or placeholder) | RSS/Cream */}
+        <div class="grid-row--3">
+          {posts[2] ? (
+            <article class="post-card">
+              <p class="post-meta">{formatDate(posts[2].data.date)} &middot; {readingTime(posts[2].body)}</p>
+              <h2 class="post-title"><a href={`/blog/${posts[2].id}/`}>{posts[2].data.title}</a></h2>
+              <p class="post-desc">{posts[2].data.description}</p>
+              <div class="tag-row">
+                {posts[2].data.tags.map((tag) => (
+                  <span class="tag">{tag}</span>
+                ))}
+              </div>
+            </article>
+          ) : (
+            <div class="post-card--placeholder">
+              <p class="placeholder-text">Writing about system boundaries,<br/>product judgment, and engineering tradeoffs.</p>
+            </div>
+          )}
+          <div class="accent-cream">
+            <a href="/rss.xml" class="rss-link">Subscribe via RSS &rarr;</a>
+          </div>
+        </div>
+
+        {/* Row 4: Post 4 | black | paper — only if post exists */}
+        {posts[3] && (
+          <div class="grid-row--4">
+            <article class="post-card">
+              <p class="post-meta">{formatDate(posts[3].data.date)} &middot; {readingTime(posts[3].body)}</p>
+              <h2 class="post-title"><a href={`/blog/${posts[3].id}/`}>{posts[3].data.title}</a></h2>
+              <p class="post-desc">{posts[3].data.description}</p>
+              <div class="tag-row">
+                {posts[3].data.tags.map((tag) => (
+                  <span class="tag">{tag}</span>
+                ))}
+              </div>
+            </article>
+            <div class="accent-black" aria-hidden="true"></div>
+            <div class="accent-paper" aria-hidden="true"></div>
+          </div>
+        )}
+
+        {/* Overflow rows: posts 5+ — alternating layouts */}
+        {posts.slice(4).map((post, i) => (
+          <div class={i % 2 === 0 ? 'grid-row--overflow-a' : 'grid-row--overflow-b'}>
+            <article class="post-card">
+              <p class="post-meta">{formatDate(post.data.date)} &middot; {readingTime(post.body)}</p>
+              <h2 class="post-title"><a href={`/blog/${post.id}/`}>{post.data.title}</a></h2>
+              <p class="post-desc">{post.data.description}</p>
+              <div class="tag-row">
+                {post.data.tags.map((tag) => (
+                  <span class="tag">{tag}</span>
+                ))}
+              </div>
+            </article>
+            <div class={i % 2 === 0 ? 'accent-cream' : 'accent-yellow'} aria-hidden="true"></div>
+          </div>
+        ))}
+
       </div>
 
-      <footer class="blog-footer">
-        <p class="blog-footer-attribution">Nathan Payne · San Francisco</p>
-        <nav class="blog-footer-nav">
-          <a class="project-action" href="/">&larr; Back to Homepage</a>
-        </nav>
+      {/* ── Footer ── */}
+      <footer class="grid-footer">
+        <span class="footer-attribution">Nathan Payne &middot; San Francisco</span>
+        <a href="/" class="footer-action">&larr; Back to Homepage</a>
       </footer>
-    </article>
+    </div>
   </main>
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -982,22 +982,303 @@ body.project-page {
   color: inherit;
 }
 
-.blog-index-layout {
-  grid-template-columns: minmax(0, 1fr);
+/* ── Blog Index: Mondrian Row Grid ──────────────────────────
+   Row-based grid matching the De Stijl blog landing mockup.
+   Each post gets its own grid row with accent color blocks.
+   @see Issue #75
+   ──────────────────────────────────────────────────────────── */
+
+.shell {
+  min-height: 100vh;
+  padding: clamp(0.9rem, 2.5vw, 1.8rem);
 }
 
-.blog-index-copy {
-  max-width: 52rem;
+.frame {
+  width: min(100%, 72rem);
+  margin: 0 auto;
+  background: rgba(244, 239, 229, 0.96);
+  border: var(--line) solid var(--ink);
+  overflow: hidden;
+  box-shadow: 14px 14px 0 rgba(17, 16, 13, 0.12);
 }
 
-.blog-index-aside {
+/* ── Hero ── */
+.hero {
+  padding: clamp(1.15rem, 3vw, 2.5rem) clamp(1.15rem, 3vw, 2.5rem);
+  border-bottom: var(--line) solid var(--ink);
+}
+
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-bottom: 1rem;
+  font-size: clamp(0.72rem, 0.92vw, 0.88rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.breadcrumbs a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.kicker {
+  margin-bottom: 0.4rem;
+  font-size: clamp(0.7rem, 0.88vw, 0.82rem);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #223f89;
+  font-weight: 600;
+}
+
+.hero h1 {
+  font-family: "Cormorant Garamond", Garamond, serif;
+  font-size: clamp(2.8rem, 6vw, 5.4rem);
+  line-height: 0.92;
+  font-weight: 600;
+}
+
+.deck {
   max-width: 38rem;
-  margin-top: calc(var(--su) * 0.8);
-  padding-left: clamp(1rem, 2.2vw, 1.6rem);
-  font-size: clamp(0.95rem, 0.9rem + 0.28vw, 1.18rem);
+  margin-top: 1rem;
+  font-size: clamp(1.05rem, 1rem + 0.42vw, 1.4rem);
   line-height: 1.45;
   font-family: "Cormorant Garamond", Garamond, serif;
-  color: rgba(17, 16, 13, 0.62);
+  color: rgba(17, 16, 13, 0.72);
+}
+
+/* ── Mondrian Blog Grid ── */
+.blog-grid {
+  display: grid;
+  background: var(--ink);
+  gap: var(--line);
+}
+
+/* Row 1: post (~50%) | red (~22%) | blue (~28%) */
+.grid-row--1 {
+  display: grid;
+  grid-template-columns: minmax(0, 5fr) minmax(0, 2.2fr) minmax(0, 2.8fr);
+  gap: var(--line);
+  min-height: 22rem;
+}
+
+/* Row 2: post (~72%) | yellow (~28%) */
+.grid-row--2 {
+  display: grid;
+  grid-template-columns: minmax(0, 7.2fr) minmax(0, 2.8fr);
+  gap: var(--line);
+  min-height: 13rem;
+}
+
+/* Row 3: post (~50%) | rss/cream (~50%) */
+.grid-row--3 {
+  display: grid;
+  grid-template-columns: minmax(0, 5fr) minmax(0, 5fr);
+  gap: var(--line);
+  min-height: 14rem;
+}
+
+/* Row 4: post (~50%) | black (~22%) | paper (~28%) */
+.grid-row--4 {
+  display: grid;
+  grid-template-columns: minmax(0, 5fr) minmax(0, 2.2fr) minmax(0, 2.8fr);
+  gap: var(--line);
+  min-height: 14rem;
+}
+
+/* Overflow rows (post 5+): alternate between two layouts */
+.grid-row--overflow-a {
+  display: grid;
+  grid-template-columns: minmax(0, 6fr) minmax(0, 4fr);
+  gap: var(--line);
+  min-height: 13rem;
+}
+
+.grid-row--overflow-b {
+  display: grid;
+  grid-template-columns: minmax(0, 4fr) minmax(0, 6fr);
+  gap: var(--line);
+  min-height: 13rem;
+}
+
+/* ── Post Cards ── */
+.post-card {
+  background: var(--paper);
+  padding: clamp(1.2rem, 2.5vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.post-meta {
+  font-size: clamp(0.65rem, 0.78vw, 0.76rem);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(17, 16, 13, 0.58);
+  margin-bottom: 0.5rem;
+}
+
+.post-title {
+  font-family: "Cormorant Garamond", Garamond, serif;
+  font-size: clamp(1.6rem, 2.2vw, 2.4rem);
+  line-height: 1.05;
+  font-weight: 600;
+  margin-bottom: 0.6rem;
+}
+
+.post-title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.post-title a:hover {
+  text-decoration: underline;
+  text-decoration-color: #223f89;
+  text-underline-offset: 0.12em;
+}
+
+.post-desc {
+  max-width: 48ch;
+  font-size: clamp(0.88rem, 0.95vw, 0.98rem);
+  line-height: 1.55;
+  color: rgba(17, 16, 13, 0.78);
+  margin-bottom: 0.9rem;
+}
+
+.tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.42rem;
+  background: rgba(17, 16, 13, 0.08);
+  font-size: clamp(0.62rem, 0.74vw, 0.72rem);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  line-height: 1.4;
+}
+
+/* ── Placeholder Cards (future posts) ── */
+.post-card--placeholder {
+  background: var(--paper);
+  padding: clamp(1.2rem, 2.5vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.placeholder-text {
+  font-family: "Cormorant Garamond", Garamond, serif;
+  font-size: clamp(1.1rem, 1.4vw, 1.5rem);
+  font-style: italic;
+  color: rgba(17, 16, 13, 0.22);
+  line-height: 1.3;
+}
+
+/* ── Color Blocks ── */
+.accent-red {
+  background: #c11d19;
+}
+
+.accent-blue {
+  background: #223f89;
+  position: relative;
+}
+
+.accent-blue-label {
+  position: absolute;
+  bottom: clamp(0.8rem, 1.5vw, 1.2rem);
+  right: clamp(0.8rem, 1.5vw, 1.2rem);
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  font-family: "Cormorant Garamond", Garamond, serif;
+  font-size: clamp(0.72rem, 0.88vw, 0.84rem);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: 500;
+}
+
+.accent-yellow {
+  background: #d9b111;
+}
+
+.accent-cream {
+  background: #DDE1E5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.accent-black {
+  background: #090907;
+}
+
+.accent-paper {
+  background: #DDE1E5;
+}
+
+.rss-link {
+  font-size: clamp(0.68rem, 0.82vw, 0.78rem);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(17, 16, 13, 0.58);
+  text-decoration: none;
+  transition: color var(--motion-hover) var(--ease-standard);
+}
+
+.rss-link:hover {
+  color: var(--ink);
+}
+
+/* ── Footer Row ── */
+.grid-footer {
+  background: rgba(244, 239, 229, 0.96);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: clamp(1.15rem, 2.5vw, 2rem) clamp(1.15rem, 3vw, 2.5rem);
+  border-top: var(--line) solid var(--ink);
+}
+
+.footer-attribution {
+  font-size: clamp(0.7rem, 0.88vw, 0.82rem);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(17, 16, 13, 0.58);
+}
+
+.footer-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.55rem 0.85rem;
+  border: 1px solid var(--ink);
+  background: transparent;
+  font-size: clamp(0.8rem, 0.92vw, 0.92rem);
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: inherit;
+  text-decoration: none;
+  transition:
+    background-color var(--motion-hover) var(--ease-standard),
+    color var(--motion-hover) var(--ease-standard),
+    transform var(--motion-hover) var(--ease-standard);
+}
+
+.footer-action:hover {
+  background: #223f89;
+  color: #f5f0e4;
+  transform: translateY(-2px);
 }
 
 /* ── Blog Post: Mondrian "Composition with Margins" Canvas ────
@@ -1391,88 +1672,6 @@ body.project-page {
   overflow-wrap: anywhere;
 }
 
-.blog-section {
-  background:
-    linear-gradient(180deg, var(--project-accent-soft), rgba(255, 255, 255, 0) 18rem),
-    rgba(255, 255, 255, 0.62);
-}
-
-.blog-card-list {
-  display: grid;
-  gap: 1rem;
-}
-
-.blog-card {
-  position: relative;
-  padding: 1rem 0 0 0.85rem;
-  border-top: 1px solid var(--rule);
-  border-left: 3px solid transparent;
-  transition: border-left-color var(--motion-hover) var(--ease-standard);
-}
-
-.blog-card:hover {
-  border-left-color: var(--project-accent);
-}
-
-.blog-card:first-child {
-  padding-top: 0.25rem;
-  border-top: 0;
-}
-
-.blog-card-meta,
-.blog-tag {
-  font-size: clamp(0.68rem, 0.82vw, 0.8rem);
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
-.blog-card-meta {
-  color: rgba(17, 16, 13, 0.58);
-}
-
-.blog-card h3 {
-  margin-top: 0.45rem;
-  font-family: "Cormorant Garamond", Garamond, serif;
-  font-size: clamp(1.45rem, 2vw, 2rem);
-  line-height: 1.05;
-}
-
-.blog-card-link {
-  color: inherit;
-  text-decoration: none;
-}
-
-.blog-card-link::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-}
-
-.blog-card-link:hover,
-.blog-card-link:focus-visible {
-  text-decoration: underline;
-  text-decoration-color: var(--project-accent);
-  text-underline-offset: 0.12em;
-}
-
-.blog-card-desc {
-  margin-top: 0.55rem;
-  max-width: 58ch;
-}
-
-.blog-tag-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-  margin-top: 0.8rem;
-}
-
-.blog-tag {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.22rem 0.42rem;
-  background: rgba(17, 16, 13, 0.08);
-}
 
 .blog-prose-title {
   margin-bottom: 0.25rem;
@@ -1852,9 +2051,6 @@ a:focus-visible {
     padding: 0.75rem 0.85rem;
   }
 
-  .blog-tag-row {
-    gap: 0.25rem 0.5rem;
-  }
 }
 
 @media (max-width: 920px) {
@@ -1981,6 +2177,40 @@ a:focus-visible {
 
   .blog-diagram-fanout-row {
     grid-template-columns: 1fr;
+  }
+
+  /* ── Blog Index grid: collapse to single column ────────── */
+  .blog-grid {
+    gap: var(--line);
+  }
+
+  .grid-row--1,
+  .grid-row--2,
+  .grid-row--3,
+  .grid-row--4,
+  .grid-row--overflow-a,
+  .grid-row--overflow-b {
+    grid-template-columns: 1fr;
+    min-height: auto;
+  }
+
+  /* Hide decorative accent blocks */
+  .accent-red,
+  .accent-blue,
+  .accent-yellow,
+  .accent-black,
+  .accent-paper {
+    display: none;
+  }
+
+  /* RSS block stays but simplifies */
+  .accent-cream {
+    min-height: 4rem;
+  }
+
+  /* Placeholder cards hidden on mobile */
+  .post-card--placeholder {
+    display: none;
   }
 
   /* ── Blog Post canvas: collapse to single column ───────── */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1111,6 +1111,15 @@ body.project-page {
   justify-content: center;
 }
 
+.post-card:hover,
+.post-card:focus-within {
+  background: #faf8f4;
+  box-shadow: inset 0 0 0 2px rgba(34, 63, 137, 0.18);
+  transition:
+    background-color var(--motion-hover) var(--ease-standard),
+    box-shadow var(--motion-hover) var(--ease-standard);
+}
+
 .post-meta {
   font-size: clamp(0.65rem, 0.78vw, 0.76rem);
   letter-spacing: 0.14em;
@@ -1222,6 +1231,15 @@ body.project-page {
 
 .accent-paper {
   background: #DDE1E5;
+}
+
+/* Overflow accent blocks — decorative only, hidden on mobile */
+.accent-overflow--cream {
+  background: #DDE1E5;
+}
+
+.accent-overflow--yellow {
+  background: #d9b111;
 }
 
 .rss-link {
@@ -2199,7 +2217,8 @@ a:focus-visible {
   .accent-blue,
   .accent-yellow,
   .accent-black,
-  .accent-paper {
+  .accent-paper,
+  .accent-overflow {
     display: none;
   }
 


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
- Replace card-list blog index with Mondrian-style row grid matching the `blog-landing 2.html` mockup exactly
- Each post gets its own grid row with distinct column proportions and accent color blocks (red, blue, yellow, cream, black, paper)
- Two placeholder rows for future posts when fewer than 3 posts exist; rows 4+ render conditionally with overflow layouts
- Responsive collapse at ≤920px hides accent blocks, stacks to single column, hides placeholders

Closes #75

## Self-Review

**Correctness:** Generated HTML matches the mockup structure element-for-element. Build passes, all 7 pages render. Visual verification at 1400px viewport confirms grid proportions, accent colors, and typography match the mockup.

**Regression risk:** Low. Old blog-index classes (`blog-card-list`, `blog-card`, `blog-tag-row`, `blog-tag`, `blog-index-layout`, `blog-index-copy`, `blog-index-aside`, `blog-section`) were only used by `blog/index.astro` (verified via grep). Blog post page CSS (`blog-canvas`, `blog-prose`, `blog-sidebar`, `blog-footer`) is untouched. Homepage and project pages unaffected — new CSS uses distinct class names.

**Style:** CSS follows existing codebase patterns — `clamp()` fluid scaling, `var(--line)` grid lines, `var(--ink)` background for Mondrian effect. Class naming is descriptive (`.grid-row--1`, `.post-card`, `.accent-red`).

**Test coverage:** Manual visual verification at desktop (1400px) and mobile (<920px) viewports. Build verification confirms no template errors.

**Security/dependency hygiene:** No new dependencies. No external resources added. Content collection query unchanged.

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Blog index at desktop width shows Mondrian grid with accent blocks matching mockup proportions
- [ ] Featured post row: card + red + blue with vertical "LATEST" label
- [ ] Placeholder rows show italic text for missing posts 2 and 3
- [ ] RSS "Subscribe via RSS →" link in cream block on row 3
- [ ] Footer with attribution and "Back to Homepage" button inside frame
- [ ] Responsive: at ≤920px accent blocks hidden, single column, placeholders hidden
- [ ] Blog post page (`/blog/six-prs-one-bug-agent-failure-modes/`) renders correctly
- [ ] Homepage and project pages render with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned blog index into a Mondrian-style grid with four featured slots, overflow listing, a “Latest” accent block, and RSS subscribe link.
  * Featured slots render placeholders when posts are missing; simplified footer with single home link.

* **Style**
  * Dates now use abbreviated month names.
  * Reading time displays as “N min”.
  * Improved responsive behavior: grid collapses to a single-column on small screens and hides decorative accents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->