### PR TITLE
Fix Related sections, add Projects index, fix blog callout

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -21,7 +21,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <div class="project-actions">
           <a class="project-action" href="/">Homepage</a>
           <a class="project-action" href="/blog/">Blog</a>
-          <a class="project-action" href="/projects/override/">Projects</a>
+          <a class="project-action" href="/projects/">Projects</a>
         </div>
       </div>
 

--- a/src/pages/projects/device-source-of-truth/index.astro
+++ b/src/pages/projects/device-source-of-truth/index.astro
@@ -125,9 +125,9 @@ const jsonLd = {
       <h2 id="dst-note">Live link</h2>
       <p class="project-note"><a href="https://device-source-of-truth.web.app" target="_blank" rel="noopener">device-source-of-truth.web.app</a></p>
     </section>
-    <section class="project-section" aria-labelledby="dst-related">
+    <section class="project-card" aria-labelledby="dst-related">
       <h2 id="dst-related">Related</h2>
-      <ul>
+      <ul class="project-checklist">
         <li><a href="/blog/six-prs-one-bug-agent-failure-modes/">Blog: Six PRs, One Bug—What AI Agents Actually Get Wrong</a></li>
         <li><a href="/projects/swipe-watch/">Project: Swipe Watch</a></li>
       </ul>

--- a/src/pages/projects/friends-and-family-billing/index.astro
+++ b/src/pages/projects/friends-and-family-billing/index.astro
@@ -125,9 +125,9 @@ const jsonLd = {
       <h2 id="ffb-note">Live link</h2>
       <p class="project-note"><a href="https://friends-and-family-billing.web.app" target="_blank" rel="noopener">friends-and-family-billing.web.app</a></p>
     </section>
-    <section class="project-section" aria-labelledby="ffb-related">
+    <section class="project-card" aria-labelledby="ffb-related">
       <h2 id="ffb-related">Related</h2>
-      <ul>
+      <ul class="project-checklist">
         <li><a href="/blog/six-prs-one-bug-agent-failure-modes/">Blog: Six PRs, One Bug—What AI Agents Actually Get Wrong</a></li>
         <li><a href="/projects/override/">Project: Override</a></li>
       </ul>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,0 +1,145 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const projects = [
+  {
+    title: "Override",
+    slug: "override",
+    description: "A Broadway-focused financial operating system—built with AI agents—for structuring capitalization, modeling investor returns, and replacing spreadsheet workflows with live, shareable deals.",
+    tags: ["Finance", "Theater", "React", "Firebase"],
+    liveUrl: "https://overridebroadway.com",
+  },
+  {
+    title: "Device Source of Truth",
+    slug: "device-source-of-truth",
+    description: "A single web application—designed and shipped with AI agents—for understanding partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN.",
+    tags: ["Enterprise", "Data", "React", "Firebase"],
+    liveUrl: "https://device-source-of-truth.web.app",
+  },
+  {
+    title: "Swipe Watch",
+    slug: "swipe-watch",
+    description: "A swipe-based discovery experiment for Disney+ and Hulu—prototyped with AI tooling—that turns taste signals into a faster, more active recommendation loop.",
+    tags: ["Consumer", "Streaming", "Vanilla JS"],
+    liveUrl: "https://swipewatch.web.app",
+  },
+  {
+    title: "Friends & Family Billing",
+    slug: "friends-and-family-billing",
+    description: "A cloud-synced billing tool—built end-to-end with AI agents—that turns recurring shared costs into clear invoices, payment tracking, and shareable summaries.",
+    tags: ["Utility", "Finance", "React", "Firebase"],
+    liveUrl: "https://friends-and-family-billing.web.app",
+  },
+];
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "CollectionPage",
+      "@id": "https://nathanpayne.com/projects/#webpage",
+      "url": "https://nathanpayne.com/projects/",
+      "name": "Projects | Nathan Payne",
+      "description": "AI-built products from a product manager—each one a real problem turned into a systems design exercise.",
+      "isPartOf": { "@id": "https://nathanpayne.com/#website" },
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "https://nathanpayne.com/projects/#breadcrumb",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Nathan Payne", "item": "https://nathanpayne.com/" },
+        { "@type": "ListItem", "position": 2, "name": "Projects", "item": "https://nathanpayne.com/projects/" },
+      ],
+    },
+  ],
+};
+---
+
+<BaseLayout
+  title="Projects | Nathan Payne"
+  description="AI-built products from a product manager—each one a real problem turned into a systems design exercise."
+  bodyClass="project-page project-page--yellow blog-page"
+  jsonLd={jsonLd}
+>
+  <main class="shell">
+    <div class="frame">
+
+      {/* ── Hero ── */}
+      <header class="hero">
+        <nav class="breadcrumbs" aria-label="Breadcrumb">
+          <a href="/">Nathan Payne</a>
+          <span>/</span>
+          <span>Projects</span>
+        </nav>
+        <p class="kicker">AI &times; Product &times; Engineering</p>
+        <h1>Projects</h1>
+        <p class="deck">Every project started as a real problem. Each one became a systems design exercise&mdash;built with AI agents from first commit to deploy.</p>
+      </header>
+
+      {/* ── Project Grid ── */}
+      <div class="blog-grid">
+
+        {/* Row 1: Featured project | Red | Blue */}
+        <div class="grid-row--1">
+          <article class="post-card">
+            <p class="post-meta">{projects[0].tags.join(' · ')}</p>
+            <h2 class="post-title"><a href={`/projects/${projects[0].slug}/`}>{projects[0].title}</a></h2>
+            <p class="post-desc">{projects[0].description}</p>
+            <div class="tag-row">
+              <a href={projects[0].liveUrl} target="_blank" rel="noopener" class="tag">Live &nearr;</a>
+            </div>
+          </article>
+          <div class="accent-red" aria-hidden="true"></div>
+          <div class="accent-blue" aria-hidden="true"></div>
+        </div>
+
+        {/* Row 2: Project 2 | Yellow */}
+        <div class="grid-row--2">
+          <article class="post-card">
+            <p class="post-meta">{projects[1].tags.join(' · ')}</p>
+            <h2 class="post-title"><a href={`/projects/${projects[1].slug}/`}>{projects[1].title}</a></h2>
+            <p class="post-desc">{projects[1].description}</p>
+            <div class="tag-row">
+              <a href={projects[1].liveUrl} target="_blank" rel="noopener" class="tag">Live &nearr;</a>
+            </div>
+          </article>
+          <div class="accent-yellow" aria-hidden="true"></div>
+        </div>
+
+        {/* Row 3: Project 3 | Cream */}
+        <div class="grid-row--3">
+          <article class="post-card">
+            <p class="post-meta">{projects[2].tags.join(' · ')}</p>
+            <h2 class="post-title"><a href={`/projects/${projects[2].slug}/`}>{projects[2].title}</a></h2>
+            <p class="post-desc">{projects[2].description}</p>
+            <div class="tag-row">
+              <a href={projects[2].liveUrl} target="_blank" rel="noopener" class="tag">Live &nearr;</a>
+            </div>
+          </article>
+          <div class="accent-cream" aria-hidden="true"></div>
+        </div>
+
+        {/* Row 4: Project 4 | Black | Paper */}
+        <div class="grid-row--4">
+          <article class="post-card">
+            <p class="post-meta">{projects[3].tags.join(' · ')}</p>
+            <h2 class="post-title"><a href={`/projects/${projects[3].slug}/`}>{projects[3].title}</a></h2>
+            <p class="post-desc">{projects[3].description}</p>
+            <div class="tag-row">
+              <a href={projects[3].liveUrl} target="_blank" rel="noopener" class="tag">Live &nearr;</a>
+            </div>
+          </article>
+          <div class="accent-black" aria-hidden="true"></div>
+          <div class="accent-paper" aria-hidden="true"></div>
+        </div>
+
+      </div>
+
+      {/* ── Footer ── */}
+      <footer class="grid-footer">
+        <span class="footer-attribution">Nathan Payne &middot; San Francisco</span>
+        <a href="/" class="footer-action">&larr; Back to Homepage</a>
+      </footer>
+    </div>
+  </main>
+</BaseLayout>

--- a/src/pages/projects/override/index.astro
+++ b/src/pages/projects/override/index.astro
@@ -125,9 +125,9 @@ const jsonLd = {
       <h2 id="override-note">Live link</h2>
       <p class="project-note"><a href="https://overridebroadway.com" target="_blank" rel="noopener">overridebroadway.com</a></p>
     </section>
-    <section class="project-section" aria-labelledby="override-related">
+    <section class="project-card" aria-labelledby="override-related">
       <h2 id="override-related">Related</h2>
-      <ul>
+      <ul class="project-checklist">
         <li><a href="/blog/six-prs-one-bug-agent-failure-modes/">Blog: Six PRs, One Bug—What AI Agents Actually Get Wrong</a></li>
         <li><a href="/projects/friends-and-family-billing/">Project: Friends &amp; Family Billing</a></li>
       </ul>

--- a/src/pages/projects/swipe-watch/index.astro
+++ b/src/pages/projects/swipe-watch/index.astro
@@ -125,9 +125,9 @@ const jsonLd = {
       <h2 id="swipe-note">Live link</h2>
       <p class="project-note"><a href="https://swipewatch.web.app" target="_blank" rel="noopener">swipewatch.web.app</a></p>
     </section>
-    <section class="project-section" aria-labelledby="swipe-related">
+    <section class="project-card" aria-labelledby="swipe-related">
       <h2 id="swipe-related">Related</h2>
-      <ul>
+      <ul class="project-checklist">
         <li><a href="/blog/six-prs-one-bug-agent-failure-modes/">Blog: Six PRs, One Bug—What AI Agents Actually Get Wrong</a></li>
         <li><a href="/projects/device-source-of-truth/">Project: Device Source of Truth</a></li>
       </ul>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -598,7 +598,7 @@ html, body {
   font-size: clamp(0.64rem, 0.74vw, 0.72rem);
   line-height: 1.45;
   letter-spacing: 0.10em;
-  color: rgba(17, 16, 13, 0.50);
+  color: rgba(17, 16, 13, 0.70);
   text-decoration: none;
   transition: color var(--motion-hover) var(--ease-standard);
 }


### PR DESCRIPTION
## Summary
- Fix Related sections on all 4 project pages: use `project-card` class (white bg) with `project-checklist` (accent-colored square bullets) instead of `project-section` (gradient bg, default bullets)
- Create `/projects/` index page with Mondrian grid layout matching the blog index pattern, linking to all 4 projects with descriptions and live links
- Update 404 page Projects link from `/projects/override/` to `/projects/`
- Darken blog callout link text from 50% to 70% opacity for better contrast against the label

Authoring-Agent: claude

## Self-Review
- **Correctness**: Related sections now use the same card styling as Project facts and Live link cards. Projects index follows the blog index pattern exactly (same grid classes, hero structure, footer).
- **Regression risk**: Low. Related section class change is cosmetic. New page adds a route. Blog callout is a single color value change.
- **Style**: Consistent with existing patterns. Projects index reuses blog-grid CSS classes.
- **Test coverage**: Build passes (9 pages). Visual verification via preview screenshots.
- **Security/dependency hygiene**: No new dependencies. External links use `rel="noopener"`.

## Test plan
- [ ] Verify Related section on project pages has white bg and colored square bullets
- [ ] Verify `/projects/` renders with all 4 projects in Mondrian grid
- [ ] Verify 404 "Projects" button links to `/projects/`
- [ ] Verify homepage blog callout link text is darker than the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)