### PR TITLE
Fix ADC temp file cleanup bug in op-preflight.sh

### DIFF
--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -121,7 +121,7 @@ if [[ "$MODE" == "review" || "$MODE" == "all" ]]; then
   # op inject resolves all op:// references in a single process — one
   # biometric prompt covers both reads.
   tpl_file="$(mktemp "${TMPDIR:-/tmp}/op-preflight-tpl-XXXXXX")"
-  trap 'rm -f "$tpl_file" "${adc_tmpfile:-}"' EXIT
+  trap 'rm -f "$tpl_file"' EXIT
 
   cat > "$tpl_file" <<TPL
 REVIEWER_PAT={{ op://Private/${reviewer_item}/token }}


### PR DESCRIPTION
## Summary

Fixes a bug found during the security audit of the direct push tracked by #89. The EXIT trap in `op-preflight.sh` deleted the GCP ADC temp file when the script exited, making `GOOGLE_APPLICATION_CREDENTIALS` point to a non-existent file for the rest of the session.

**Root cause:** The trap at line 124 included `${adc_tmpfile:-}` for cleanup. When run as `eval "$(scripts/op-preflight.sh --mode all)"`, the subshell exits (firing the trap) before `eval` runs in the parent shell. The ADC file is deleted before any downstream deploy command can use it.

**Impact:** `--mode all` (the recommended default) silently breaks deploy credentials. `--mode deploy` alone was unaffected because the trap was only set inside the review block.

**Fix:** Remove `${adc_tmpfile:-}` from the trap. The ADC temp file persists for the session in `$TMPDIR` and is cleaned up by the OS.

## Security Audit Summary (#89)

Full audit of the direct push (security baseline + credential preflight):

| Area | Status | Details |
|---|---|---|
| `op-preflight.sh` PAT handling | **Good** | PATs passed via env vars (not files), template file cleaned up immediately, never logged |
| `op-preflight.sh` ADC handling | **Bug fixed** | EXIT trap deleted ADC temp file prematurely in `--mode all` |
| GitHub Actions SHA pinning | **Good** | All third-party actions pinned to full commit SHAs with version comments |
| Workflow permissions | **Good** | All 4 workflows declare explicit, minimally-scoped `permissions` blocks |
| Expression injection | **Low risk** | PR body consumed via `env:` block (correct pattern); all other interpolations use safe types (SHAs, PR numbers) |
| Secret handling | **Good** | Secrets passed through `env:` blocks, never echoed or interpolated into shell strings |
| SECURITY.md | **Good** | Present, directs to GitHub private vulnerability reporting |
| CODEOWNERS | **Good** | Covers all files + sensitive paths |
| dependabot.yml | **Good** | Monitors both `github-actions` and `npm` weekly, grouped updates |
| REVIEW_POLICY.md | **Good** | Phase 0 preflight documented, Template Usage section covers governance files + CodeRabbit |

No other issues requiring code changes were found.

Closes #89

Authoring-Agent: claude

## Self-Review

- **Correctness:** Verified the bug exists (ADC file MISSING after `--mode all`) and the fix works (ADC file EXISTS after fix). The template file cleanup (`$tpl_file`) is unaffected — it's still cleaned up by both the explicit `rm` at line 133 and the trap.
- **Regression risk:** None. The only change is removing 1 filename from the trap cleanup list.
- **Style:** Minimal 1-line change.
- **Test coverage:** Manually verified with `--mode all` and `--mode deploy`.
- **Security/dependency hygiene:** This IS the security audit — no new dependencies.

## Test plan

- [ ] `eval "$(scripts/op-preflight.sh --agent claude --mode all)" && test -f "$GOOGLE_APPLICATION_CREDENTIALS"` — ADC file should exist
- [ ] `eval "$(scripts/op-preflight.sh --agent claude --mode deploy)" && test -f "$GOOGLE_APPLICATION_CREDENTIALS"` — ADC file should exist
- [ ] `eval "$(scripts/op-preflight.sh --agent claude --mode review)"` — should not set GOOGLE_APPLICATION_CREDENTIALS

🤖 Generated with [Claude Code](https://claude.com/claude-code)