### PR TITLE
Resolve Astro Audit warnings, fix reading time for code-heavy posts

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -248,7 +248,7 @@ const jsonLd = {
       <footer class="blog-canvas-footer">
         <div class="blog-footer">
           <p class="blog-footer-attribution">{author} · San Francisco</p>
-          <nav class="blog-footer-nav">
+          <nav class="blog-footer-nav" aria-label="Blog footer navigation">
             <a class="project-action" href="/blog/">&larr; Back to Blog</a>
             <a class="project-action" href="/">Back to Homepage &rarr;</a>
           </nav>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -16,10 +16,13 @@ const { post } = Astro.props;
 // headings: { depth: number; slug: string; text: string }[]
 const { Content, headings } = await render(post);
 
-// Calculate reading time (avg 225 words per minute)
-const words = post.body?.split(/\s+/).length ?? 0;
-const minutes = Math.ceil(words / 225);
-const readingTime = `${minutes} min read`;
+// Calculate reading time: prose at 225 wpm, code blocks at ~30% weight
+const rawBody = post.body ?? '';
+const codeBlocks: string[] = [];
+const prose = rawBody.replace(/```[\s\S]*?```/g, (m) => { codeBlocks.push(m); return ' '; });
+const proseWords = prose.trim().split(/\s+/).filter(Boolean).length;
+const codeWords = codeBlocks.reduce((n, b) => n + b.split(/\s+/).filter(Boolean).length, 0);
+const readingTime = `${Math.max(1, Math.ceil((proseWords + codeWords * 0.3) / 225))} min read`;
 ---
 
 <BlogPost

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -37,8 +37,13 @@ function formatDate(date: Date): string {
 }
 
 function readingTime(body: string | undefined): string {
-  const words = body?.split(/\s+/).length ?? 0;
-  return `${Math.ceil(words / 225)} min`;
+  if (!body) return '1 min';
+  const codeBlocks: string[] = [];
+  const prose = body.replace(/```[\s\S]*?```/g, (m) => { codeBlocks.push(m); return ' '; });
+  const proseWords = prose.trim().split(/\s+/).filter(Boolean).length;
+  const codeWords = codeBlocks.reduce((n, b) => n + b.split(/\s+/).filter(Boolean).length, 0);
+  const minutes = Math.ceil((proseWords + codeWords * 0.3) / 225);
+  return `${Math.max(1, minutes)} min`;
 }
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -61,8 +61,8 @@ const homepageJsonLd = {
 >
   <main class="stage">
     <section class="mondrian" id="mondrian" aria-label="Interactive portfolio sections">
-      <article class="panel panel--red" data-panel="about" data-label="Nathan Payne" tabindex="0" role="region" aria-label="About Nathan Payne">
-        <div class="panel-label panel-label--name"><span>Nathan Payne</span></div>
+      <article class="panel panel--red" data-panel="about" data-label="Nathan Payne" role="region" aria-label="About Nathan Payne">
+        <div class="panel-label panel-label--name" tabindex="0" role="button" aria-label="Open Nathan Payne section"><span>Nathan Payne</span></div>
         <div class="panel-content">
           <div class="content-inner">
             <h1>Nathan Payne</h1>
@@ -86,8 +86,8 @@ const homepageJsonLd = {
 
       <div class="block block--white-a" aria-hidden="true"></div>
 
-      <article class="panel panel--yellow" data-panel="projects" data-label="Vibe Coding" tabindex="0" role="region" aria-label="Vibe coding projects">
-        <div class="panel-label">Vibe Coding</div>
+      <article class="panel panel--yellow" data-panel="projects" data-label="Vibe Coding" role="region" aria-label="Vibe coding projects">
+        <div class="panel-label" tabindex="0" role="button" aria-label="Open Vibe Coding section">Vibe Coding</div>
         <div class="panel-content">
           <div class="content-inner">
             <h2>Vibe Coding</h2>
@@ -132,8 +132,8 @@ const homepageJsonLd = {
 
       <div class="block block--white-b" aria-hidden="true"></div>
 
-      <article class="panel panel--black" data-panel="community" data-label="Community" tabindex="0" role="region" aria-label="Community organizing and fundraising">
-        <div class="panel-label">Community</div>
+      <article class="panel panel--black" data-panel="community" data-label="Community" role="region" aria-label="Community organizing and fundraising">
+        <div class="panel-label" tabindex="0" role="button" aria-label="Open Community section">Community</div>
         <div class="panel-content">
           <div class="content-inner">
             <h2>Giving &amp; Governing</h2>
@@ -167,8 +167,8 @@ const homepageJsonLd = {
       <div class="block block--gray-e" aria-hidden="true"></div>
       <div class="block block--gray-d" aria-hidden="true"></div>
 
-      <article class="panel panel--blue" data-panel="connect" data-label="Connect" tabindex="0" role="region" aria-label="Connect links">
-        <div class="panel-label">Connect</div>
+      <article class="panel panel--blue" data-panel="connect" data-label="Connect" role="region" aria-label="Connect links">
+        <div class="panel-label" tabindex="0" role="button" aria-label="Open Connect section">Connect</div>
         <div class="panel-content">
           <div class="content-inner">
             <h2>Connect</h2>


### PR DESCRIPTION
## Summary

- **#97:** Resolve all 4 Astro Audit "Invalid tabindex on non-interactive element" warnings by moving `tabindex="0"` from `<article>` panels to their `.panel-label` children with `role="button"` and `aria-label`. Also add `aria-label` to BlogPost footer nav for landmark disambiguation.
- **#18:** Fix reading time undercounting on code-heavy posts. Separate prose from fenced code blocks — prose at 225 wpm, code weighted at 30% (readers scan code rather than read word-by-word). Applied to both `blog/index.astro` and `blog/[slug].astro`.

Closes #97, closes #18

Authoring-Agent: claude

## Self-Review

- **Correctness:** Panel keyboard interaction preserved — `focusin` events bubble from the label to the panel, so `openPanel()` still fires. `keydown` on the panel still catches Enter/Space/Escape from focused children. Reading time formula tested: code blocks are extracted via `/```[\s\S]*?```/g`, counted separately at 30% weight, and combined with prose word count.
- **Regression risk:** Low. The tabindex move is purely structural — same DOM tree, same event delegation. The reading time change will adjust displayed times for code-heavy posts (more accurate, slightly different numbers than before). Posts with no code blocks are unaffected.
- **Style:** Follows existing patterns. No new files or abstractions — the reading time logic is kept inline in both locations since it's only 5 lines.
- **Test coverage:** Build passes. Verified in dev server: 0 articles with tabindex, 4 labels with tabindex/role/aria-label. Reading time renders correctly on both blog index and post detail.
- **Security/dependency hygiene:** No new dependencies. No user input handling.

## Test plan

- [ ] Open Astro Dev Toolbar → Audit panel on homepage — confirm 0 warnings
- [ ] Tab through homepage panels — confirm labels receive focus, Enter/Space opens panels, Escape closes
- [ ] Check blog post reading time on `/blog/six-prs-one-bug-agent-failure-modes/` — should reflect code-adjusted estimate
- [ ] Check blog index reading time matches the detail page
- [ ] Verify BlogPost footer nav has `aria-label="Blog footer navigation"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)