### PR TITLE
Match blog callout link styling to stack items

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -598,7 +598,8 @@ html, body {
   font-size: clamp(0.64rem, 0.74vw, 0.72rem);
   line-height: 1.45;
   letter-spacing: 0.10em;
-  color: rgba(17, 16, 13, 0.70);
+  word-spacing: 0.05em;
+  color: rgba(17, 16, 13, 0.50);
   text-decoration: none;
   transition: color var(--motion-hover) var(--ease-standard);
 }


### PR DESCRIPTION
## Summary
- Change `.blog-callout-link` color from `rgba(17, 16, 13, 0.70)` to `rgba(17, 16, 13, 0.50)` to match `.stack-items`
- Add `word-spacing: 0.05em` to match `.stack-items`

Authoring-Agent: claude

## Self-Review
- **Correctness**: Inspected both computed styles — color, letter-spacing ratio, and word-spacing now match exactly.
- **Regression risk**: None — single CSS property change on one element.
- **Style**: Now consistent with the Stack ribbon text directly above it.
- **Test coverage**: Verified via `preview_inspect` comparison.
- **Security/dependency hygiene**: N/A.

## Test plan
- [ ] Visually confirm blog callout text matches Stack items text on homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)