### PR TITLE
test: fix pre-existing test failures and CodeRabbit hygiene findings (#161)

### DIFF
--- a/tests/blog-pages.test.js
+++ b/tests/blog-pages.test.js
@@ -33,7 +33,12 @@ describe('Blog Pages', () => {
 
     expect(canonical?.getAttribute('href')).toBe('https://nathanpayne.com/blog/');
     expect(postLink).not.toBeNull();
-    expect(ogImage?.getAttribute('content')).toBe('https://nathanpayne.com/og/blog.png');
+    // og:image carries an optional ?v=<hash> cache-busting query so social
+    // platforms re-fetch the image after each deploy (see commit 49d2c39).
+    // The base URL stays stable; only the query varies.
+    expect(ogImage?.getAttribute('content')).toMatch(
+      /^https:\/\/nathanpayne\.com\/og\/blog\.png(\?v=\d+)?$/,
+    );
   });
 
   it('blog post page includes article metadata and screenshot embeds', () => {

--- a/tests/blog-responsive.test.js
+++ b/tests/blog-responsive.test.js
@@ -76,12 +76,25 @@ describe('Blog Responsive Layout', () => {
   });
 
   describe('blog post image markup', () => {
-    it('no blog post images have inline width attributes', () => {
+    it('blog post images have intrinsic width and height attributes for CLS prevention', () => {
+      // Inline width/height reserve space for the image during layout, which
+      // prevents Cumulative Layout Shift as images load. They do NOT conflict
+      // with responsive sizing — the `.blog-figure img { width: 100%; height:
+      // auto }` rule (asserted above) overrides the inline values for display
+      // while preserving the intrinsic aspect ratio. See the static dimension
+      // map in src/plugins/rehype-figure-captions.mjs.
       for (const post of blogPostPaths) {
         setupDOM(post.html);
         const images = document.querySelectorAll('.blog-figure img');
         for (const img of images) {
-          expect(img.hasAttribute('width'), `${post.slug}: image has inline width`).toBe(false);
+          expect(
+            img.hasAttribute('width'),
+            `${post.slug}: image missing intrinsic width attribute`,
+          ).toBe(true);
+          expect(
+            img.hasAttribute('height'),
+            `${post.slug}: image missing intrinsic height attribute`,
+          ).toBe(true);
         }
       }
     });

--- a/tests/keyboard-navigation.test.js
+++ b/tests/keyboard-navigation.test.js
@@ -40,10 +40,19 @@ describe('Keyboard Navigation', () => {
     loadScript();
   });
 
-  it('panels have tabindex="0"', () => {
+  it('each panel has a focusable .panel-label with tabindex="0"', () => {
+    // The .panel-label inside each .panel is the button-role element that
+    // receives tab focus. The panel itself is a <region> that registers the
+    // keydown handlers — Enter/Space/Escape bubble up from the focused label.
+    // Giving both elements tabindex="0" would create a confusing tab order, so
+    // focusability lives on the label, not the panel.
     const panels = document.querySelectorAll('.panel');
+    expect(panels.length).toBeGreaterThan(0);
     panels.forEach((panel) => {
-      expect(panel.getAttribute('tabindex')).toBe('0');
+      const label = panel.querySelector('.panel-label');
+      expect(label, 'panel missing .panel-label child').not.toBeNull();
+      expect(label.getAttribute('tabindex')).toBe('0');
+      expect(label.getAttribute('role')).toBe('button');
     });
   });
 

--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -52,8 +52,14 @@ describe('Project Pages — routes', () => {
     const sourceFiles = readdirSync(CONTENT).filter((f) => f.endsWith('.md'));
     const nonDraftSources = sourceFiles.filter((f) => {
       const body = readFileSync(join(CONTENT, f), 'utf-8');
-      // Projects without `draft:` in frontmatter default to draft: false per the schema.
-      return !/^draft:\s*true\s*$/m.test(body);
+      // Restrict the draft: true check to the YAML frontmatter block at the
+      // top of the file. A documentation example in the body that contains
+      // `draft: true` as an indented code sample should not make the project
+      // look drafted. Projects without `draft:` at all default to false per
+      // the schema. (See #161.)
+      const fmMatch = body.match(/^---\n([\s\S]*?)\n---/);
+      const frontmatter = fmMatch ? fmMatch[1] : '';
+      return !/^draft:\s*true\s*$/m.test(frontmatter);
     });
     expect(nonDraftSources.length).toBe(projectSlugs.length);
   });
@@ -139,6 +145,7 @@ describe('Project Pages — screenshot aspect variants', () => {
   it('Swipe Watch uses the narrow screenshot variant', () => {
     setupDOM(readDistHtml('projects/swipe-watch/index.html'));
     const figure = document.querySelector('figure.project-screenshot');
+    expect(figure, 'figure.project-screenshot not found on swipe-watch').not.toBeNull();
     expect(figure.className).toContain('project-screenshot--narrow');
   });
 
@@ -147,6 +154,10 @@ describe('Project Pages — screenshot aspect variants', () => {
     for (const slug of wideSlugs) {
       setupDOM(readDistHtml(`projects/${slug}/index.html`));
       const figure = document.querySelector('figure.project-screenshot');
+      expect(
+        figure,
+        `${slug}: figure.project-screenshot not found`,
+      ).not.toBeNull();
       expect(
         figure.className,
         `${slug} should use project-screenshot--wide`,


### PR DESCRIPTION
## Summary

Turn the test suite fully green. Five small test-file fixes across four files — three pre-existing failures that had been persisting on `main` since before #159, plus the two CodeRabbit hygiene findings CodeRabbit posted on #160 just as auto-merge fired.

### Pre-existing failures (not tracked in an issue — fixing directly)

| File | Failure | Fix |
|---|---|---|
| `tests/blog-pages.test.js` | `og:image` asserted as exact match but the URL has a `?v=<hash>` cache-busting query (intentional, from commit [`49d2c39`](https://github.com/nathanjohnpayne/nathanpaynedotcom/commit/49d2c39)) | Relax to regex with optional query |
| `tests/blog-responsive.test.js` | Asserted blog images have NO inline `width`, but `rehype-figure-captions.mjs` sets width/height from a static dimension map for CLS prevention | Invert — assert width/height ARE present (the companion CSS rule test at line 72 already asserts responsive sizing via `.blog-figure img { width: 100% }`) |
| `tests/keyboard-navigation.test.js` | Asserted `.panel` has `tabindex="0"`, but the focusable element is `.panel-label` (verified: all four panels in `src/pages/index.astro`) | Select `.panel-label` inside each `.panel` and assert tabindex + role there |

### #161 — CodeRabbit hygiene findings on `project-pages.test.js`

| Finding | Fix |
|---|---|
| Draft regex matched full markdown body, not just frontmatter | Slice the `^---\n…\n---` block first and test only that |
| `figure.className` read without null-guard | Add `expect(figure).not.toBeNull()` before each `className` check |

## Self-Review

**Correctness.** `npm test` — **97 passed (97), 0 failures** (up from 94 passed / 3 failures on `main`). Fresh `astro build && vitest run` — all 12 test files green. Every pre-existing failure has a diagnosis in the commit message that explains why the test was wrong rather than just changing expectations.

**Regression risk.** Zero. This PR touches only test files — no source changes, no content changes, no CSS changes, no schema changes. The build output and live site are completely unaffected.

**Style.** Two focused commits — one for the three pre-existing failures (each with a multi-paragraph diagnosis in the commit body so git blame stays useful), one for the two #161 fixes. `Closes #161` trailer on the second.

**Test coverage.** Net zero new tests; the changes tighten existing assertions. The `blog-responsive` inversion goes from asserting the WRONG behavior (no inline width) to the RIGHT behavior (inline width present for CLS). The `keyboard-navigation` fix adds a real assertion that `.panel-label` has `role="button"` on top of the tabindex check.

**Security / dependency hygiene.** No new dependencies. No changes to auth, secrets, `.github/`, `firebase.json`, `.firebaserc`, `astro.config.mjs`, or any source/content files.

## Test plan

- [x] `npm test` — 97/97 passing
- [x] `npx vitest run tests/blog-pages.test.js` — passes
- [x] `npx vitest run tests/blog-responsive.test.js` — passes
- [x] `npx vitest run tests/keyboard-navigation.test.js` — passes
- [x] `npx vitest run tests/project-pages.test.js` — passes
- [x] Diff touches only `tests/` — verified with `git diff --stat`

## Rationale for bundling

All five fixes are test hygiene on the same substrate (`tests/`), landed together the same day. Filing separate issues for three failures that took ~10 minutes to diagnose and one commit to fix would add more ceremony than the changes warrant. 52 lines of diff, safely under the external-review threshold, all four test files now passing.

---

Authoring-Agent: claude