### PR TITLE
Breadcrumb shortTitle, multi-segment nav, revert topic tags

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -5,6 +5,7 @@ const blog = defineCollection({
   loader: glob({ pattern: '**/*.md', base: './src/content/blog' }),
   schema: z.object({
     title: z.string(),
+    shortTitle: z.string().optional(),
     description: z.string(),
     author: z.string().default('Nathan Payne'),
     date: z.coerce.date(),

--- a/src/content/blog/six-prs-one-bug-agent-failure-modes.md
+++ b/src/content/blog/six-prs-one-bug-agent-failure-modes.md
@@ -1,5 +1,6 @@
 ---
 title: "Six PRs, One Bug: What AI Agents Actually Get Wrong"
+shortTitle: "Six PRs, One Bug"
 description: "A billing email bug took six AI-authored PRs to diagnose—not because the agent couldn't write code, but because it never promoted a repeated local failure into a structural question."
 author: "Nathan Payne"
 date: 2026-04-04

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -23,6 +23,7 @@ import BaseLayout from './BaseLayout.astro';
 
 interface Props {
   title: string;
+  shortTitle?: string;
   description: string;
   author: string;
   date: Date;
@@ -36,6 +37,7 @@ interface Props {
 
 const {
   title,
+  shortTitle,
   description,
   author,
   date,
@@ -149,7 +151,11 @@ const jsonLd = {
       {/* ── Header ── */}
       <header class="blog-canvas-header">
         <nav class="project-breadcrumbs" aria-label="Breadcrumb">
-          <a href="/blog/">&larr; Blog</a>
+          <a href="/">Nathan Payne</a>
+          <span class="breadcrumb-sep">/</span>
+          <a href="/blog/">Blog</a>
+          <span class="breadcrumb-sep">/</span>
+          <span class="breadcrumb-current">{shortTitle || 'Article'}</span>
         </nav>
         <h1>{title}</h1>
         <p class="project-deck">{description}</p>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -24,6 +24,7 @@ const readingTime = `${minutes} min read`;
 
 <BlogPost
   title={post.data.title}
+  shortTitle={post.data.shortTitle}
   description={post.data.description}
   author={post.data.author}
   date={post.data.date}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1396,13 +1396,31 @@ body.blog-page {
 /* Header typography — explicit rules since blog-canvas-header
    is outside the .project-hero scope that normally provides these. */
 .blog-canvas-header .project-breadcrumbs {
-  font-weight: 500;
-  color: rgba(17, 16, 13, 0.42);
+  font-weight: 400;
+  color: rgba(17, 16, 13, 0.38);
   margin-bottom: 1.5rem;
 }
 
 .blog-canvas-header .project-breadcrumbs a {
-  color: rgba(17, 16, 13, 0.42);
+  color: rgba(17, 16, 13, 0.38);
+}
+
+.blog-canvas-header .project-breadcrumbs a:hover {
+  color: rgba(17, 16, 13, 0.62);
+}
+
+.blog-canvas-header .breadcrumb-sep {
+  color: rgba(17, 16, 13, 0.22);
+  user-select: none;
+}
+
+.blog-canvas-header .breadcrumb-current {
+  color: rgba(17, 16, 13, 0.52);
+  letter-spacing: 0.04em;
+  max-width: 28ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .blog-canvas-header h1 {
@@ -1447,14 +1465,14 @@ body.blog-page {
   display: inline-flex;
   align-items: center;
   padding: 0.18rem 0.45rem;
-  background: transparent;
+  background: rgba(17, 16, 13, 0.08);
   border-radius: 2px;
   font-family: "Inter", system-ui, sans-serif;
   font-size: 0.6rem;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(17, 16, 13, 0.48);
+  color: rgba(17, 16, 13, 0.62);
 }
 
 .blog-sidebar-meta dl {


### PR DESCRIPTION
Closes #86

Authoring-Agent: claude

## Summary

- Add optional `shortTitle` frontmatter field to blog content schema
- Update breadcrumb from `← Blog` to multi-segment `NATHAN PAYNE / BLOG / SIX PRS, ONE BUG` with CSS weight differentiation (lighter ancestors, slightly darker current segment with `letter-spacing: 0.04em`)
- Revert `.blog-sidebar-topic` styling to pre-#85 bordered treatment (`background: rgba(17,16,13,0.08)`, `font-weight: 600`, `color: rgba(17,16,13,0.62)`)
- Add `text-overflow: ellipsis` and `max-width: 28ch` on final breadcrumb segment for narrow viewports

## Self-Review

- **Correctness:** Build passes, all 64 tests pass. Breadcrumb renders `Six PRs, One Bug` from frontmatter with `Article` fallback when `shortTitle` is omitted. Topic tags restored to bordered style.
- **Regression risk:** Low — breadcrumb change is additive (new prop with fallback), topic tag revert is a direct property swap. JSON-LD breadcrumb schema was already correct and untouched.
- **Style:** CSS follows existing patterns (rgba color tokens, clamp sizing). No hard-coded motion values. New selectors scoped under `.blog-canvas-header`.
- **Test coverage:** Existing blog page tests continue to pass. Schema test validates frontmatter structure.
- **Security/dependency hygiene:** No new dependencies. No external URLs added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced breadcrumb navigation in blog posts with multi-level hierarchy (Homepage → Blog → Article)
  * Added support for optional shortened article titles displayed in breadcrumbs

* **Style**
  * Refined breadcrumb styling with improved visual hierarchy and hover states
  * Enhanced topic pill visibility with increased contrast and font weight

<!-- end of auto-generated comment: release notes by coderabbit.ai -->