### PR TITLE
Fix blog color, hover, footer, and mermaid diagram issues

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1123,11 +1123,8 @@ body.blog-page {
 
 .post-card:hover,
 .post-card:focus-within {
-  background: #faf8f4;
   box-shadow: inset 0 0 0 2px rgba(34, 63, 137, 0.18);
-  transition:
-    background-color var(--motion-hover) var(--ease-standard),
-    box-shadow var(--motion-hover) var(--ease-standard);
+  transition: box-shadow var(--motion-hover) var(--ease-standard);
 }
 
 .post-meta {
@@ -1267,7 +1264,7 @@ body.blog-page {
 
 /* ── Footer Row ── */
 .grid-footer {
-  background: var(--surface);
+  background: var(--paper);
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -1345,7 +1342,10 @@ body.blog-page {
   width: min(100%, 72rem);
   margin: 0 auto;
   border: 1px solid var(--grid-border);
-  overflow: hidden;
+  /* Use clip instead of hidden — hidden creates a scroll container
+     which breaks position:sticky on .blog-sidebar-inner. clip
+     provides the same visual clipping without a new scroll context. */
+  overflow: clip;
 }
 
 /* ── Left margin: per-row Mondrian accent blocks ── */
@@ -1378,7 +1378,7 @@ body.blog-page {
 
 .blog-margin--footer {
   grid-row: 6;
-  background: var(--surface);
+  background: var(--paper);
 }
 
 /* ── Header ── */
@@ -1386,7 +1386,7 @@ body.blog-page {
   grid-column: 4;
   grid-row: 2;
   min-width: 0;
-  background: var(--surface);
+  background: var(--paper);
   padding: clamp(1.15rem, 3vw, 2.5rem);
   display: flex;
   flex-direction: column;
@@ -1498,14 +1498,9 @@ body.blog-page {
   min-width: 0;
   background: var(--surface);
   padding: 0;
-  overflow: hidden;
 }
 
 .blog-sidebar-inner {
-  position: sticky;
-  top: 0;
-  max-height: 100vh;
-  overflow-y: auto;
   padding: clamp(0.85rem, 2vw, 1.5rem);
 }
 
@@ -1630,7 +1625,7 @@ body.blog-page {
   grid-column: 2 / -2;
   grid-row: 6;
   min-width: 0;
-  background: var(--surface);
+  background: var(--paper);
 }
 
 /* Legacy single-column fallback (kept for backward compatibility) */


### PR DESCRIPTION
## Summary
- Blog post header → bright white (`var(--paper)`), content & sidebar stay cream
- Blog index post card hover no longer changes background color
- Both page footers (index + post) → bright white
- Mermaid diagram in sidebar: fixed clipping (`overflow: clip` on canvas, removed `overflow: hidden` from sidebar, removed sticky positioning so sidebar scrolls with page)

Authoring-Agent: claude

## Self-Review
- **Correctness**: All 5 reported issues addressed. Verified in preview server — header is white, content stays cream, footers are white, hover only shows box-shadow, mermaid diagram scrolls with page.
- **Regression risk**: Low. Changes are scoped to blog index/post CSS only. `overflow: clip` is well-supported and provides same visual clipping as `hidden` without breaking scroll context.
- **Style**: Consistent with existing patterns — uses CSS custom properties (`var(--paper)`, `var(--surface)`).
- **Test coverage**: Visual verification via preview. No automated visual regression tests exist.
- **Security/dependency hygiene**: No new dependencies. CSS-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined post card interactions by removing background color changes on hover, now emphasizing shadow effects.
  * Adjusted blog layout background colors for improved visual consistency.
  * Modified blog canvas overflow handling for better content clipping.
  * Removed sticky scrolling from the sidebar to simplify layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->