### PR TITLE
Polish breadcrumbs: link Projects, add hover states, normalize markup

### DIFF
--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -58,10 +58,10 @@ const {
       <header class="project-hero">
         <nav class="project-breadcrumbs" aria-label="Breadcrumb">
           <a href="/">Nathan Payne</a>
-          <span>/</span>
-          <span>Projects</span>
-          <span>/</span>
-          <span set:html={breadcrumbLabel} />
+          <span class="breadcrumb-sep">/</span>
+          <a href="/projects/">Projects</a>
+          <span class="breadcrumb-sep">/</span>
+          <span class="breadcrumb-current" set:html={breadcrumbLabel} />
         </nav>
         <p class="project-kicker">{kicker}</p>
         <h1 set:html={headline} />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -13,7 +13,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <div class="e-content">
         <nav class="breadcrumbs" aria-label="Breadcrumb">
           <a href="/">Nathan Payne</a>
-          <span>/</span>
+          <span class="breadcrumb-sep">/</span>
           <span>404</span>
         </nav>
         <h1>Page not found</h1>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -57,7 +57,7 @@ function readingTime(body: string | undefined): string {
       <header class="hero">
         <nav class="breadcrumbs" aria-label="Breadcrumb">
           <a href="/">Nathan Payne</a>
-          <span>/</span>
+          <span class="breadcrumb-sep">/</span>
           <span>Blog</span>
         </nav>
         <p class="kicker">AI &times; Product &times; Reality</p>

--- a/src/pages/projects/device-source-of-truth/index.astro
+++ b/src/pages/projects/device-source-of-truth/index.astro
@@ -33,6 +33,12 @@ const jsonLd = {
         {
           "@type": "ListItem",
           "position": 2,
+          "name": "Projects",
+          "item": "https://nathanpayne.com/projects/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
           "name": "Device Source of Truth",
           "item": "https://nathanpayne.com/projects/device-source-of-truth/"
         }

--- a/src/pages/projects/friends-and-family-billing/index.astro
+++ b/src/pages/projects/friends-and-family-billing/index.astro
@@ -33,6 +33,12 @@ const jsonLd = {
         {
           "@type": "ListItem",
           "position": 2,
+          "name": "Projects",
+          "item": "https://nathanpayne.com/projects/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
           "name": "Friends & Family Billing",
           "item": "https://nathanpayne.com/projects/friends-and-family-billing/"
         }

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -70,7 +70,7 @@ const jsonLd = {
       <header class="hero">
         <nav class="breadcrumbs" aria-label="Breadcrumb">
           <a href="/">Nathan Payne</a>
-          <span>/</span>
+          <span class="breadcrumb-sep">/</span>
           <span>Projects</span>
         </nav>
         <p class="kicker">AI &times; Product &times; Engineering</p>

--- a/src/pages/projects/override/index.astro
+++ b/src/pages/projects/override/index.astro
@@ -33,6 +33,12 @@ const jsonLd = {
         {
           "@type": "ListItem",
           "position": 2,
+          "name": "Projects",
+          "item": "https://nathanpayne.com/projects/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
           "name": "Override",
           "item": "https://nathanpayne.com/projects/override/"
         }

--- a/src/pages/projects/swipe-watch/index.astro
+++ b/src/pages/projects/swipe-watch/index.astro
@@ -33,6 +33,12 @@ const jsonLd = {
         {
           "@type": "ListItem",
           "position": 2,
+          "name": "Projects",
+          "item": "https://nathanpayne.com/projects/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
           "name": "Swipe Watch",
           "item": "https://nathanpayne.com/projects/swipe-watch/"
         }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -883,6 +883,14 @@ body.blog-page {
   text-decoration: none;
 }
 
+.project-breadcrumbs a:hover {
+  text-decoration: underline;
+}
+
+.project-breadcrumbs .breadcrumb-sep {
+  user-select: none;
+}
+
 .project-kicker {
   margin-bottom: calc(var(--su) * 0.9);
   padding-left: clamp(1rem, 2.2vw, 1.6rem);
@@ -1105,6 +1113,14 @@ body.blog-page {
 .breadcrumbs a {
   color: inherit;
   text-decoration: none;
+}
+
+.breadcrumbs a:hover {
+  text-decoration: underline;
+}
+
+.breadcrumbs .breadcrumb-sep {
+  user-select: none;
 }
 
 .kicker {
@@ -1683,6 +1699,7 @@ a.tag:hover {
 
 .blog-canvas-header .project-breadcrumbs a:hover {
   color: rgba(17, 16, 13, 0.62);
+  text-decoration: none;
 }
 
 .blog-canvas-header .breadcrumb-sep {


### PR DESCRIPTION
## Summary

- **#100:** Make "Projects" breadcrumb on project detail pages a functional link to `/projects/`
- **#101 + #102:** Add consistent `text-decoration: underline` hover state to all breadcrumb links site-wide (project detail, index, 404); blog canvas header retains its existing color-change hover
- **Consistency audit:** Normalize all separator `<span>` elements to use `breadcrumb-sep` class with `user-select: none`; add `breadcrumb-current` class to active item in ProjectLayout; fix Schema.org `BreadcrumbList` on all 4 project detail pages to include the missing "Projects" intermediate level

Closes #100, closes #101, closes #102

Authoring-Agent: claude

## Self-Review

- **Correctness:** All breadcrumb links verified working via dev server. Schema.org data now matches the 3-level visual breadcrumb (Home → Projects → Project Name). Blog post breadcrumbs (which already had hover via `.blog-canvas-header`) get an explicit `text-decoration: none` override to prevent the new base underline from stacking on top of the color-change hover.
- **Regression risk:** Low. Changes are limited to breadcrumb nav elements and their CSS. No layout, grid, or typography changes. The pre-existing `blog-responsive.test.js` failure (image width attribute) is unrelated.
- **Style:** Follows existing patterns — same CSS property ordering, same selector specificity approach, same class naming convention (`breadcrumb-sep`, `breadcrumb-current`).
- **Test coverage:** Build passes. All 10 non-flaky test files pass. Breadcrumb markup verified via accessibility tree snapshots and CSS inspection on dev server.
- **Security/dependency hygiene:** No new dependencies. No user input handling changes.

## Test plan

- [ ] Verify "Projects" breadcrumb links to `/projects/` on all 4 project detail pages
- [ ] Hover over breadcrumb links on project detail, blog index, projects index, and 404 pages — confirm underline appears
- [ ] Hover over breadcrumb links on a blog post page — confirm color darkens (no underline)
- [ ] Confirm breadcrumb separators are not selectable (user-select: none)
- [ ] Validate Schema.org breadcrumb JSON-LD includes 3 levels on project detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)