### PR TITLE
fix: cache-bust OG image URLs for social platform freshness

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -47,6 +47,11 @@ const normalizedPathname = rawPathname === '/' || rawPathname.includes('.')
     : `${rawPathname}/`;
 const canonical = canonicalProp || new URL(normalizedPathname, Astro.site).href;
 const socialDescription = ogDescription || description;
+
+// Cache-bust OG image URLs so social platforms re-fetch after each deploy.
+// Rounded to the nearest minute for consistency across all pages in a single build.
+const buildTime = Math.floor(Date.now() / 60000).toString();
+const ogImageUrl = ogImage.includes('?') ? `${ogImage}&v=${buildTime}` : `${ogImage}?v=${buildTime}`;
 ---
 
 <!DOCTYPE html>
@@ -78,8 +83,8 @@ const socialDescription = ogDescription || description;
   <meta property="og:title" content={title} />
   <meta property="og:description" content={socialDescription} />
   <meta property="og:url" content={canonical} />
-  <meta property="og:image" content={ogImage} />
-  <meta property="og:image:secure_url" content={ogImage} />
+  <meta property="og:image" content={ogImageUrl} />
+  <meta property="og:image:secure_url" content={ogImageUrl} />
   <meta property="og:image:type" content="image/png" />
   <meta property="og:image:width" content={ogImageWidth} />
   <meta property="og:image:height" content={ogImageHeight} />
@@ -100,7 +105,7 @@ const socialDescription = ogDescription || description;
   <meta name="twitter:title" content={title} />
   <meta name="twitter:description" content={socialDescription} />
   <meta name="twitter:url" content={canonical} />
-  <meta name="twitter:image" content={ogImage} />
+  <meta name="twitter:image" content={ogImageUrl} />
   <meta name="twitter:image:width" content={ogImageWidth} />
   <meta name="twitter:image:height" content={ogImageHeight} />
   <meta name="twitter:image:alt" content={ogImageAlt} />


### PR DESCRIPTION
## Summary

- Append build-time timestamp (`?v=BUILD_TIME`) to all `og:image` and `twitter:image` meta tag URLs so social platforms re-fetch OG images after each deploy instead of serving stale cached versions
- Centralized in `BaseLayout.astro` so all pages (homepage, blog posts, projects) automatically get cache-busted OG image URLs
- Fixes the "showing cached image" symptom from #123

**Note:** The "empty page" symptom in LinkedIn Post Inspector is caused by Cloudflare bot protection blocking social media crawlers — that requires a Cloudflare WAF exception rule (infrastructure change, not code). See #123 for details.

Authoring-Agent: claude

## Self-Review

- **Correctness:** Build-time `Date.now()` rounded to the nearest minute ensures consistent `?v=` values across all pages in a single build. Each new deploy produces a new value, busting social platform caches.
- **Regression risk:** Low. Only modifies meta tag URLs in the HTML `<head>`. No functional, visual, or behavioral changes to the site. OG image files themselves are unchanged.
- **Style:** Follows existing frontmatter computation patterns in BaseLayout.astro.
- **Test coverage:** Verified via `npm run build` — all 17 pages build successfully, OG meta tags in built HTML contain `?v=` parameter, and the value is consistent across pages.
- **Security/dependency hygiene:** No new dependencies. No user input involved — the cache-bust value is a static build-time constant.

## Test plan

- [x] `npm run build` succeeds (17 pages, 8 OG images)
- [x] Built HTML contains `?v=BUILD_TIME` in `og:image`, `og:image:secure_url`, and `twitter:image` meta tags
- [x] Value is consistent across homepage, blog post, and project pages
- [ ] After deploy, LinkedIn Post Inspector shows updated OG images (blocked by Cloudflare — see #123)

🤖 Generated with [Claude Code](https://claude.com/claude-code)