### PR TITLE
Move blog callout to Connect, fix font/color/hover states

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -126,10 +126,6 @@ const homepageJsonLd = {
               <span class="stack-label">Stack</span>
               <span class="stack-items">React · TypeScript · Vite · Tailwind CSS · Firebase · Vanilla JS · Claude Code · Codex · Cursor</span>
             </div>
-            <div class="blog-callout">
-              <span class="blog-callout-label">From the Blog</span>
-              <a href="/blog/six-prs-one-bug-agent-failure-modes/" class="blog-callout-link">Six PRs, One Bug: What AI Agents Actually Get Wrong &rarr;</a>
-            </div>
           </div>
         </div>
       </article>
@@ -244,6 +240,10 @@ const homepageJsonLd = {
                 <span class="s-label">X</span>
                 <span class="s-arrow">→</span>
               </a>
+            </div>
+            <div class="blog-callout">
+              <span class="blog-callout-label">From the Blog</span>
+              <a href="/blog/six-prs-one-bug-agent-failure-modes/" class="blog-callout-link">Six PRs, One Bug: What AI Agents Actually Get Wrong &rarr;</a>
             </div>
           </div>
         </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -569,7 +569,8 @@ html, body {
 }
 
 .stack-items,
-.impact-items {
+.impact-items,
+.blog-callout-link {
   font-size: clamp(0.64rem, 0.74vw, 0.72rem);
   line-height: 1.45;
   letter-spacing: 0.10em;
@@ -594,17 +595,46 @@ html, body {
   color: rgba(17, 16, 13, 0.50);
 }
 
-.blog-callout-link {
+.content-inner .blog-callout-link {
   font-size: clamp(0.64rem, 0.74vw, 0.72rem);
-  line-height: 1.45;
-  letter-spacing: 0.10em;
-  word-spacing: 0.05em;
-  color: rgba(17, 16, 13, 0.50);
   text-decoration: none;
   transition: color var(--motion-hover) var(--ease-standard);
 }
 
 .blog-callout-link:hover {
+  color: var(--ink);
+}
+
+.panel--blue .blog-callout {
+  border-top-color: rgba(240, 244, 255, 0.18);
+}
+
+.panel--blue .blog-callout-label {
+  color: rgba(240, 244, 255, 0.55);
+}
+
+.panel--blue .blog-callout-link {
+  color: rgba(240, 244, 255, 0.55);
+}
+
+.panel--blue .blog-callout-link:hover {
+  color: rgba(240, 244, 255, 0.9);
+}
+
+/* When Connect panel is expanded, revert to dark text on cream bg */
+.panel--blue.is-open .blog-callout {
+  border-top-color: var(--rule);
+}
+
+.panel--blue.is-open .blog-callout-label {
+  color: rgba(17, 16, 13, 0.50);
+}
+
+.panel--blue.is-open .blog-callout-link {
+  color: rgba(17, 16, 13, 0.50);
+}
+
+.panel--blue.is-open .blog-callout-link:hover {
   color: var(--ink);
 }
 
@@ -981,6 +1011,7 @@ body.blog-page {
 
 .project-card .project-checklist a:hover {
   color: var(--project-accent);
+  text-decoration: underline;
 }
 
 .project-sidebar {
@@ -1220,6 +1251,17 @@ body.blog-page {
   letter-spacing: 0.14em;
   text-transform: uppercase;
   line-height: 1.4;
+}
+
+a.tag {
+  text-decoration: none;
+  color: inherit;
+  font-weight: 700;
+  transition: background var(--motion-hover) var(--ease-standard);
+}
+
+a.tag:hover {
+  background: rgba(17, 16, 13, 0.18);
 }
 
 /* ── Placeholder Cards (future posts) ── */


### PR DESCRIPTION
## Summary
- Move "From the Blog" callout from Vibe Coding panel to Connect panel
- Fix font size: `.content-inner a` was overriding the clamp (13.76px → 10.24px to match Scope items)
- Add `.is-open` overrides: dark gray text on cream bg (desktop expanded), light text on blue bg (mobile)
- Bold `Live ↗` links on Projects index (`a.tag` gets `font-weight: 700` + hover)
- Add `text-decoration: underline` to Related link hover (fixes FFB where `--project-accent` is invisible against text)

Authoring-Agent: claude

## Self-Review
- **Correctness**: Inspected computed styles — blog callout link and impact items both resolve to 10.24px. Desktop expanded and mobile views both verified via screenshots.
- **Regression risk**: Low. The `.content-inner .blog-callout-link` specificity override is scoped tightly. The `a.tag` styles only affect anchor tags with `.tag` class. The `.is-open` overrides match the existing pattern for panel state changes.
- **Style**: Color values match existing panel state patterns (`.panel--blue .connect-label`, `.panel--blue .social-row`).
- **Test coverage**: Visual verification via preview at desktop and mobile viewports.
- **Security/dependency hygiene**: N/A.

## Test plan
- [ ] Desktop: expand Connect panel → blog callout visible with dark gray text on cream bg
- [ ] Mobile: blog callout visible with light text on blue bg
- [ ] Projects index: Live ↗ links are bold with hover darkening
- [ ] FFB project: Related links show underline on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)