### PR TITLE
chore+test: dead CSS cleanup (#155) and project page smoke tests (#156)

### DIFF
--- a/specs/project-pages.md
+++ b/specs/project-pages.md
@@ -1,8 +1,6 @@
 ---
 spec_id: project-pages
 title: Project Pages
-tested: false
-reason: "Smoke tests for project page routes and rendering are tracked in issue #156 and will ship in a follow-up PR."
 ---
 
 # Project Pages

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -956,84 +956,6 @@ body.blog-page {
   transform: translateY(calc(var(--shift-small) * -1));
 }
 
-/* .project-layout removed — replaced by single-column .project-copy */
-
-.project-detail-footer {
-  padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.15rem, 3vw, 2.5rem);
-  border-top: 1px solid var(--rule);
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.project-copy {
-  display: grid;
-  gap: 1.2rem;
-  min-width: 0;
-}
-
-/* .project-section removed — narrative content now styled via .project-copy */
-
-.project-checklist {
-  list-style: none;
-  display: grid;
-  gap: 0.7rem;
-}
-
-.project-checklist li {
-  position: relative;
-  padding-left: 1rem;
-}
-
-.project-checklist li::before {
-  content: "";
-  position: absolute;
-  top: 0.5em;
-  left: 0;
-  width: 0.42rem;
-  height: 0.42rem;
-  background: var(--project-accent);
-}
-
-/* .project-card .project-checklist removed — related links now use .project-related__list */
-
-/* .project-sidebar, .project-card removed — old two-column layout */
-
-.project-facts {
-  display: grid;
-  gap: 0.8rem;
-}
-
-.project-facts div {
-  padding-bottom: 0.65rem;
-  border-bottom: 1px solid var(--rule);
-}
-
-.project-facts div:last-child {
-  padding-bottom: 0;
-  border-bottom: 0;
-}
-
-.project-facts dt {
-  margin-bottom: 0.18rem;
-  font-size: clamp(0.68rem, 0.82vw, 0.78rem);
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: rgba(17, 16, 13, 0.58);
-}
-
-.project-facts dd,
-.project-note {
-  font-size: clamp(0.9rem, 0.9rem + 0.08vw, 0.98rem);
-  line-height: 1.55;
-}
-
-.project-note a {
-  color: inherit;
-}
-
 /* ── Redesigned Project Detail ── Hero, Metadata, Related, Footer ── */
 
 /* Hero header — accent bar, no gradient (gradient is on the metadata surface) */
@@ -1186,8 +1108,13 @@ body.blog-page {
   color: var(--ink);
 }
 
-/* Project copy — single column, full-width rules, left-aligned text */
+/* Project copy — single column, full-width rules, left-aligned text.
+   display: grid gives consistent 1.2rem vertical rhythm between children
+   regardless of individual margin rules. */
 .project-copy {
+  display: grid;
+  gap: 1.2rem;
+  min-width: 0;
   padding: clamp(1rem, 2vw, 1.5rem) clamp(1.15rem, 3vw, 2.5rem);
 }
 
@@ -2775,8 +2702,6 @@ a:focus-visible {
   .project-detail {
     box-shadow: 8px 8px 0 rgba(17, 16, 13, 0.1);
   }
-
-  /* .project-layout, .project-sidebar responsive rules removed */
 
   .project-detail-footer {
     flex-direction: column;

--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { resolve, join } from 'path';
+
+// Smoke tests for the content-collection-driven project detail pages.
+// See specs/project-pages.md and issue #156.
+//
+// These tests read from the already-built dist/ directory — `npm test`
+// runs `astro build && vitest run`, so dist/ is always fresh.
+
+const DIST = resolve(__dirname, '../dist');
+const CONTENT = resolve(__dirname, '../src/content/projects');
+
+const projectSlugs = [
+  'override',
+  'device-source-of-truth',
+  'friends-and-family-billing',
+  'swipe-watch',
+];
+
+function readDistHtml(relativePath) {
+  return readFileSync(resolve(DIST, relativePath), 'utf-8');
+}
+
+function setupDOM(rawHtml) {
+  // Strip bare <script> blocks to prevent auto-execution during document.write,
+  // but keep <script type="application/ld+json"> for structured-data assertions.
+  const safe = rawHtml.replace(/<script>[\s\S]*?<\/script>/g, '');
+  document.documentElement.innerHTML = '';
+  document.write(safe);
+  document.close();
+}
+
+describe('Project Pages — routes', () => {
+  it('every project slug generates a static HTML file in dist/', () => {
+    for (const slug of projectSlugs) {
+      const path = join(DIST, 'projects', slug, 'index.html');
+      expect(existsSync(path), `missing /projects/${slug}/index.html`).toBe(true);
+    }
+  });
+
+  it('the projects index page links to every non-draft project slug', () => {
+    setupDOM(readDistHtml('projects/index.html'));
+
+    for (const slug of projectSlugs) {
+      const link = document.querySelector(`a[href="/projects/${slug}/"]`);
+      expect(link, `projects index missing link to /projects/${slug}/`).not.toBeNull();
+    }
+  });
+
+  it('the collection source has the same number of non-draft projects as the index renders', () => {
+    const sourceFiles = readdirSync(CONTENT).filter((f) => f.endsWith('.md'));
+    const nonDraftSources = sourceFiles.filter((f) => {
+      const body = readFileSync(join(CONTENT, f), 'utf-8');
+      // Projects without `draft:` in frontmatter default to draft: false per the schema.
+      return !/^draft:\s*true\s*$/m.test(body);
+    });
+    expect(nonDraftSources.length).toBe(projectSlugs.length);
+  });
+});
+
+describe('Project Pages — render', () => {
+  for (const slug of projectSlugs) {
+    describe(`/projects/${slug}/`, () => {
+      beforeEach(() => {
+        setupDOM(readDistHtml(`projects/${slug}/index.html`));
+      });
+
+      it('has a non-empty <title> that includes "Nathan Payne"', () => {
+        const title = document.querySelector('title')?.textContent;
+        expect(title).toBeTruthy();
+        expect(title).toMatch(/Nathan Payne/);
+      });
+
+      it('has a metadata strip with exactly four <dt>/<dd> items', () => {
+        const strip = document.querySelector('.metadata-strip');
+        expect(strip, '.metadata-strip not found').not.toBeNull();
+        const items = strip.querySelectorAll('.metadata-strip__item');
+        expect(items.length).toBe(4);
+      });
+
+      it('renders all four metadata labels (Domain, Format, Focus, Status)', () => {
+        const labels = Array.from(document.querySelectorAll('.metadata-strip dt')).map(
+          (dt) => dt.textContent.trim(),
+        );
+        expect(labels).toEqual(['Domain', 'Format', 'Focus', 'Status']);
+      });
+
+      it('has a <figure class="project-screenshot"> containing an <img> with src and alt', () => {
+        const figure = document.querySelector('figure.project-screenshot');
+        expect(figure, 'figure.project-screenshot not found').not.toBeNull();
+        const img = figure.querySelector('img');
+        expect(img, '<img> inside .project-screenshot not found').not.toBeNull();
+        expect(img.getAttribute('src')).toBeTruthy();
+        expect(img.getAttribute('alt')).toBeTruthy();
+      });
+
+      it('has a .project-copy container with an <h2>Overview</h2> heading', () => {
+        const copy = document.querySelector('.project-copy');
+        expect(copy, '.project-copy not found').not.toBeNull();
+        const headings = Array.from(copy.querySelectorAll('h2')).map((h) =>
+          h.textContent.trim(),
+        );
+        expect(headings).toContain('Overview');
+      });
+
+      it('renders both CTA actions (View Live Product and View on GitHub)', () => {
+        const actions = Array.from(document.querySelectorAll('.project-action')).map(
+          (a) => a.textContent.trim(),
+        );
+        expect(actions).toContain('View Live Product');
+        expect(actions).toContain('View on GitHub');
+      });
+
+      it('emits a JSON-LD graph containing a SoftwareApplication entity', () => {
+        const scripts = document.querySelectorAll('script[type="application/ld+json"]');
+        expect(scripts.length).toBeGreaterThan(0);
+
+        let foundSoftwareApp = false;
+        for (const script of scripts) {
+          try {
+            const ld = JSON.parse(script.textContent);
+            const graph = Array.isArray(ld['@graph']) ? ld['@graph'] : [ld];
+            if (graph.some((e) => e && e['@type'] === 'SoftwareApplication')) {
+              foundSoftwareApp = true;
+              break;
+            }
+          } catch {
+            // malformed JSON-LD would fail another test; ignore here
+          }
+        }
+        expect(foundSoftwareApp, 'no SoftwareApplication entity in JSON-LD graph').toBe(true);
+      });
+    });
+  }
+});
+
+describe('Project Pages — screenshot aspect variants', () => {
+  it('Swipe Watch uses the narrow screenshot variant', () => {
+    setupDOM(readDistHtml('projects/swipe-watch/index.html'));
+    const figure = document.querySelector('figure.project-screenshot');
+    expect(figure.className).toContain('project-screenshot--narrow');
+  });
+
+  it('Override, DST, and FFB use the wide screenshot variant', () => {
+    const wideSlugs = ['override', 'device-source-of-truth', 'friends-and-family-billing'];
+    for (const slug of wideSlugs) {
+      setupDOM(readDistHtml(`projects/${slug}/index.html`));
+      const figure = document.querySelector('figure.project-screenshot');
+      expect(
+        figure.className,
+        `${slug} should use project-screenshot--wide`,
+      ).toContain('project-screenshot--wide');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two-issue follow-up to #159. Both issues were flagged as post-review observations on #154 and scoped out of the project-page overhaul for review-hygiene reasons. This PR closes both in a focused cleanup pass.

- **#155** — Remove ~70 lines of dead CSS from the pre-collection project layout (duplicate `.project-detail-footer`, duplicate `.project-copy`, orphan `.project-checklist`/`.project-facts`/`.project-note` rules, and leftover cleanup comments).
- **#156** — Add `tests/project-pages.test.js` with 33 smoke tests covering route existence, the projects index, per-project render checks, and screenshot aspect variants. Unblocks the `check_spec_test_alignment` CI check by removing the temporary `tested: false` marker on `specs/project-pages.md` (added as a placeholder in #159).

## Self-Review

**Correctness.**
- CSS cleanup:
  - Counted duplicates before/after: `.project-detail-footer` went from 2 definitions to 1, `.project-copy` went from 2 to 1. All targeted stale classes (`.project-layout`, `.project-sidebar`, `.project-section`, `.project-card`, `.project-checklist`, `.project-facts`, `.project-note`) have zero remaining references in `src/`.
  - The dead `.project-copy` block had `display: grid; gap: 1.2rem; min-width: 0` — those properties *were* load-bearing (grid auto-flow drives the 1.2rem vertical rhythm between h2/p children in the body copy). Consolidated them into the live block rather than deleting. Verified on the preview server: computed style is `display: grid, gap: 19.2px, min-width: 0px` on `.project-copy` — identical to pre-PR behavior.
  - All four project pages still render correctly on the preview server.
- Smoke tests: `npx vitest run tests/project-pages.test.js` → **33/33 passing**. `./scripts/ci/check_spec_test_alignment` → PASS (resolves `project-pages` spec via filename matching against `tests/project-pages.test.js`).

**Regression risk.**
- CSS cleanup is additive-safe because the duplicate rules were overridden by the cascade (so removing the earlier rule is a no-op) or consolidated before removal (for the `.project-copy` grid properties). Nothing's visually different post-cleanup.
- New test file reads from `dist/` like the existing `seo-metadata.test.js`, uses the same `document.write` + script-strip pattern. No new dependencies.
- `specs/project-pages.md` frontmatter change: dropped the `tested: false` / `reason:` lines. The spec body itself (already updated in #159) is unchanged in this PR.

**Style.** Two focused commits, one per issue, each with a "Closes #NNN" trailer. Commit messages follow repo convention.

**Test coverage.** This PR *adds* test coverage (+33 tests). The 3 pre-existing failures (blog-pages cache-busting query, blog-responsive inline width, keyboard-navigation `.panel` tabindex) are unrelated and documented in #159's self-review — not addressed here.

**Security / dependency hygiene.** No new dependencies. No changes to auth, secrets, `.github/`, `firebase.json`, `.firebaserc`, or `astro.config.mjs`.

## Test plan

- [x] `grep` for stale class references — all gone
- [x] `grep -c` duplicate-selector counts — both down to 1
- [x] `npm run build` — clean (17 pages, 8 OG images, no warnings)
- [x] `npx vitest run tests/project-pages.test.js` — 33/33 passing
- [x] Full `npm test` — 94 passing, 3 failing (same pre-existing non-project failures from #159, none in this PR's new file)
- [x] All 6 `scripts/ci/check_*` scripts pass locally
- [x] Preview server spot-checks on all 4 project pages — layout unchanged

## Rationale for a single PR

Per the plan laid out on #159, both #155 and #156 were scheduled for a single follow-up PR. They're each small (~80 LOC of CSS removal and ~160 LOC of new tests), they both touch the project-page surface area that #159 just finished rebuilding, and they don't cross-depend. Bundling them into one PR keeps the ceremony proportionate to the scope. The PR is 245 lines total, under the 300-line external-review threshold, so no `nathanpayne-codex` handoff is needed.

---

Authoring-Agent: claude