### PR TITLE
Blog color refinements: hero, sidebar, margin lines

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,6 +6,7 @@
   --blue: #223f89;
   --black: #11100d;
   --accent-black: #333333;
+  --accent-gray: #d4d4d4;
   --linkedin-blue-6: #006699;
   --linkedin-blue-4: #00A0DC;
   --linkedin-gray-6: #313335;
@@ -1228,7 +1229,7 @@ body.blog-page {
 }
 
 .accent-cream {
-  background: #d4d4d4;
+  background: var(--accent-gray);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1428,7 +1429,7 @@ body.blog-page {
   grid-column: 6;
   grid-row: 2;
   min-width: 0;
-  background: #d4d4d4;
+  background: var(--accent-gray);
   padding: clamp(0.85rem, 2vw, 1.5rem);
   display: flex;
   flex-direction: column;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1013,6 +1013,7 @@ body.blog-page {
 /* ── Hero ── */
 .hero {
   padding: clamp(1.15rem, 3vw, 2.5rem) clamp(1.15rem, 3vw, 2.5rem);
+  background: var(--paper);
   border-bottom: var(--line) solid var(--ink);
 }
 
@@ -1227,7 +1228,7 @@ body.blog-page {
 }
 
 .accent-cream {
-  background: #DDE1E5;
+  background: #d4d4d4;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1358,14 +1359,18 @@ body.blog-page {
 
 .blog-margin--body {
   grid-row: 4;
-  /* Gradient stripe: yellow → white → blue (varies by section) */
+  /* Gradient stripe: yellow | ink line | white | ink line | blue */
   background: linear-gradient(
     to bottom,
     var(--yellow) 0%,
     var(--yellow) 25%,
-    var(--paper) 25%,
+    var(--ink) 25%,
+    var(--ink) calc(25% + var(--line)),
+    var(--paper) calc(25% + var(--line)),
     var(--paper) 60%,
-    var(--blue) 60%,
+    var(--ink) 60%,
+    var(--ink) calc(60% + var(--line)),
+    var(--blue) calc(60% + var(--line)),
     var(--blue) 100%
   );
 }
@@ -1423,7 +1428,7 @@ body.blog-page {
   grid-column: 6;
   grid-row: 2;
   min-width: 0;
-  background: var(--surface);
+  background: #d4d4d4;
   padding: clamp(0.85rem, 2vw, 1.5rem);
   display: flex;
   flex-direction: column;
@@ -1492,6 +1497,7 @@ body.blog-page {
   min-width: 0;
   background: var(--surface);
   padding: 0;
+  overflow: hidden;
 }
 
 .blog-sidebar-inner {


### PR DESCRIPTION
## Summary

- Blog index hero: pure white background to distinguish from the cream content surface below
- Blog post sidebar-meta (Published/Author/Topics cube): uses homepage gray (`#d4d4d4`) instead of cream
- RSS tile (`.accent-cream`): matches homepage gray (`#d4d4d4`) for consistency with Mondrian decorative blocks
- Blog margin body: added ink separator lines at the yellow→white and white→blue transitions within the gradient
- Blog sidebar: added `overflow: hidden` to prevent mermaid diagrams from clipping past the sidebar boundary

Follow-up to #79, #80. Related: #78.

Authoring-Agent: claude

## Self-Review

- **Correctness**: All changes are targeted CSS property additions/modifications. Blog hero gets explicit `background: var(--paper)`. Sidebar-meta and accent-cream both change to `#d4d4d4`. Margin gradient adds `var(--ink)` stops at 25% and 60% with `var(--line)` thickness. Sidebar gets `overflow: hidden`.
- **Regression risk**: Low — hero white is additive (new property). Gray changes are value swaps. Gradient modification preserves existing color zones with ink lines inserted at hard stops. Sidebar overflow hidden may clip content that extends beyond the column, but `.blog-sidebar-item` already has `overflow-x: auto` for scrollable content.
- **Style**: Follows existing patterns. No new variables introduced.
- **Test coverage**: Build passes. Visual verification via preview confirmed hero white, sidebar-meta gray, and margin ink lines.
- **Security/dependency hygiene**: CSS-only changes.

## Test plan

- [ ] Blog index: hero area is pure white, distinct from cream post cards below
- [ ] Blog index: RSS tile matches homepage gray blocks
- [ ] Blog post: sidebar-meta (top-right) is gray, matching homepage
- [ ] Blog post: left margin has black separator lines between yellow/white and white/blue
- [ ] Blog post: sidebar mermaid diagrams don't clip past right boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Introduced two new accent variables for black and gray to unify theme colors.
  * Replaced hard-coded accents across panels, project pages, and accent elements for consistent visuals.
  * Updated blog and post card backgrounds to a unified surface tone and adjusted hero background.
  * Set blog sidebar overflow to hidden for layout stability.
  * Refined margin gradient stripe for crisper edge and ink/line banding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->