### PR TITLE
Unify content surface to warm cream

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1111,7 +1111,7 @@ body.blog-page {
 
 /* ── Post Cards ── */
 .post-card {
-  background: var(--paper);
+  background: var(--surface);
   padding: clamp(1.2rem, 2.5vw, 2rem);
   display: flex;
   flex-direction: column;
@@ -1181,7 +1181,7 @@ body.blog-page {
 
 /* ── Placeholder Cards (future posts) ── */
 .post-card--placeholder {
-  background: var(--paper);
+  background: var(--surface);
   padding: clamp(1.2rem, 2.5vw, 2rem);
   display: flex;
   flex-direction: column;
@@ -1379,7 +1379,7 @@ body.blog-page {
   grid-column: 4;
   grid-row: 2;
   min-width: 0;
-  background: var(--paper);
+  background: var(--surface);
   padding: clamp(1.15rem, 3vw, 2.5rem);
   display: flex;
   flex-direction: column;
@@ -1476,7 +1476,7 @@ body.blog-page {
   grid-column: 4;
   grid-row: 4;
   min-width: 0;
-  background: var(--paper);
+  background: var(--surface);
   padding: clamp(1.15rem, 3vw, 2.5rem);
   align-self: stretch;
 }
@@ -1489,7 +1489,7 @@ body.blog-page {
   grid-column: 6;
   grid-row: 4;
   min-width: 0;
-  background: var(--paper);
+  background: var(--surface);
   padding: 0;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,6 +5,7 @@
   --yellow: #d9b111;
   --blue: #223f89;
   --black: #11100d;
+  --accent-black: #333333;
   --linkedin-blue-6: #006699;
   --linkedin-blue-4: #00A0DC;
   --linkedin-gray-6: #313335;
@@ -685,7 +686,7 @@ html, body {
 .panel--black {
   grid-column: 2;
   grid-row: 6 / 9;
-  background: #333333;
+  background: var(--accent-black);
   color: var(--cream);
 }
 
@@ -762,7 +763,7 @@ body.blog-page {
 }
 
 .project-page--black {
-  --project-accent: #333333;
+  --project-accent: var(--accent-black);
   --project-accent-foreground: #f5f0e4;
   --project-accent-soft: rgba(51, 51, 51, 0.12);
   --project-bg: #d1cbc2;
@@ -1233,7 +1234,7 @@ body.blog-page {
 }
 
 .accent-black {
-  background: #333333;
+  background: var(--accent-black);
 }
 
 .accent-paper {


### PR DESCRIPTION
## Summary

- Blog post content, sidebar, header, and post cards were using `var(--paper)` (`#ffffff`) while the blog index frame and project pages used `var(--surface)` (warm cream `rgba(244, 239, 229, 0.96)`)
- Standardizes all reading surfaces to `var(--surface)` for a cohesive De Stijl paper aesthetic
- Homepage Mondrian white blocks stay `var(--paper)` — they are decorative elements, not reading surfaces
- Homepage panel open state stays `#e4ded0` — it's a transient interactive state, not a resting surface

Follow-up to #79. Closes #78.

Authoring-Agent: claude

## Self-Review

- **Correctness**: 5 selectors changed from `var(--paper)` to `var(--surface)`. All are reading surfaces (post cards, blog content, blog header, blog sidebar). Verified via preview — warm cream renders correctly across blog index and blog post.
- **Regression risk**: Low — the cream is only slightly off-white. Post card hover (`#faf8f4`) still provides visible brightening against the new base.
- **Style**: Consistent with existing variable usage patterns.
- **Test coverage**: No test files; verified via build + visual preview.
- **Security/dependency hygiene**: CSS-only, no new dependencies.

## Test plan

- [ ] `npm run build` succeeds
- [ ] Blog index: post cards use warm cream background, hover still brightens visibly
- [ ] Blog post: header, content area, and sidebar all use warm cream (not pure white)
- [ ] Project pages: unchanged (already used `var(--surface)`)
- [ ] Homepage: white Mondrian blocks still pure white

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized black accent styling across panels, project pages, and accent blocks for improved visual consistency.
  * Updated blog interface styling to provide uniform appearance across post cards and blog layout elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->