### PR TITLE
Make blog callout programmatic to always display newest post

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,9 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { getCollection } from 'astro:content';
+
+const latestPost = (await getCollection('blog', ({ data }) => !data.draft))
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())[0];
 
 const homepageJsonLd = {
   "@context": "https://schema.org",
@@ -241,10 +245,12 @@ const homepageJsonLd = {
                 <span class="s-arrow">→</span>
               </a>
             </div>
-            <div class="blog-callout">
-              <span class="blog-callout-label">From the Blog</span>
-              <a href="/blog/six-prs-one-bug-agent-failure-modes/" class="blog-callout-link">Six PRs, One Bug: What AI Agents Actually Get Wrong &rarr;</a>
-            </div>
+            {latestPost && (
+              <div class="blog-callout">
+                <span class="blog-callout-label">From the Blog</span>
+                <a href={`/blog/${latestPost.id}/`} class="blog-callout-link">{latestPost.data.title} &rarr;</a>
+              </div>
+            )}
           </div>
         </div>
       </article>


### PR DESCRIPTION
## Summary

- **#96:** Replace the hardcoded blog callout on the homepage with a dynamic query. Uses `getCollection('blog')` at build time to fetch the most recent non-draft post by date, then renders its title and slug. New posts automatically appear in the callout without manual homepage edits.

Closes #96

Authoring-Agent: claude

## Self-Review

- **Correctness:** Build produces the correct output — the callout renders the latest post's title and links to `/blog/{slug}/`. Added a guard (`{latestPost && (...)}`) so the callout gracefully hides if no posts exist.
- **Regression risk:** Minimal. The `getCollection` import and query are the same pattern used in `blog/index.astro`. The rendered HTML is structurally identical to the hardcoded version.
- **Style:** Follows existing Astro patterns. Query is inline in the frontmatter (3 lines), not a separate utility — same approach as the blog index page.
- **Test coverage:** Build passes. Verified rendered `dist/index.html` contains the correct post title and URL.
- **Security/dependency hygiene:** No new dependencies. `getCollection` is a built-in Astro API.

## Test plan

- [ ] Build and check `dist/index.html` — blog callout should show the latest post title
- [ ] Add a new blog post (draft: false, newer date) — rebuild — callout should update automatically
- [ ] Delete all blog posts — rebuild — callout should not render (no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)