### PR TITLE
feat(projects): expand narratives, rebuild metadata strip, add stack line

### DIFF
--- a/specs/project-pages.md
+++ b/specs/project-pages.md
@@ -40,9 +40,10 @@ githubUrl: "https://github.com/you/repo"
 tags: ["Tag1", "Tag2", "Tag3"]
 metadata:
   domain: "Domain × Subdomain"
-  format: "What it's built with"
+  format: "Product-type label (e.g., Financial operating system)"
   focus: "What it does in a few words"
   status: "Live product"
+stack: "React · TypeScript · Vite · Firebase · Vitest"
 related:
   - label: "Blog: Related Post Title"
     href: "/blog/related-post-slug/"
@@ -71,9 +72,10 @@ draft: false
 | `githubUrl` | string | yes | URL for "View on GitHub" CTA |
 | `tags` | string[] | yes | Category/technology tags |
 | `metadata.domain` | string | yes | Metadata strip: domain value |
-| `metadata.format` | string | yes | Metadata strip: format/tech value |
+| `metadata.format` | string | yes | Metadata strip: product-type label (e.g., "Internal platform tool"). The tech stack lives in the separate `stack` field — this field is for product category |
 | `metadata.focus` | string | yes | Metadata strip: focus area value |
 | `metadata.status` | string | yes | Metadata strip: project status |
+| `stack` | string | no | Tech stack values separated by ` · ` (e.g., `"React · TypeScript · Vite · Firebase · Vitest"`). Rendered as a figcaption below the screenshot. Optional — projects without a stack field render without the caption |
 | `related` | array | no | Related links with `label` and `href` |
 | `draft` | boolean | no | `true` to exclude from builds (default: `false`) |
 
@@ -103,27 +105,29 @@ Bullet lists get square markers colored with `--project-accent`. Horizontal rule
 
 ## Layout Variants
 
-The `screenshotAspect` field controls which layout renders.
+Every project page uses the same `.metadata-surface` container, which wraps a 4-column horizontal metadata strip above a `<figure class="project-screenshot">` element that holds the image and (optionally) a `<figcaption class="project-stack">` caption below it. The `screenshotAspect` field controls only how the figure sizes its image — the metadata strip itself is always identical across projects.
 
 ### Wide (`screenshotAspect: "wide"`)
 
-Used for desktop web app screenshots. The metadata strip (4-column, single row) sits above a full-width screenshot, both wrapped in a single gradient surface with dotted internal dividers.
+Used for desktop web app screenshots. The figure spans the full width of the gradient surface; the image is bordered and rounded, and the stack caption (if present) sits flush left directly below it at the same width.
 
 **Projects using this**: Override, Device Source of Truth, Friends & Family Billing.
 
 ### Narrow (`screenshotAspect: "narrow"`)
 
-Used for phone/mobile screenshots. The metadata strip (2×2 grid) sits above a centered phone image, both in a single gradient surface. The phone image sits flush against the bottom of the card.
+Used for phone/mobile screenshots. The figure's inner wrapper (`.project-screenshot__inner`) is constrained to `max-width: 320px` (280px at the tablet breakpoint) and centered horizontally within the gradient surface. The stack caption inherits the same max-width constraint via the `.project-screenshot--narrow .project-stack` selector, so it aligns to the phone screenshot's left edge rather than the content container's. The phone image is rounded on all four corners and has sufficient bottom padding so the transition to the `Overview` heading below feels intentional.
 
 **Projects using this**: Swipe Watch.
 
 ### Responsive behavior
 
-| Breakpoint | Wide layout | Narrow layout |
-|------------|------------|---------------|
-| Desktop (>768px) | 4-column metadata strip above full-width screenshot | 2×2 metadata grid above centered phone |
-| Tablet (≤768px) | Metadata collapses to 2×2 grid | Same as desktop (already stacked) |
-| Phone (≤480px) | Metadata collapses to single column | Metadata collapses to single column |
+| Breakpoint | Metadata strip | Wide screenshot | Narrow screenshot |
+|------------|----------------|-----------------|-------------------|
+| Desktop (>768px) | 4-column horizontal row | Full-width image with stack caption flush left below | Centered 320px phone image with stack caption aligned to the image's left edge |
+| Tablet (≤768px) | Collapses to 2×2 grid | Full-width image (unchanged) | Inner wrapper and stack caption both narrow to 280px; alignment preserved |
+| Phone (≤480px) | Collapses to single column | Full-width image (unchanged) | Inner wrapper and stack caption stay at the tablet 280px cap; natural wrapping |
+
+The `.metadata-strip--grid-2x2` variant from the previous architecture has been removed — the metadata strip no longer varies by screenshot aspect. Wide and narrow differ only in how the figure sizes the image.
 
 ---
 
@@ -167,14 +171,21 @@ The layout sets three custom properties from frontmatter:
 ### Template chain
 
 ```
-[slug].astro → ProjectLayout.astro → { HeroWide | HeroNarrow } + MetadataStrip
+[slug].astro
+  → ProjectLayout.astro
+      → { HeroWide | HeroNarrow }
+      → .metadata-surface
+          → MetadataStrip
+          → <figure class="project-screenshot">
+              → .project-screenshot__inner → <img>
+              → <figcaption class="project-stack"> (optional, from the `stack` field)
 ```
 
-- **`src/pages/projects/[slug].astro`**: Dynamic route. Calls `getStaticPaths()` from the projects collection, generates JSON-LD, passes all frontmatter to `ProjectLayout`.
-- **`src/layouts/ProjectLayout.astro`**: Sets CSS custom properties on the shell. Conditionally renders `HeroWide` or `HeroNarrow` based on `screenshotAspect`. Always renders `MetadataStrip` with the screenshot.
-- **`src/components/HeroWide.astro`**: Hero header for wide-layout projects (no screenshot—screenshot is in MetadataStrip).
-- **`src/components/HeroNarrow.astro`**: Hero header for narrow-layout projects (no screenshot—screenshot is in MetadataStrip).
-- **`src/components/MetadataStrip.astro`**: Unified metadata + screenshot surface. Renders metadata grid (4-col or 2×2) on top, screenshot below, all in one gradient card with dotted internal dividers.
+- **`src/pages/projects/[slug].astro`**: Dynamic route. Calls `getStaticPaths()` from the projects collection, generates JSON-LD, passes all frontmatter to `ProjectLayout`. Forwards the optional `stack` field through `stack={data.stack}`.
+- **`src/layouts/ProjectLayout.astro`**: Sets CSS custom properties on the shell. Conditionally renders `HeroWide` or `HeroNarrow` based on `screenshotAspect`. Owns the `.metadata-surface` container that wraps `MetadataStrip` and the `<figure class="project-screenshot">`. The figure is rendered here (not in `MetadataStrip`) and contains the `<img>` plus a conditional `<figcaption class="project-stack">` when `stack` is present. The figcaption is a direct child of `<figure>` per HTML5 semantic rules.
+- **`src/components/HeroWide.astro`**: Hero header for wide-layout projects. No screenshot — the screenshot is rendered by `ProjectLayout` below the hero.
+- **`src/components/HeroNarrow.astro`**: Hero header for narrow-layout projects. No screenshot — same as `HeroWide`, the screenshot is rendered by `ProjectLayout` below the hero.
+- **`src/components/MetadataStrip.astro`**: Strip-only — four `<dt>`/`<dd>` pairs for domain, format, focus, and status. Does not own the screenshot; does not accept `screenshotSrc`/`screenshotAlt`/`screenshotAspect` props. The strip is always rendered as a single 4-column horizontal row on desktop and collapses responsively (2-column at ≤768px, 1-column at ≤480px) via `.metadata-strip--grid-4` media queries.
 
 ### Content collection schema
 
@@ -200,8 +211,8 @@ const { Content } = await render(project);
 | Project title | Large serif (clamp 2.4–5.1rem) | Roman | Primary |
 | Description | 16–17px serif | Roman | Primary |
 | CTA buttons | ~14px | Uppercase, 0.14em tracking | Primary, accent fill on hover |
-| Metadata labels | 10–11px | Uppercase, 0.16em tracking | Tertiary (0.4 opacity) |
-| Metadata values | 14–15px | Roman | Primary |
+| Metadata labels | 10–11px | Uppercase, 0.16em tracking | Tertiary (0.62 opacity) — also used for `.project-stack__label` |
+| Metadata values | 14–15px | Roman | Primary — also used for `.project-stack__value` |
 | Section headings | 22–23px | Serif italic | Primary |
 | "Related" heading | 16–18px | Serif italic | Secondary (0.72 opacity) |
 | Body text | 16px | Roman | Primary, line-height 1.65 |
@@ -227,9 +238,9 @@ src/content.config.ts              Collection schema (Zod)
 src/pages/projects/[slug].astro    Dynamic route + JSON-LD
 src/pages/projects/index.astro     Project index grid
 src/layouts/ProjectLayout.astro    Layout wrapper (CSS props, hero, metadata, footer)
-src/components/HeroWide.astro      Wide hero header
-src/components/HeroNarrow.astro    Narrow hero header
-src/components/MetadataStrip.astro Metadata + screenshot surface
-src/styles/global.css              All project page styles
+src/components/HeroWide.astro      Wide hero header (no screenshot)
+src/components/HeroNarrow.astro    Narrow hero header (no screenshot)
+src/components/MetadataStrip.astro 4-column metadata strip (domain/format/focus/status)
+src/styles/global.css              All project page styles (.metadata-strip, .project-screenshot, .project-stack)
 public/images/projects/            Hero screenshots
 ```

--- a/specs/project-pages.md
+++ b/specs/project-pages.md
@@ -1,3 +1,10 @@
+---
+spec_id: project-pages
+title: Project Pages
+tested: false
+reason: "Smoke tests for project page routes and rendering are tracked in issue #156 and will ship in a follow-up PR."
+---
+
 # Project Pages
 
 Specification for the content-collection-driven project detail pages.

--- a/src/components/MetadataStrip.astro
+++ b/src/components/MetadataStrip.astro
@@ -4,35 +4,26 @@ interface Props {
   format: string;
   focus: string;
   status: string;
-  screenshotSrc: string;
-  screenshotAlt?: string;
-  screenshotAspect: 'wide' | 'narrow';
 }
 
-const { domain, format, focus, status, screenshotSrc, screenshotAlt, screenshotAspect } = Astro.props;
-const isNarrow = screenshotAspect === 'narrow';
+const { domain, format, focus, status } = Astro.props;
 ---
 
-<div class={`metadata-surface ${isNarrow ? 'metadata-surface--narrow' : 'metadata-surface--wide'}`}>
-  <dl class={`metadata-strip ${isNarrow ? 'metadata-strip--grid-2x2' : 'metadata-strip--grid-4'}`}>
-    <div class="metadata-strip__item">
-      <dt>Domain</dt>
-      <dd>{domain}</dd>
-    </div>
-    <div class="metadata-strip__item">
-      <dt>Format</dt>
-      <dd>{format}</dd>
-    </div>
-    <div class="metadata-strip__item">
-      <dt>Focus</dt>
-      <dd>{focus}</dd>
-    </div>
-    <div class="metadata-strip__item">
-      <dt>Status</dt>
-      <dd>{status}</dd>
-    </div>
-  </dl>
-  <div class="metadata-surface__screenshot">
-    <img src={screenshotSrc} alt={screenshotAlt || 'Product screenshot'} loading="eager" />
+<dl class="metadata-strip metadata-strip--grid-4">
+  <div class="metadata-strip__item">
+    <dt>Domain</dt>
+    <dd>{domain}</dd>
   </div>
-</div>
+  <div class="metadata-strip__item">
+    <dt>Format</dt>
+    <dd>{format}</dd>
+  </div>
+  <div class="metadata-strip__item">
+    <dt>Focus</dt>
+    <dd>{focus}</dd>
+  </div>
+  <div class="metadata-strip__item">
+    <dt>Status</dt>
+    <dd>{status}</dd>
+  </div>
+</dl>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -24,6 +24,7 @@ const projects = defineCollection({
       focus: z.string(),
       status: z.string(),
     }),
+    stack: z.string().optional(),
     related: z.array(z.object({
       label: z.string(),
       href: z.string(),

--- a/src/content/projects/device-source-of-truth.md
+++ b/src/content/projects/device-source-of-truth.md
@@ -42,7 +42,7 @@ Device Source of Truth consolidates all of it into one system. The product impor
 
 ## How it was built
 
-Device Source of Truth started from a "Starting Over" commit after an initial scaffold was scrapped, and grew to 210 commits across a purpose-built data platform on React, TypeScript, Vite, and Firebase.
+Device Source of Truth started from a "Starting Over" commit after an initial scaffold was scrapped, and grew—well past two hundred commits—into a purpose-built data platform on React, TypeScript, Vite, and Firebase.
 
 The first serious engineering arc was contract alignment. An early commit fixed client/server misalignments across 14 integration points, followed by a contract-hardening effort (DST-TDI-001) that introduced shared Zod schemas and typed DTOs in a `@dst/contracts` monorepo package. The result is that every device import, mutation, and API response now validates against a single source of truth—the kind of invariant that matters most when an AI agent is writing both sides of the wire.
 

--- a/src/content/projects/device-source-of-truth.md
+++ b/src/content/projects/device-source-of-truth.md
@@ -1,7 +1,7 @@
 ---
 title: "Device Source of Truth"
 slug: "device-source-of-truth"
-description: "A single web application—designed and shipped with AI agents—for understanding partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN."
+description: "A single web application for understanding partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN."
 kicker: "AI × Enterprise × Data"
 order: 2
 screenshotAspect: "wide"
@@ -15,9 +15,10 @@ githubUrl: "https://github.com/nathanjohnpayne/device-source-of-truth"
 tags: ["Enterprise", "Data", "React", "Firebase"]
 metadata:
   domain: "Enterprise × Data"
-  format: "React + Firebase web app"
+  format: "Internal platform tool"
   focus: "Partner platforms and device support"
   status: "Live product"
+stack: "React · TypeScript · Vite · Firebase · Vitest"
 related:
   - label: "Blog: Six PRs, One Bug—What AI Agents Actually Get Wrong"
     href: "/blog/six-prs-one-bug-agent-failure-modes/"
@@ -27,19 +28,32 @@ related:
 
 ## Overview
 
-Device Source of Truth brings together the partner-device information that usually ends up scattered across Airtable, Datadog, and spreadsheets. The goal is simple: give teams one place to understand the hardware, DRM, and codec realities behind Disney+, Hulu, and ESPN device support.
+Disney supports streaming on hundreds of partner devices—PlayStation, Xbox, Amazon Vega OS, smart TVs, set-top boxes—each with its own hardware specs, DRM requirements, codec support, and ADK version. The information that describes those devices lives across Airtable, Datadog, partner-submitted questionnaires, and spreadsheets maintained by different teams. When a platform question comes up—can this device support Dolby Vision? Is that partner on a current ADK?—the answer often depends on who you ask and which spreadsheet they last updated.
 
-Instead of treating device knowledge as loose operational memory, the product turns it into a structured system that can be reviewed, updated, and shared with confidence.
+Device Source of Truth consolidates all of it into one system. The product imports device data from multiple sources, normalizes it against a shared schema, and makes it queryable and auditable. Instead of treating device knowledge as loose operational memory, it turns it into a structured record that can be reviewed, updated, and shared with confidence.
 
 ## What the product does
 
-- Consolidates fragmented partner-device records into one inventory.
-- Tracks hardware specifications, DRM requirements, and codec support in a single model.
-- Applies rules-based device scoring to make prioritization and compatibility easier to reason about.
-- Creates a shared reference point for partner-platform conversations that would otherwise depend on scattered spreadsheets.
+- Imports device data from partner-submitted questionnaires, CSV exports (AllModels, partner key mappings, telemetry), and manual entry—with AI-assisted extraction of structured specs from 350-question Excel questionnaires, including batching, rate-limit handling, and per-device retry.
+- Normalizes ADK version strings and validates live versions against a version mapping registry, flagging devices running outdated or unrecognized builds.
+- Tracks telemetry freshness with a dashboard badge showing the actual import time range, so teams can see how current the data is at a glance.
+- Manages partner relationships through an alias registry with contextual resolution, automatic partner creation from CSV imports, and a partner key registry with import history.
+- Surfaces actionable alerts—pagination-aware, dismissible, with resolution paths that link directly to device registration or partner key creation.
+
+## How it was built
+
+Device Source of Truth started from a "Starting Over" commit after an initial scaffold was scrapped, and grew to 210 commits across a purpose-built data platform on React, TypeScript, Vite, and Firebase.
+
+The first serious engineering arc was contract alignment. An early commit fixed client/server misalignments across 14 integration points, followed by a contract-hardening effort (DST-TDI-001) that introduced shared Zod schemas and typed DTOs in a `@dst/contracts` monorepo package. The result is that every device import, mutation, and API response now validates against a single source of truth—the kind of invariant that matters most when an AI agent is writing both sides of the wire.
+
+The most complex feature arc was the questionnaire intake pipeline. Disney's partner device certification uses an Excel-based technical questionnaire with 350+ questions across 15 sections, and DST needed to ingest these, extract structured specs from free-text answers, and map them to the normalized device model. The pipeline that emerged (DST-047 through DST-055) runs AI-assisted extraction with mandatory cost disclosure, 30-pair batch chunking for rate-limit safety, real-time per-device status with retry, and a multi-step admin review workflow. The extraction was originally fire-and-forget; a later commit replaced it with a Cloud Tasks queue for retry safety and stale-clock recovery.
+
+Like the rest of the portfolio, DST uses the multi-agent code review pipeline first developed for [Override](/projects/override/)—machine user reviewers, CodeRabbit with domain-specific guidance, and the two-strike rule on bug fixes.
 
 ## Why it matters
 
-This project was built for the partner-engineering world I work in. When a platform question comes up, the cost of uncertainty is immediate: support burden grows, launch conversations slow down, and decision quality drops. Device Source of Truth treats that ambiguity as a product problem instead of an inevitable operational tax.
+When Amazon launches Vega OS and replaces the Android-based Fire TV stack, the first question is which devices are affected and what their certification status is. When a partner submits a new questionnaire, someone has to extract the specs, map them to known devices, and flag anything that doesn't match. When an ADK version goes end-of-life, someone has to know which partners are still running it.
 
-Built with React and Firebase, the emphasis is not just on storing data but on turning device knowledge into something navigable and durable enough to support real product and platform decisions.
+Those are all answerable questions—but before DST, answering them meant cross-referencing three or four data sources maintained by different people on different cadences. The cost of uncertainty isn't abstract: support tickets increase, launch timelines slip, and partner conversations happen without a shared factual foundation.
+
+Device Source of Truth treats that ambiguity as a product problem. The questionnaire pipeline automates the most labor-intensive part of the certification workflow. The version registry flags stale ADK builds. The telemetry freshness badge tells you whether you're looking at data from last week or last quarter. This is the partner-engineering work I spend my days on at Disney, and DST is the tool I wanted to exist before I sat down to build it.

--- a/src/content/projects/friends-and-family-billing.md
+++ b/src/content/projects/friends-and-family-billing.md
@@ -1,7 +1,7 @@
 ---
 title: "Friends & Family Billing"
 slug: "friends-and-family-billing"
-description: "A cloud-synced billing tool—built end-to-end with AI agents—that turns recurring shared costs into clear invoices, payment tracking, and shareable summaries."
+description: "A cloud-synced billing tool that turns recurring shared costs into clear invoices, payment tracking, and shareable summaries."
 kicker: "AI × Utility × Finance"
 order: 4
 screenshotAspect: "wide"
@@ -15,9 +15,10 @@ githubUrl: "https://github.com/nathanjohnpayne/friends-and-family-billing"
 tags: ["Utility", "Finance", "React", "Firebase"]
 metadata:
   domain: "Utility × Finance"
-  format: "Cloud-synced web application"
+  format: "Household coordination tool"
   focus: "Shared subscriptions and recurring group expenses"
   status: "Live product"
+stack: "React · TypeScript · Vite · Firebase · Vitest"
 related:
   - label: "Blog: Six PRs, One Bug—What AI Agents Actually Get Wrong"
     href: "/blog/six-prs-one-bug-agent-failure-modes/"
@@ -27,19 +28,32 @@ related:
 
 ## Overview
 
-Friends & Family Billing is built around a familiar problem: shared subscriptions and recurring group expenses are easy to agree to and surprisingly messy to settle. Costs renew on different cadences, responsibilities drift over time, and nobody wants to manually rebuild the math every billing cycle.
+My husband and I split T-Mobile, Apple One, and 1Password across a household of eight people. Every year, the same thing happened: someone would ask how much they owed, and I'd open a spreadsheet, re-derive the math from three different billing cadences, and text them a number. Then someone else would ask, and I'd do it again.
 
-The product turns that recurring coordination into a clearer annual workflow.
+Friends & Family Billing exists because that coordination problem—simple math made annoying by repetition, shared responsibility, and the social awkwardness of asking for money—is a product problem, not a spreadsheet problem. The tool turns recurring shared costs into a system that computes what everyone owes, tracks who has paid, and generates a shareable summary that anyone in the household can check without asking me.
 
 ## What the product does
 
-- Organizes monthly and annual shared costs for households and friend groups.
-- Converts those recurring expenses into clear annual invoices.
-- Tracks who has paid, what is still outstanding, and what each person owes.
-- Generates shareable summaries so payment status is easy to communicate.
+- Organizes monthly and annual shared costs with per-bill frequency toggling, derived amount previews, and a money integrity layer that flags calculation drift.
+- Builds annual invoices with member name tokens, customizable email templates, and a live preview that renders exactly what the recipient will see.
+- Tracks payments with a settlement board showing per-member status, a three-state balance model (outstanding, partial, settled), and a payment edit flow with audit trail.
+- Generates shareable summaries via token-scoped links—each link carries the recipient's name, bill breakdown, and payment methods, accessible without login.
+- Supports dispute management with lifecycle-stage email notifications, evidence attachments, and resolution workflows with share-page integration.
+
+## How it was built
+
+Friends & Family Billing is the oldest and most developed project in the portfolio—384 commits across a full architecture migration from a vanilla JavaScript single-page app to a React, Vite, and Vitest stack on Firebase.
+
+The migration happened in six numbered phases rather than a single rewrite. Phase 0 scaffolded Vite, React, and Vitest alongside the legacy build. Phases 1 through 2c ported the shell, navigation, and core views—members, bills, settlement board, invoicing, review requests—with the two apps coexisting during the transition. Phase 4 cut over fully, deleted the vanilla JS, ported the share page, and added code splitting. The legacy app wasn't thrown away in one commit; it was extracted, wrapped, and replaced view by view.
+
+The most expensive feature was the invoice template editor. The original plaintext editor with `%token%` markers worked until it didn't—Preview showed one thing, the sent email showed another, and the editor showed a third. The TipTap WYSIWYG migration (PR #144) was supposed to fix this, but it preserved the old markdown bridge, creating three divergent rendering paths. Six PRs across twenty hours failed to fix the parity bug. The seventh PR—prompted as a failed-fix investigation rather than another incremental patch—removed the bridge entirely and unified Preview and email onto a single canonical renderer.
+
+Like the rest of the portfolio, FFB runs on the multi-agent code review pipeline first developed for [Override](/projects/override/)—and in many ways it pressure-tested that system before I had it fully nailed down.
 
 ## Why it matters
 
-The product is less about accounting complexity and more about social clarity. Shared money can create friction even when the amounts are small. Friends & Family Billing reframes that awkwardness as a straightforward coordination workflow.
+The product is less about accounting complexity and more about social clarity. Shared money creates friction even when the amounts are small—not because the math is hard, but because asking someone to pay feels awkward, and checking whether someone has paid feels intrusive. Friends & Family Billing reframes that dynamic as a coordination workflow where the system does the asking and the tracking, and the person who set it up doesn't have to be the enforcer.
 
-Cloud sync is central to the idea. The value of the tool comes from keeping everyone aligned on the same current record, not from emailing around static summaries or rebuilding the numbers in a spreadsheet.
+Cloud sync is central to the idea. The share page means a household member can check their own balance, see exactly how it was calculated, and find the payment methods—without texting me. That self-service loop is the real product. The invoicing, settlement tracking, and dispute management are all in service of the same goal: removing me from the middle of a recurring conversation that doesn't need a human intermediary.
+
+It's also the project that produced the ["Six PRs, One Bug"](/blog/six-prs-one-bug-agent-failure-modes/) blog post—a twenty-hour debugging arc on the invoice template parity bug that taught me more about AI agent failure modes than any other piece of work in the portfolio. The household coordination tool is what the build produced. The case study is what the debugging produced.

--- a/src/content/projects/friends-and-family-billing.md
+++ b/src/content/projects/friends-and-family-billing.md
@@ -42,7 +42,7 @@ Friends & Family Billing exists because that coordination problem—simple math 
 
 ## How it was built
 
-Friends & Family Billing is the oldest and most developed project in the portfolio—384 commits across a full architecture migration from a vanilla JavaScript single-page app to a React, Vite, and Vitest stack on Firebase.
+Friends & Family Billing is the oldest and most developed project in the portfolio—well over four hundred commits across a full architecture migration from a vanilla JavaScript single-page app to a React, Vite, and Vitest stack on Firebase.
 
 The migration happened in six numbered phases rather than a single rewrite. Phase 0 scaffolded Vite, React, and Vitest alongside the legacy build. Phases 1 through 2c ported the shell, navigation, and core views—members, bills, settlement board, invoicing, review requests—with the two apps coexisting during the transition. Phase 4 cut over fully, deleted the vanilla JS, ported the share page, and added code splitting. The legacy app wasn't thrown away in one commit; it was extracted, wrapped, and replaced view by view.
 

--- a/src/content/projects/override.md
+++ b/src/content/projects/override.md
@@ -1,7 +1,7 @@
 ---
 title: "Override"
 slug: "override"
-description: "A Broadway-focused financial operating system—built with AI agents—for structuring capitalization, modeling investor returns, and replacing spreadsheet workflows with live, shareable deals."
+description: "A Broadway-focused financial operating system for structuring capitalization, modeling investor returns, and replacing spreadsheet workflows with live, shareable deals."
 kicker: "AI × Finance × Theater"
 order: 1
 screenshotAspect: "wide"
@@ -15,9 +15,10 @@ githubUrl: "https://github.com/nathanjohnpayne/overridebroadway"
 tags: ["Finance", "Theater", "React", "Firebase"]
 metadata:
   domain: "Finance × Theater"
-  format: "Broadway finance web application"
+  format: "Financial operating system"
   focus: "Capitalization, ownership, and investor workflows"
   status: "Live product"
+stack: "Next.js · TypeScript · Firebase · Vitest"
 related:
   - label: "Blog: Six PRs, One Bug—What AI Agents Actually Get Wrong"
     href: "/blog/six-prs-one-bug-agent-failure-modes/"
@@ -27,19 +28,30 @@ related:
 
 ## Overview
 
-Override applies product thinking to one of the most document-heavy operating environments I know: Broadway finance. Capitalization plans, ownership details, investor updates, and deal materials often move through spreadsheets and PDFs that are difficult to maintain once a production is live.
+I invest in Broadway productions. The first time I wired money for a show, I received a PDF term sheet, an Excel cap table, and a subscription agreement by email. Three months later, the cap table had drifted from the term sheet. Nobody was wrong—the spreadsheet just wasn't a system. It was a snapshot that stopped being maintained the moment the production went live.
 
-The project reframes that work as a product workflow instead of a file-management problem.
+Override exists because I wanted the financial layer of a Broadway production to work like a product: structured, auditable, and shareable without requiring someone to rebuild a spreadsheet every time an investor asks a question.
 
 ## What the product does
 
-- Structures a production's capitalization in a dedicated web workflow.
-- Models investor returns against live deal terms instead of static spreadsheet snapshots.
-- Tracks ownership information in a format that can be maintained over time.
-- Shares live deals with backers without relying on PDF-based handoffs.
+- Structures a production's capitalization—weekly nut, royalties, house fees, GP structures, and waterfall rules—in a guided web workflow with industry-standard defaults.
+- Models investor returns with per-investor ROI, cash-on-cash multiples, IRR, and recoupment forecasts, driven automatically from the cap table.
+- Runs Bear, Base, and Bull scenarios side by side, with sensitivity grids across occupancy rates and run lengths showing the full investor outcome surface.
+- Tracks every investor's commitment, funded amount, ownership percentage, and subscription status from invited through fully admitted.
+- Generates a private Deal Room link so backers can see deal structure and scenarios without creating an account.
+
+## How it was built
+
+Override started as a `create-next-app` scaffold and grew into a production financial platform in about 75 commits. The stack is Next.js 16, TypeScript, and Firebase, with Sonner for notifications and Vitest for testing.
+
+The early commits were product work: production CRUD, dashboard view modes, the waterfall modeling engine, and the investor ledger. The domain model required getting comfortable with theatrical financing mechanics—recoup-first versus share-from-dollar-one structures, running royalty offsets, and GP fee calculations—and translating them into interfaces that a non-technical producer could use.
+
+The middle phase was about operational trust. Financial software can't have credential leaks or deployment ambiguity, so the repo moved to a 1Password-first authentication model, with service account keys stored in vaults and a bootstrap script that restores local config from 1Password item IDs. Deploy auth was documented, rotated, and eventually shifted toward keyless Firebase deploys.
+
+The final phase was the one I learned the most from: building the multi-agent code review system that now runs across all my repos. Override was where I first set up machine user accounts (nathanpayne-claude, nathanpayne-codex, nathanpayne-cursor), wrote the cross-agent review pipeline, added CodeRabbit with custom financial modeling review guidance, and introduced the disagreement detection workflow that flags when reviewers diverge. The PreToolUse hook, the bug fix escalation policy, and the two-strike rule all originated here—before being extracted into a template that I applied to every other project.
 
 ## Why it matters
 
-Broadway is a relationship-driven business, but the operating layer is still full of brittle document workflows. Override is built around the idea that trust-sensitive financial work should still feel legible, structured, and up to date.
+Broadway is a relationship-driven business, but the operating layer is still full of brittle document workflows. A producer managing a $15M capitalization might have investor commitments in a spreadsheet, executed agreements in a Dropbox folder, and waterfall terms in a PDF that was last updated during the offering. Override is built around the idea that trust-sensitive financial work should still feel legible, structured, and up to date—even after the production opens.
 
-The interesting part of this project is not just the finance domain. It is the translation exercise: taking highly specific theatrical financing mechanics and turning them into interfaces that are easier to work with, share, and reason about.
+The interesting part of this project is the translation exercise. Theatrical financing has its own vocabulary and its own math: recoupment triggers, operating reserve mechanics, overcall provisions, creative fee waterfalls. These concepts are well understood by industry professionals, but they've never had dedicated software. The work was figuring out which abstractions make the math accessible without flattening the domain—and building interfaces that a general partner and a first-time angel investor can both use.

--- a/src/content/projects/swipe-watch.md
+++ b/src/content/projects/swipe-watch.md
@@ -1,7 +1,7 @@
 ---
 title: "Swipe Watch"
 slug: "swipe-watch"
-description: "A swipe-based discovery experiment for Disney+ and Hulu—prototyped with AI tooling—that turns taste signals into a faster, more active recommendation loop."
+description: "A swipe-based discovery experiment for Disney+ and Hulu that turns taste signals into a faster, more active recommendation loop."
 kicker: "AI × Consumer × Streaming"
 order: 3
 screenshotAspect: "narrow"
@@ -15,9 +15,10 @@ githubUrl: "https://github.com/nathanjohnpayne/swipewatch"
 tags: ["Consumer", "Streaming", "Vanilla JS"]
 metadata:
   domain: "Consumer × Streaming"
-  format: "Vanilla JavaScript prototype"
+  format: "Interaction prototype"
   focus: "Discovery, recommendations, and interaction design"
   status: "Live experiment"
+stack: "Vanilla JavaScript · Firebase Hosting"
 related:
   - label: "Blog: Six PRs, One Bug—What AI Agents Actually Get Wrong"
     href: "/blog/six-prs-one-bug-agent-failure-modes/"
@@ -27,19 +28,31 @@ related:
 
 ## Overview
 
-Swipe Watch explores a simple question: what happens when streaming discovery feels active instead of passive? Rather than browsing endless shelves, the product uses a swipe interaction to let users react quickly, train their recommendations, and shape what the system learns.
+I work on the platforms that run Disney+ and Hulu. One thing that's always struck me is how passive the discovery experience is—you scroll, you browse, you maybe click into something, and the system tries to learn from what you watched. But watching a show is a 30-minute commitment. Swiping past a card takes a second. The signal density is completely different.
 
-It is a lightweight concept, but it is aimed at a real product problem: helping people express taste faster than a conventional streaming interface usually allows.
+Swipe Watch explores that gap. Instead of inferring taste from what people finish watching, it asks users to react to content cards in real time—swipe left, swipe right, or save for later. Each swipe is a fast, low-stakes preference signal that a recommendation system could use to learn what someone likes before they've committed to watching anything.
 
 ## What the product does
 
-- Presents streaming choices through a rapid swipe-based interface.
-- Turns user reactions into recommendation signals.
-- Adds coins and watchlist building as lightweight feedback loops.
-- Tests whether a faster interaction model can make discovery feel less static.
+- Presents content cards from an 80-title pool spanning Disney+ and Hulu—series, films, and specials—organized by a content taxonomy that maps to the apps' discovery modes.
+- Captures swipe-left (dismiss), swipe-right (interested), and save-for-later signals as lightweight preference data, each taking under a second.
+- Uses a coin mechanic to gate access to curated discovery batches—spend coins earned from swiping to unlock new content modes, creating a feedback loop that rewards engagement.
+- Tracks session state and swipe history so the system knows what a user has already seen and can avoid repeat presentations.
+
+## How it was built
+
+Swipe Watch was built in a weekend in vanilla JavaScript—no framework, no build step, no bundler. That constraint was deliberate. The point was to test whether the swipe interaction felt right before investing in a stack. The initial commit landed with a working swipe UI, a content pool, session management, and analytics tracking.
+
+The content catalog is hand-curated. Starting from an initial set, the pool grew through several commits—20 new tiles with poster-format upgrades, then 12 more, then 27—reaching 80 titles with a documented poster guide that specifies image handling, content types, and format standards. Each batch aligned with a content taxonomy that maps to the discovery modes in the app (genres, moods, trending). Duplicate detection was manual; one commit removes a duplicate "America's National Parks (Classic)" tile that slipped through.
+
+The coin and unlock system came after the core swiping worked. The initial build proved the interaction model, but sessions felt finite—you'd swipe through the deck and stop. The coin mechanic (earn coins by swiping, spend them to unlock curated discovery batches) was added to create a reason to come back. The end screen was redesigned to show a persistent coin bank with a spend mechanic rather than a dead-end "you're done" state.
+
+The onboarding UX and interaction affordances were polished in a dedicated pass—making sure the swipe gesture was discoverable, the card animations felt responsive, and the first session didn't require explanation. A later commit fixed mobile card image scaling and badge clipping, which only surfaced on smaller viewports where the poster art cropped differently than expected.
 
 ## Why it matters
 
-Recommendation systems are often evaluated on model quality alone, but the interface that gathers preference signals matters too. Swipe Watch focuses on that front-end layer: the mechanics of how people tell a product what they want to watch next.
+Recommendation systems are usually evaluated on model quality—precision, recall, serendipity. But the interface that gathers preference signals is upstream of the model and determines the quality of data it has to work with. A system that only learns from viewing history has to wait for a user to commit 30 minutes before it gets a signal. A system that learns from swipes gets a signal every second.
 
-Built over a weekend in vanilla JavaScript, the speed of the prototype matters: it is a deliberately lightweight way to test the interaction idea without the overhead of a larger stack.
+Swipe Watch focuses on that front-end layer: the mechanics of how people tell a product what they want to watch next. It's a prototype, not a production recommendation engine—there's no ML backend, no collaborative filtering, no real personalization yet. The question it was built to answer is narrower: does the swipe interaction feel natural enough for content discovery that people would actually use it? The 80-title pool and the coin mechanic are enough to test that question. What comes after—connecting the swipe data to an actual recommendation model—is a different project.
+
+I demoed Swipe Watch to Disney's EVP of Product. The reaction confirmed the hypothesis: the interaction model is compelling, and the signal-density argument resonates with people who think about recommendation systems professionally. Whether it ever ships as a feature inside Disney+ is a separate question, but as a prototype for testing an interaction hypothesis, it did its job.

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -104,7 +104,7 @@ const {
         />
       )}
 
-      <div class={`metadata-surface metadata-surface--${screenshotAspect}`}>
+      <div class="metadata-surface">
         <MetadataStrip
           domain={metadata.domain}
           format={metadata.format}

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -114,13 +114,13 @@ const {
         <figure class={`project-screenshot project-screenshot--${screenshotAspect}`}>
           <div class="project-screenshot__inner">
             <img src={screenshotSrc} alt={`${headline} product screenshot`} loading="eager" />
-            {stack && (
-              <figcaption class="project-stack">
-                <span class="project-stack__label">Stack</span>
-                <span class="project-stack__value">{stack}</span>
-              </figcaption>
-            )}
           </div>
+          {stack && (
+            <figcaption class="project-stack">
+              <span class="project-stack__label">Stack</span>
+              <span class="project-stack__value">{stack}</span>
+            </figcaption>
+          )}
         </figure>
       </div>
 

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -31,6 +31,7 @@ interface Props {
     focus: string;
     status: string;
   };
+  stack?: string;
   related: RelatedLink[];
   jsonLd: object;
   ogImage?: string;
@@ -56,6 +57,7 @@ const {
   liveUrl,
   githubUrl,
   metadata,
+  stack,
   related,
   jsonLd,
   ogImage,
@@ -102,15 +104,25 @@ const {
         />
       )}
 
-      <MetadataStrip
-        domain={metadata.domain}
-        format={metadata.format}
-        focus={metadata.focus}
-        status={metadata.status}
-        screenshotSrc={screenshotSrc}
-        screenshotAlt={`${headline} product screenshot`}
-        screenshotAspect={screenshotAspect}
-      />
+      <div class={`metadata-surface metadata-surface--${screenshotAspect}`}>
+        <MetadataStrip
+          domain={metadata.domain}
+          format={metadata.format}
+          focus={metadata.focus}
+          status={metadata.status}
+        />
+        <figure class={`project-screenshot project-screenshot--${screenshotAspect}`}>
+          <div class="project-screenshot__inner">
+            <img src={screenshotSrc} alt={`${headline} product screenshot`} loading="eager" />
+            {stack && (
+              <figcaption class="project-stack">
+                <span class="project-stack__label">Stack</span>
+                <span class="project-stack__value">{stack}</span>
+              </figcaption>
+            )}
+          </div>
+        </figure>
+      </div>
 
       <div class="project-copy">
         <slot />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -95,7 +95,7 @@ const homepageJsonLd = {
         <div class="panel-content">
           <div class="content-inner">
             <h2>Vibe Coding</h2>
-            <p>Every project started as a real problem. Each one became a systems design exercise.</p>
+            <p>Every project started as a real problem. Each one was built end-to-end with AI agents—Claude Code, Codex, and Cursor—under a multi-agent code review system I designed to catch the failure modes agents don't catch themselves. <a href="/blog/six-prs-one-bug-agent-failure-modes/" class="p-link">What agents actually get wrong →</a></p>
             <div class="project-list">
               <div class="project-item">
                 <div class="p-head">

--- a/src/pages/og-templates/projects.astro
+++ b/src/pages/og-templates/projects.astro
@@ -5,5 +5,5 @@ import OgCard from '../../layouts/OgCard.astro';
 <OgCard
   label="nathanpayne.com / projects"
   heading="Projects"
-  description="AI-built products from a product manager—each one a real problem turned into a systems design exercise."
+  description="Products from a product manager—each one a real problem turned into a systems design exercise."
 />

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -71,6 +71,7 @@ const jsonLd = {
   liveUrl={data.liveUrl}
   githubUrl={data.githubUrl}
   metadata={data.metadata}
+  stack={data.stack}
   related={data.related}
   jsonLd={jsonLd}
 >

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -13,7 +13,7 @@ const jsonLd = {
       "@id": "https://nathanpayne.com/projects/#webpage",
       "url": "https://nathanpayne.com/projects/",
       "name": "Projects | Nathan Payne",
-      "description": "AI-built products from a product manager—each one a real problem turned into a systems design exercise.",
+      "description": "Products from a product manager—each one a real problem turned into a systems design exercise.",
       "isPartOf": { "@id": "https://nathanpayne.com/#website" },
     },
     {
@@ -30,7 +30,7 @@ const jsonLd = {
 
 <BaseLayout
   title="Projects | Nathan Payne"
-  description="AI-built products from a product manager—each one a real problem turned into a systems design exercise."
+  description="Products from a product manager—each one a real problem turned into a systems design exercise."
   ogImage="https://nathanpayne.com/og/projects.png"
   ogImageAlt="Projects index open graph image"
   bodyClass="project-page project-page--yellow blog-page"
@@ -48,7 +48,7 @@ const jsonLd = {
         </nav>
         <p class="kicker">AI &times; Product &times; Engineering</p>
         <h1>Projects</h1>
-        <p class="deck">Every project started as a real problem. Each one became a systems design exercise&mdash;built with AI agents from first commit to deploy.</p>
+        <p class="deck">Every project started as a real problem. Each one became a systems design exercise&mdash;built end-to-end with AI agents under structured supervision, using multi-agent code review and the two-strike rule I developed after watching an agent open six PRs for the same bug. <a href="/blog/six-prs-one-bug-agent-failure-modes/">Read the case study &rarr;</a></p>
       </header>
 
       {/* ── Project Grid ──

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1086,36 +1086,8 @@ body.blog-page {
   );
 }
 
-/* Screenshot area inside the surface */
-.metadata-surface__screenshot {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: clamp(1rem, 2vw, 1.5rem);
-  border-top: 1px dotted rgba(17, 16, 13, 0.18);
-}
-
-/* Wide variant — full-width screenshot */
-.metadata-surface--wide .metadata-surface__screenshot img {
-  display: block;
-  width: 100%;
-  height: auto;
-  border: 1px solid var(--rule, rgba(17, 16, 13, 0.12));
-}
-
-/* Narrow variant — phone image centered, snug to card bottom */
-.metadata-surface--narrow .metadata-surface__screenshot {
-  padding-bottom: 0;
-}
-
-.metadata-surface--narrow .metadata-surface__screenshot img {
-  display: block;
-  max-height: 500px;
-  width: auto;
-  border-radius: 12px 12px 0 0;
-}
-
-/* Metadata strip — shared label/value styles */
+/* Metadata strip — always a 4-column horizontal row on desktop, regardless
+   of screenshot aspect. Collapses to 2-col on tablet, 1-col on phone. */
 .metadata-strip {
   display: grid;
   gap: 0;
@@ -1123,44 +1095,16 @@ body.blog-page {
   padding: 0;
 }
 
-/* Wide variant: 4 columns in a single row */
 .metadata-strip--grid-4 {
   grid-template-columns: repeat(4, 1fr);
-}
-
-/* Narrow variant: 2×2 grid beside the screenshot — matches phone height */
-.metadata-strip--grid-2x2 {
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr 1fr;
-}
-
-.metadata-strip--grid-2x2 .metadata-strip__item {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
 }
 
 .metadata-strip__item {
   padding: clamp(0.6rem, 1.2vw, 0.9rem) clamp(0.75rem, 1.5vw, 1rem);
   border-left: 1px dotted rgba(17, 16, 13, 0.18);
-  border-top: 1px dotted rgba(17, 16, 13, 0.18);
 }
 
-/* Remove top border on items in the first row */
-.metadata-strip--grid-4 .metadata-strip__item {
-  border-top: none;
-}
-
-.metadata-strip--grid-2x2 .metadata-strip__item:nth-child(-n+2) {
-  border-top: none;
-}
-
-/* Remove left border on first item in each row */
 .metadata-strip--grid-4 .metadata-strip__item:first-child {
-  border-left: none;
-}
-
-.metadata-strip--grid-2x2 .metadata-strip__item:nth-child(odd) {
   border-left: none;
 }
 
@@ -1173,6 +1117,70 @@ body.blog-page {
 }
 
 .metadata-strip dd {
+  font-size: clamp(0.9rem, 0.9rem + 0.12vw, 0.98rem);
+  line-height: 1.45;
+  color: var(--ink);
+}
+
+/* Project screenshot — figure container below the metadata strip.
+   Wide variant fills the content width; narrow variant centers a
+   phone-sized image. The inner wrapper constrains width so the
+   stack-line caption can align with the image's left edge. */
+.project-screenshot {
+  margin: 0;
+  padding: clamp(1rem, 2vw, 1.5rem);
+  border-top: 1px dotted rgba(17, 16, 13, 0.18);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.project-screenshot__inner {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.project-screenshot--narrow .project-screenshot__inner {
+  max-width: 320px;
+}
+
+.project-screenshot img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.project-screenshot--wide img {
+  border: 1px solid var(--rule, rgba(17, 16, 13, 0.12));
+}
+
+.project-screenshot--narrow img {
+  border-radius: 12px;
+}
+
+/* Stack line — rendered as a <figcaption> inside the screenshot figure.
+   Single horizontal row with a small-caps label and the stack values.
+   Aligned to the inner wrapper, so narrow layouts align with the
+   screenshot's left edge. */
+.project-stack {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin: clamp(0.6rem, 1vw, 0.85rem) 0 0;
+  padding: 0;
+}
+
+.project-stack__label {
+  flex: 0 0 auto;
+  font-size: clamp(0.6rem, 0.7vw, 0.68rem);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(17, 16, 13, 0.5);
+}
+
+.project-stack__value {
+  flex: 1 1 auto;
   font-size: clamp(0.9rem, 0.9rem + 0.12vw, 0.98rem);
   line-height: 1.45;
   color: var(--ink);
@@ -1321,15 +1329,14 @@ body.blog-page {
     border-left: none;
   }
 
-  .metadata-surface--narrow .metadata-surface__screenshot img {
-    max-height: 360px;
+  .project-screenshot--narrow .project-screenshot__inner {
+    max-width: 280px;
   }
 }
 
 @media (max-width: 480px) {
   /* All metadata → single column */
-  .metadata-strip--grid-4,
-  .metadata-strip--grid-2x2 {
+  .metadata-strip--grid-4 {
     grid-template-columns: 1fr;
   }
   .metadata-strip__item {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1113,7 +1113,7 @@ body.blog-page {
   font-size: clamp(0.6rem, 0.7vw, 0.68rem);
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: rgba(17, 16, 13, 0.5);
+  color: rgba(17, 16, 13, 0.62);
 }
 
 .metadata-strip dd {
@@ -1141,22 +1141,21 @@ body.blog-page {
   flex-direction: column;
 }
 
-.project-screenshot--narrow .project-screenshot__inner {
+.project-screenshot--narrow .project-screenshot__inner,
+.project-screenshot--narrow .project-stack {
   max-width: 320px;
+  width: 100%;
 }
 
 .project-screenshot img {
   display: block;
   width: 100%;
   height: auto;
+  border-radius: 12px;
 }
 
 .project-screenshot--wide img {
   border: 1px solid var(--rule, rgba(17, 16, 13, 0.12));
-}
-
-.project-screenshot--narrow img {
-  border-radius: 12px;
 }
 
 /* Stack line — rendered as a <figcaption> inside the screenshot figure.
@@ -1169,6 +1168,7 @@ body.blog-page {
   gap: 0.75rem;
   margin: clamp(0.6rem, 1vw, 0.85rem) 0 0;
   padding: 0;
+  width: 100%;
 }
 
 .project-stack__label {
@@ -1176,7 +1176,7 @@ body.blog-page {
   font-size: clamp(0.6rem, 0.7vw, 0.68rem);
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: rgba(17, 16, 13, 0.5);
+  color: rgba(17, 16, 13, 0.62);
 }
 
 .project-stack__value {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1329,7 +1329,8 @@ body.blog-page {
     border-left: none;
   }
 
-  .project-screenshot--narrow .project-screenshot__inner {
+  .project-screenshot--narrow .project-screenshot__inner,
+  .project-screenshot--narrow .project-stack {
     max-width: 280px;
   }
 }


### PR DESCRIPTION
## Summary

- Drop "built with AI agents" framing from card subtitles and hero decks; keep the AI methodology story in two canonical places (homepage Vibe Coding panel + projects index deck) that link to the six-PRs blog post as evidence
- Expand all four project pages with a consistent section order (Overview → What the product does → How it was built → Why it matters → Related) and a loose "stack + starting point → 2–3 engineering arcs → cross-repo reference" formula for "How it was built"
- Add optional `stack` field to the project schema; render it as a figcaption inside a new `.project-screenshot` figure. Simplify `MetadataStrip` to a single 4-column horizontal layout and drop the 2×2 narrow variant entirely
- Repurpose FORMAT as a product-type label (Financial operating system, Internal platform tool, Household coordination tool, Interaction prototype) now that the stack line handles the tech side
- Narrow-screenshot projects (Swipe Watch) constrain the figure to 320px centered, and the caption sits flush to the phone screenshot's left edge rather than the content container's

Closes #158 — the old narrow layout had `padding-bottom: 0` on the screenshot container and `border-radius: 12px 12px 0 0` on the phone image, putting the image flush against the Overview heading. The new figure+caption layout has 72px of clearance from the stack caption to the next h2.

## Self-Review

**Correctness.** Verified on the preview server across all four project pages:
- Wide layout (Override, DST, FFB): image and caption share identical geometry (`left=98.45, width=996.11` on all three).
- Narrow layout (Swipe Watch): image and caption share identical geometry (`left=436.5, width=320`), confirming the caption aligns to the phone screenshot's left edge rather than the content container. The caption wraps to two lines at 320px, as anticipated in the spec.
- Section structure verified via DOM inspection on all four pages: the new order resolves with correct paragraph/bullet counts per the content spec.
- Homepage Vibe Coding panel, projects index deck, and OG image template all emit the new copy; the meta description, `og:description`, `twitter:description`, and JSON-LD `CollectionPage.description` on the projects index all carry the new "Products from a product manager…" string.
- No server errors or console errors on any page.

**Regression risk.**
- Schema change adds an **optional** `stack` field, so existing tooling that reads the projects collection continues to work without it.
- `MetadataStrip.astro` no longer accepts `screenshotSrc`, `screenshotAlt`, or `screenshotAspect` props — the layout now owns the screenshot markup. Any future callers of `MetadataStrip` will need to render their own screenshot, but `MetadataStrip` is only used inside `ProjectLayout.astro` today so this is a contained change.
- The `.metadata-strip--grid-2x2` and `.metadata-surface__screenshot` rules and their responsive overrides have been removed from `global.css`. Grepped for stale references — none remain.
- Content collection tests (`tests/content-schema.test.js`) are blog-only and unaffected by the project schema change.

**Style.** CSS follows existing motion token discipline (no bare `ms`/`ease`). Commit message and PR follow conventional commit style per the repo history.

**Test coverage.** No new tests in this PR. Smoke tests for project page routes are tracked separately in #156, which will be handled in a follow-up PR alongside #155.

**Security / dependency hygiene.** No new dependencies. No changes to auth, secrets, `.github/`, `firebase.json`, `.firebaserc`, or `astro.config.mjs`. The new `stack` field carries plain strings from content frontmatter; no user input is reflected.

## Test plan

- [x] `/` — Vibe Coding panel shows new two-sentence intro + "What agents actually get wrong →" link, styled via `.p-link`
- [x] `/projects/` — deck shows new "…six PRs for the same bug" hook + "Read the case study →" link; card subtitles drop the AI clauses
- [x] `/projects/override/` — hero subtitle clean; Overview opens with "I invest in Broadway productions"; 5 bullets; How it was built has 4 paragraphs (agent-review story is canonical here); Why it matters ends on domain-depth vocabulary
- [x] `/projects/device-source-of-truth/` — Overview problem-first; 5 consolidated bullets; How it was built has 3 arc paragraphs + Override reference-back; Why it matters ends on day-job connection
- [x] `/projects/friends-and-family-billing/` — 5 bullets; How it was built has 3 arc paragraphs + Override reference-back; Why it matters closes on the Six PRs blog post
- [x] `/projects/swipe-watch/` — Overview professional vantage; 4 bullets; How it was built has 4 paragraphs; Why it matters ends on the Disney EVP demo
- [x] All four pages: metadata strip is a 4-column horizontal layout; stack line renders as a figcaption below the screenshot
- [x] Swipe Watch specifically: caption left-edge aligns with phone screenshot left-edge (verified at `x=436.5`)

---

Authoring-Agent: claude