### PR TITLE
test(seo): smoke-check every og:image target exists in dist

### DIFF
--- a/tests/og-image-targets.test.js
+++ b/tests/og-image-targets.test.js
@@ -28,9 +28,9 @@
  * @see Issue #165 — Add SEO smoke checks for robots sitemap and OG image targets
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
-import { resolve, join, relative, dirname } from 'node:path';
+import { resolve, join, relative, isAbsolute } from 'node:path';
 import { JSDOM } from 'jsdom';
 
 const distDir = resolve(__dirname, '../dist');
@@ -77,22 +77,56 @@ function extractImageMetas(htmlPath) {
 
 /**
  * Resolve an og:image / twitter:image URL to a path under dist/.
- * Returns null if the URL is not under the site origin.
+ * Returns null if the URL is not under the site origin OR if the
+ * resolved path would escape the dist/ directory via path traversal.
+ *
+ * Uses the WHATWG URL parser (which normalizes `..` segments in the
+ * pathname) and then double-checks containment with `path.relative`.
+ * Belt and suspenders — see CodeRabbit review on #172.
  */
 function urlToDistPath(url) {
-  // Strip query string (the ?v=<hash> cache-bust is intentional)
-  const noQuery = url.split('?')[0];
-  if (!noQuery.startsWith(`${SITE}/`)) return null;
-  const rel = noQuery.slice(SITE.length + 1); // trim "https://nathanpayne.com/"
-  return resolve(distDir, rel);
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.origin !== SITE) return null;
+
+  // Strip the leading slash from the pathname. Query string and
+  // fragment are ignored — the ?v=<hash> cache-bust is intentional
+  // and intentionally not matched against disk.
+  const relPath = parsed.pathname.replace(/^\/+/, '');
+  const resolved = resolve(distDir, relPath);
+
+  // Containment check: `relative(distDir, resolved)` returns a path
+  // that starts with `..` or is absolute if `resolved` escapes distDir.
+  const relFromDist = relative(distDir, resolved);
+  if (relFromDist.startsWith('..') || isAbsolute(relFromDist)) return null;
+
+  return resolved;
 }
 
-const htmlFiles = findIndexHtmlFiles(distDir);
-const ogImageFindings = htmlFiles.flatMap((htmlPath) =>
-  extractImageMetas(htmlPath).map((meta) => ({ htmlPath, ...meta }))
-);
+// Discovered lazily inside beforeAll so the suite fails with a clear
+// "build output missing" error rather than a readdir stack trace if
+// someone runs vitest without first running `astro build`.
+let htmlFiles = [];
+let ogImageFindings = [];
 
 describe('OG image targets (post-build)', () => {
+  beforeAll(() => {
+    expect(
+      existsSync(distDir),
+      `Build output not found at ${distDir}. ` +
+        `Run \`npm run build\` (or \`npm test\`, which runs it for you) ` +
+        `before invoking vitest directly.`
+    ).toBe(true);
+    htmlFiles = findIndexHtmlFiles(distDir);
+    ogImageFindings = htmlFiles.flatMap((htmlPath) =>
+      extractImageMetas(htmlPath).map((meta) => ({ htmlPath, ...meta }))
+    );
+  });
+
   it('finds at least one built HTML page with an og:image tag', () => {
     // Sanity check: if the build collapses and produces zero pages with
     // og:image tags, something upstream is badly broken — we want a
@@ -132,7 +166,9 @@ describe('OG image targets (post-build)', () => {
     for (const finding of ogImageFindings) {
       const path = urlToDistPath(finding.content);
       if (!path) continue; // already covered by the absolute-URL test
-      if (!existsSync(path)) {
+      // Must exist AND be a regular file — a directory at the resolved
+      // path would also pass existsSync and falsely satisfy the test.
+      if (!existsSync(path) || !statSync(path).isFile()) {
         broken.push({
           page: relative(distDir, finding.htmlPath),
           tag: finding.tag,
@@ -143,9 +179,10 @@ describe('OG image targets (post-build)', () => {
     }
     expect(
       broken,
-      'These pages reference OG images that do not exist in dist/. ' +
-        'This is the class of bug #163 diagnosed — verify the integration ' +
-        'that generates OG images ran and wrote the expected filename.'
+      'These pages reference OG images that do not exist in dist/ ' +
+        '(or resolve to a directory). This is the class of bug #163 ' +
+        'diagnosed — verify the integration that generates OG images ' +
+        'ran and wrote the expected filename.'
     ).toEqual([]);
   });
 

--- a/tests/og-image-targets.test.js
+++ b/tests/og-image-targets.test.js
@@ -1,0 +1,188 @@
+/**
+ * Smoke check: every og:image and twitter:image URL referenced by a
+ * built HTML page resolves to a real asset in dist/.
+ *
+ * Existing SEO tests (tests/seo-metadata.test.js, tests/blog-pages.test.js)
+ * assert that the OG tags are PRESENT and shaped correctly on specific
+ * pages. They do NOT verify the URLs actually point at files that shipped.
+ * That gap is what #163 exposed: the tags were fine on paper, the plumbing
+ * behind them was not.
+ *
+ * This test walks dist/ for every index.html, parses each one, and for
+ * each `<meta property="og:image">` and `<meta name="twitter:image">`
+ * tag it resolves the referenced URL to a dist-relative path and asserts
+ * the file is actually on disk.
+ *
+ * Rules enforced:
+ *   - URL must be absolute (`https://nathanpayne.com/...`)
+ *   - URL must resolve to a file that exists under dist/
+ *   - Optional `?v=<hash>` cache-bust query strings are tolerated
+ *     (see commit 49d2c39 for the rationale)
+ *
+ * If this test fails, either:
+ *   (a) the page references an `og:image` URL that no file in dist/
+ *       matches (broken pipeline — #163-class bug), or
+ *   (b) you intentionally removed an OG image and forgot to update the
+ *       page frontmatter / layout to stop referencing it.
+ *
+ * @see Issue #165 — Add SEO smoke checks for robots sitemap and OG image targets
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join, relative, dirname } from 'node:path';
+import { JSDOM } from 'jsdom';
+
+const distDir = resolve(__dirname, '../dist');
+const SITE = 'https://nathanpayne.com';
+
+/**
+ * Walk a directory recursively and return every index.html file.
+ */
+function findIndexHtmlFiles(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      results.push(...findIndexHtmlFiles(full));
+    } else if (entry === 'index.html') {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/**
+ * Parse an HTML file and pull the content= value for each matching
+ * meta selector. Returns an array of { tag, content } pairs.
+ */
+function extractImageMetas(htmlPath) {
+  const html = readFileSync(htmlPath, 'utf-8');
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+
+  const out = [];
+  for (const meta of doc.querySelectorAll(
+    'meta[property="og:image"], meta[property="og:image:secure_url"], meta[name="twitter:image"]'
+  )) {
+    const content = meta.getAttribute('content');
+    if (content) {
+      const which = meta.getAttribute('property') || meta.getAttribute('name');
+      out.push({ tag: which, content });
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve an og:image / twitter:image URL to a path under dist/.
+ * Returns null if the URL is not under the site origin.
+ */
+function urlToDistPath(url) {
+  // Strip query string (the ?v=<hash> cache-bust is intentional)
+  const noQuery = url.split('?')[0];
+  if (!noQuery.startsWith(`${SITE}/`)) return null;
+  const rel = noQuery.slice(SITE.length + 1); // trim "https://nathanpayne.com/"
+  return resolve(distDir, rel);
+}
+
+const htmlFiles = findIndexHtmlFiles(distDir);
+const ogImageFindings = htmlFiles.flatMap((htmlPath) =>
+  extractImageMetas(htmlPath).map((meta) => ({ htmlPath, ...meta }))
+);
+
+describe('OG image targets (post-build)', () => {
+  it('finds at least one built HTML page with an og:image tag', () => {
+    // Sanity check: if the build collapses and produces zero pages with
+    // og:image tags, something upstream is badly broken — we want a
+    // noisy failure here, not an empty test suite passing.
+    expect(htmlFiles.length).toBeGreaterThan(0);
+    const ogImages = ogImageFindings.filter((f) => f.tag === 'og:image');
+    expect(ogImages.length).toBeGreaterThan(0);
+  });
+
+  it('every page has an og:image tag', () => {
+    const pagesWithoutOgImage = htmlFiles.filter((htmlPath) => {
+      const metas = extractImageMetas(htmlPath);
+      return !metas.some((m) => m.tag === 'og:image');
+    });
+    expect(
+      pagesWithoutOgImage.map((p) => relative(distDir, p)),
+      'These pages have no og:image meta tag. Add one to the page layout.'
+    ).toEqual([]);
+  });
+
+  it('every og:image / og:image:secure_url / twitter:image URL is absolute https on nathanpayne.com', () => {
+    const invalid = ogImageFindings.filter(
+      (f) => !f.content.startsWith(`${SITE}/`)
+    );
+    expect(
+      invalid.map((f) => ({
+        page: relative(distDir, f.htmlPath),
+        tag: f.tag,
+        content: f.content,
+      })),
+      'These image tags are not absolute URLs under https://nathanpayne.com/.'
+    ).toEqual([]);
+  });
+
+  it('every og:image / og:image:secure_url / twitter:image URL resolves to a file in dist/', () => {
+    const broken = [];
+    for (const finding of ogImageFindings) {
+      const path = urlToDistPath(finding.content);
+      if (!path) continue; // already covered by the absolute-URL test
+      if (!existsSync(path)) {
+        broken.push({
+          page: relative(distDir, finding.htmlPath),
+          tag: finding.tag,
+          content: finding.content,
+          expected: relative(distDir, path),
+        });
+      }
+    }
+    expect(
+      broken,
+      'These pages reference OG images that do not exist in dist/. ' +
+        'This is the class of bug #163 diagnosed — verify the integration ' +
+        'that generates OG images ran and wrote the expected filename.'
+    ).toEqual([]);
+  });
+
+  it('og:image and twitter:image agree on the same URL within a page', () => {
+    const mismatches = [];
+    for (const htmlPath of htmlFiles) {
+      const metas = extractImageMetas(htmlPath);
+      const og = metas.find((m) => m.tag === 'og:image');
+      const tw = metas.find((m) => m.tag === 'twitter:image');
+      if (og && tw && og.content !== tw.content) {
+        mismatches.push({
+          page: relative(distDir, htmlPath),
+          'og:image': og.content,
+          'twitter:image': tw.content,
+        });
+      }
+    }
+    expect(
+      mismatches,
+      'og:image and twitter:image should point at the same asset.'
+    ).toEqual([]);
+  });
+
+  it('og:image:secure_url matches og:image when both are present', () => {
+    const mismatches = [];
+    for (const htmlPath of htmlFiles) {
+      const metas = extractImageMetas(htmlPath);
+      const og = metas.find((m) => m.tag === 'og:image');
+      const secure = metas.find((m) => m.tag === 'og:image:secure_url');
+      if (og && secure && og.content !== secure.content) {
+        mismatches.push({
+          page: relative(distDir, htmlPath),
+          'og:image': og.content,
+          'og:image:secure_url': secure.content,
+        });
+      }
+    }
+    expect(mismatches).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #165 (OG image half). Part of #163 closeout.

**Authoring-Agent:** claude

## Summary

Existing SEO tests (`tests/seo-metadata.test.js`, `tests/blog-pages.test.js`) assert that `og:image` / `twitter:image` meta tags are **present** and **shaped correctly** on specific pages. They do **not** verify the URLs actually point at files that shipped. That gap is exactly what #163 exposed: the tags were fine on paper, the plumbing behind them was not.

This PR adds a post-build smoke check: `tests/og-image-targets.test.js`. It walks `dist/` for every `index.html`, parses each with `jsdom`, extracts `og:image` / `og:image:secure_url` / `twitter:image` content URLs, and asserts:

1. At least one built HTML page has an `og:image` tag (canary against a broken build dropping all OG tags)
2. **Every** built page has an `og:image` tag
3. Every extracted URL is absolute under `https://nathanpayne.com/`
4. **Every extracted URL resolves to a real file in `dist/`** — the key new assertion that would have caught #163
5. `og:image` and `twitter:image` agree on the same URL within a page
6. `og:image:secure_url` matches `og:image` when both are present

Optional `?v=<hash>` cache-bust query strings are tolerated (see commit `49d2c39` for the rationale behind versioned OG image URLs).

### Scope note

#165's acceptance criteria include two smoke checks:

> (a) CI/build verifies that the `Sitemap:` URL declared in `dist/robots.txt` maps to a real built sitemap route or file.
> (b) CI/build verifies that every `og:image` (and ideally `twitter:image`) referenced by built HTML resolves to an existing built asset…

Half **(a)** is covered by `tests/robots-sitemap.test.js` in **#171** (the `#164` drift prevention PR). This PR covers half **(b)** and is independent of #171 — either can land first.

If #171 does not merge, #165 would still be half-open. I've left #165 in that state and opened this PR only against the OG image half; feel free to re-scope.

## Verification

```
$ npx vitest run tests/og-image-targets.test.js

 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Full suite:

```
$ npx vitest run

 Test Files  13 passed (13)
      Tests  103 passed (103)
```

## Self-Review

- **Correctness.** The test walks `dist/` with `readdirSync` / `statSync`, parses each `index.html` with `jsdom` (same library the existing SEO tests use), and asserts file existence via `existsSync`. No mocks, no I/O fixtures — it reads the real build output. URL normalization strips the `?v=<hash>` query string before resolving to a dist-relative path, matching the pattern used in `tests/blog-pages.test.js` line 39–41. I manually spot-checked against the current build output: 8 OG images in `dist/og/` (`home.png`, `blog.png`, `projects.png`, plus one per blog post and per project) match what each built `index.html` references.

- **Regression risk.** This is a test-only change. No runtime code touched. If this test starts failing in the future, it's either because:
  - (a) Someone broke the OG image pipeline (the whole point of the test — success mode)
  - (b) Someone changed the URL format (the absolute-https assertion catches it with a clear message)
  - (c) `jsdom` or `vitest` major version bump changes behavior (same risk existing SEO tests already carry)

- **Style.** Mirrors the existing `tests/sitemap.test.js` / `tests/seo-metadata.test.js` / `tests/blog-pages.test.js` style: `describe` / `it`, `readFileSync` / `resolve(__dirname, …)`, `JSDOM` for parsing. Error messages on every `expect(…)` failure include the failing file path and URL so a test failure is immediately actionable without needing to re-run with verbose logging.

- **Test coverage.** 6 new test cases; each targets a distinct failure mode listed in #165 acceptance criteria. The "every page has an og:image" check is slightly broader than #165 strictly asks for, but it's cheap and catches a class of bug (page layouts forgetting to include OG tags) that would also lead to #163-style failures. If the team wants to relax it (e.g. 404 pages are allowed to skip OG tags), swap `toEqual([])` for a whitelist.

- **Security / dependency hygiene.** `jsdom` is already a `devDependency` (used by `tests/seo-metadata.test.js`, `tests/blog-pages.test.js`, and others). No new dependencies. No network calls — the test validates against the local filesystem only. `.github/**` is untouched, so the protected-paths external-review trigger does not fire.

## External review threshold

Diff is **188 lines added** (1 new file, no modifications). Policy threshold is **300**. This PR is under the threshold and does **not** require external review. I will peer-review it as `nathanpayne-claude` after CodeRabbit (Phase 2.5) and auto-merge should be able to merge it via the existing `auto-merge-on-approval` workflow.

## Test plan

- [x] `npx vitest run tests/og-image-targets.test.js` — 6 passed
- [x] `npx vitest run` — 103 passed (no existing test regressions)
- [x] All 6 assertions validated against real `dist/` build output
- [x] `jsdom` already present; no `package.json` changes
- [ ] CodeRabbit review (Phase 2.5) addressed
- [ ] Internal peer review as `nathanpayne-claude`

## Related

- Closes the OG image half of #165
- The sitemap half of #165 is covered by `tests/robots-sitemap.test.js` in #171
- Part of #163 closeout
- Does not depend on #171; either can land first

🤖 Generated with [Claude Code](https://claude.com/claude-code)