### PR TITLE
fix(seo): point robots.txt Sitemap at /sitemap-index.xml

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://nathanpayne.com/sitemap.xml
+Sitemap: https://nathanpayne.com/sitemap-index.xml


### PR DESCRIPTION
Closes #166. Part of #163 closeout.

**Authoring-Agent:** claude

## Summary

One-line fix: `public/robots.txt` was declaring `Sitemap: https://nathanpayne.com/sitemap.xml`, but that URL returns HTTP 404. The working sitemap (generated by `@astrojs/sitemap`) lives at `/sitemap-index.xml`. This is almost certainly why `site:nathanpayne.com` returns zero results in Google — Search Console reads the `Sitemap:` line, fetches it, gets a 404, and has no canonical URL list to crawl against.

```diff
- Sitemap: https://nathanpayne.com/sitemap.xml
+ Sitemap: https://nathanpayne.com/sitemap-index.xml
```

## Verification

```bash
$ curl -sI https://nathanpayne.com/sitemap.xml
HTTP/2 404
$ curl -sI https://nathanpayne.com/sitemap-index.xml
HTTP/2 200
$ curl -sS https://nathanpayne.com/sitemap-index.xml
<?xml version="1.0" encoding="UTF-8"?>
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <sitemap><loc>https://nathanpayne.com/sitemap-0.xml</loc></sitemap>
</sitemapindex>
$ curl -sS https://nathanpayne.com/sitemap-0.xml | grep -c '<url>'
8
```

After deploy, #167 covers the GSC resubmission that's needed to actually kick Google into reindexing.

## Self-Review

- **Correctness.** Astro config uses `@astrojs/sitemap` which writes `sitemap-index.xml` (verified against `astro.config.mjs` and the live `dist/` output). `sitemap-index.xml` is live now and returns 200. The change makes the `robots.txt` declaration match reality.
- **Regression risk.** Minimal. `public/robots.txt` is copied verbatim to `dist/robots.txt` at build time — no template interpolation, no moving parts. The old URL was already broken, so any client that was successfully using it is impossible; the only behavioral change is that Google / Bing / etc. will now successfully fetch the sitemap when they re-read `robots.txt`. No code paths or routes touched.
- **Style.** Same file, same trailing newline, same indentation. No stylistic drift.
- **Test coverage.** `public/robots.txt` is a static asset with no dedicated unit tests. #165 tracks adding a CI smoke check that follows every URL declared in `robots.txt` and every `og:image` referenced in the build output, which would have caught this class of bug automatically. #164 tracks preventing drift between Astro's generated sitemap filename and the hand-authored `robots.txt` declaration. This PR deliberately does not expand scope into either of those; they are tracked separately and can be landed on their own.
- **Security / dependency hygiene.** No dependency changes. No new network endpoints. No secrets. `robots.txt` is public by design.

## Test plan

- [x] `git diff public/robots.txt` — single line change, looks right
- [x] Confirmed `curl -sI https://nathanpayne.com/sitemap-index.xml` → 200
- [x] Confirmed `curl -sI https://nathanpayne.com/sitemap.xml` → 404 (the broken one)
- [x] Confirmed `astro.config.mjs` uses `@astrojs/sitemap` (default output: `sitemap-index.xml`)
- [ ] After deploy: `curl -sS https://nathanpayne.com/robots.txt | grep -i sitemap` returns `sitemap-index.xml`
- [ ] After deploy + #167: GSC Sitemaps tab shows `sitemap-index.xml` with Success status
- [ ] After deploy + GSC reindex: `site:nathanpayne.com` returns at least one result

## Related

- Closes #166
- Part of #163 closeout
- Followups: #164 (drift prevention), #165 (CI smoke check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)