### PR TITLE
Polish Related sections and add Back to Projects link

### DIFF
--- a/src/pages/projects/device-source-of-truth/index.astro
+++ b/src/pages/projects/device-source-of-truth/index.astro
@@ -68,6 +68,7 @@ const jsonLd = {
   actions={[
     { label: "View Live Product", href: "https://device-source-of-truth.web.app", external: true },
     { label: "View on GitHub", href: "https://github.com/nathanjohnpayne/device-source-of-truth", external: true },
+    { label: "Back to Projects", href: "/projects/" },
     { label: "Back to Homepage", href: "/" },
   ]}
   jsonLd={jsonLd}

--- a/src/pages/projects/friends-and-family-billing/index.astro
+++ b/src/pages/projects/friends-and-family-billing/index.astro
@@ -68,6 +68,7 @@ const jsonLd = {
   actions={[
     { label: "View Live Product", href: "https://friends-and-family-billing.web.app", external: true },
     { label: "View on GitHub", href: "https://github.com/nathanjohnpayne/friends-and-family-billing", external: true },
+    { label: "Back to Projects", href: "/projects/" },
     { label: "Back to Homepage", href: "/" },
   ]}
   jsonLd={jsonLd}

--- a/src/pages/projects/override/index.astro
+++ b/src/pages/projects/override/index.astro
@@ -68,6 +68,7 @@ const jsonLd = {
   actions={[
     { label: "View Live Product", href: "https://overridebroadway.com", external: true },
     { label: "View on GitHub", href: "https://github.com/nathanjohnpayne/overridebroadway", external: true },
+    { label: "Back to Projects", href: "/projects/" },
     { label: "Back to Homepage", href: "/" },
   ]}
   jsonLd={jsonLd}

--- a/src/pages/projects/swipe-watch/index.astro
+++ b/src/pages/projects/swipe-watch/index.astro
@@ -68,6 +68,7 @@ const jsonLd = {
   actions={[
     { label: "View Live Product", href: "https://swipewatch.web.app", external: true },
     { label: "View on GitHub", href: "https://github.com/nathanjohnpayne/swipewatch", external: true },
+    { label: "Back to Projects", href: "/projects/" },
     { label: "Back to Homepage", href: "/" },
   ]}
   jsonLd={jsonLd}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -964,11 +964,23 @@ body.blog-page {
 .project-checklist li::before {
   content: "";
   position: absolute;
-  top: 0.7em;
+  top: 0.5em;
   left: 0;
   width: 0.42rem;
   height: 0.42rem;
   background: var(--project-accent);
+}
+
+.project-card .project-checklist a {
+  color: inherit;
+  text-decoration: none;
+  font-size: clamp(0.9rem, 0.9rem + 0.08vw, 0.98rem);
+  line-height: 1.55;
+  transition: color var(--motion-hover) var(--ease-standard);
+}
+
+.project-card .project-checklist a:hover {
+  color: var(--project-accent);
 }
 
 .project-sidebar {


### PR DESCRIPTION
## Summary
- Add "Back to Projects" action button on all 4 project pages
- Align checklist bullet squares with first line of text (top 0.7em → 0.5em)
- Style Related card links: inherit color, match `project-note` font size, hover to accent color
- Remove default purple link styling from Related cards

Authoring-Agent: claude

## Self-Review
- **Correctness**: Bullet alignment and link styling verified via preview. Font size matches `project-note` exactly.
- **Regression risk**: Low. Bullet `top` change from 0.7em → 0.5em applies to all `.project-checklist` usage, which is only the "What the product does" lists and Related cards — both benefit from the alignment fix.
- **Style**: Hover effect uses `var(--project-accent)` matching the accent color system.
- **Test coverage**: Visual verification via preview screenshots.
- **Security/dependency hygiene**: N/A.

## Test plan
- [ ] Verify "Back to Projects" button on all project pages
- [ ] Verify Related card bullets align with first line of link text
- [ ] Verify Related links hover to accent color

🤖 Generated with [Claude Code](https://claude.com/claude-code)