### PR TITLE
Remove SPA rewrite so custom 404 page works

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -60,12 +60,6 @@
           }
         ]
       }
-    ],
-    "rewrites": [
-      {
-        "source": "**",
-        "destination": "/index.html"
-      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Remove the `** → /index.html` catch-all rewrite from `firebase.json`
- Firebase Hosting automatically serves `404.html` for unmatched routes when no catch-all rewrite exists
- The SPA rewrite was overriding this, causing unknown URLs to show the homepage instead of the custom 404 page
- Static Astro sites (`output: 'static'`) don't need SPA rewrites — every page is pre-rendered as its own HTML file

Authoring-Agent: claude

## Self-Review
- **Correctness**: Verified `404.html` is generated by `npm run build`. Firebase serves it automatically for missing routes once the catch-all is removed.
- **Regression risk**: Low. All existing pages are static HTML at known paths (`/index.html`, `/blog/index.html`, etc.) and will continue to be served directly. Only unknown URLs change behavior (from showing homepage to showing 404).
- **Style**: Single deletion, no new code.
- **Test coverage**: Build passes. Manual verification needed after deploy (navigate to a non-existent URL).
- **Security/dependency hygiene**: No new dependencies. Removing the rewrite is strictly more correct — it prevents the homepage from being served at arbitrary URLs.

## Test plan
- [ ] Deploy to Firebase and navigate to `https://nathanpayne.com/does-not-exist/`
- [ ] Confirm custom 404 page (Mondrian grid) appears instead of homepage
- [ ] Confirm existing pages (`/`, `/blog/`, `/projects/override/`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)