### PR TITLE
Homepage and projects page polish: hover, copy, footer, color

### DIFF
--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -87,7 +87,7 @@ const {
 
       <footer class="project-detail-footer">
         <p class="blog-footer-attribution">Nathan Payne · San Francisco</p>
-        <nav class="blog-footer-nav">
+        <nav class="blog-footer-nav" aria-label="Project footer navigation">
           <a class="project-action" href="/projects/">&larr; Back to Projects</a>
           <a class="project-action" href="/">Back to Homepage &rarr;</a>
         </nav>

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -84,6 +84,14 @@ const {
           <slot name="sidebar" />
         </aside>
       </div>
+
+      <footer class="project-detail-footer">
+        <p class="blog-footer-attribution">Nathan Payne · San Francisco</p>
+        <nav class="blog-footer-nav">
+          <a class="project-action" href="/projects/">&larr; Back to Projects</a>
+          <a class="project-action" href="/">Back to Homepage &rarr;</a>
+        </nav>
+      </footer>
     </article>
   </main>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -98,7 +98,7 @@ const homepageJsonLd = {
                   <a class="p-name p-name-link" href="/projects/device-source-of-truth/" aria-label="Read the Device Source of Truth project page">Device Source of Truth</a>
                   <span class="p-tag">Enterprise × Data</span>
                 </div>
-                <p>Disney has hundreds of partner devices across Disney+, Hulu, and ESPN—each with different hardware specs, DRM requirements, and codec support tracked across Airtable, Datadog, and spreadsheets. DST consolidates all of it into a single React + Firebase app with rules-based device scoring. Built for the partner engineering world I live in. <a href="https://device-source-of-truth.web.app" target="_blank" rel="noopener" class="p-link" aria-label="View the live Device Source of Truth app">Live ↗</a></p>
+                <p>A single web application for understanding partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN. <a href="https://device-source-of-truth.web.app" target="_blank" rel="noopener" class="p-link" aria-label="View the live Device Source of Truth app">Live ↗</a></p>
               </div>
               <div class="project-item">
                 <div class="p-head">

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -118,7 +118,7 @@ const jsonLd = {
               <a href={projects[2].liveUrl} target="_blank" rel="noopener" class="tag">Live &nearr;</a>
             </div>
           </article>
-          <div class="accent-cream" aria-hidden="true"></div>
+          <div class="accent-white" aria-hidden="true"></div>
         </div>
 
         {/* Row 4: Project 4 | Black | Paper */}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -477,6 +477,10 @@ html, body {
   line-height: 1.1;
 }
 
+.p-name-link:hover {
+  text-decoration: underline;
+}
+
 .p-tag {
   font-size: clamp(0.6rem, 0.75vw, 0.68rem);
   letter-spacing: 0.12em;
@@ -958,6 +962,16 @@ body.blog-page {
   padding: clamp(1.15rem, 3vw, 2.5rem);
 }
 
+.project-detail-footer {
+  padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.15rem, 3vw, 2.5rem);
+  border-top: 1px solid var(--rule);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
 .project-copy {
   display: grid;
   gap: 1.2rem;
@@ -1339,6 +1353,10 @@ a.tag:hover {
 
 .accent-paper {
   background: #DDE1E5;
+}
+
+.accent-white {
+  background: var(--paper);
 }
 
 /* Overflow accent blocks — decorative only, hidden on mobile */
@@ -2499,6 +2517,11 @@ a:focus-visible {
     order: -1;
   }
 
+  .project-detail-footer {
+    flex-direction: column;
+    text-align: center;
+  }
+
   .blog-meta-bar dl {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -2539,6 +2562,7 @@ a:focus-visible {
   .accent-yellow,
   .accent-black,
   .accent-paper,
+  .accent-white,
   .accent-overflow {
     display: none;
   }


### PR DESCRIPTION
## Summary

- **#98:** Add `text-decoration: underline` hover to Vibe Coding project links (`.p-name-link`)
- **#99:** Update Device Source of Truth description on homepage to concise one-liner
- **#103:** Add "Back to Projects" / "Back to Homepage" footer to all project detail pages, matching the blog post footer pattern
- **#104:** Change Swipe Watch row accent from gray (`--accent-gray`) to bright white (`--paper`) on the projects index page

Closes #98, closes #99, closes #103, closes #104

Authoring-Agent: claude

## Self-Review

- **Correctness:** All four changes verified in dev server preview. Hover rule confirmed in stylesheet. DST description text matches issue spec. Footer renders with correct links and attribution. Swipe Watch accent computed as `rgb(255, 255, 255)`.
- **Regression risk:** Low. CSS additions are additive (new hover rule, new class, new footer style). The DST copy change is a single paragraph replacement. The Swipe Watch class swap from `accent-cream` to `accent-white` only affects the projects page (blog index still uses `accent-cream` for its RSS block). `.accent-white` is included in the mobile `display: none` list for decorative accent blocks.
- **Style:** Footer reuses existing `blog-footer-attribution`, `blog-footer-nav`, and `project-action` classes. New `.project-detail-footer` mirrors `.blog-footer` layout properties. `.accent-white` follows the existing accent class naming convention.
- **Test coverage:** Build passes. Pre-existing `blog-responsive.test.js` image-width failure is unrelated.
- **Security/dependency hygiene:** No new dependencies. No user input handling.

## Test plan

- [ ] Hover over project name links in the Vibe Coding section on homepage — confirm underline appears
- [ ] Read DST description on homepage — confirm updated text
- [ ] Scroll to bottom of any project detail page — confirm footer with "Back to Projects" and "Back to Homepage" links
- [ ] View Swipe Watch row on /projects/ — confirm accent block is white, not gray

🤖 Generated with [Claude Code](https://claude.com/claude-code)