### PR TITLE
test: enforce fileURLToPath contract for Astro integrations

### DIFF
--- a/tests/integration-contracts.test.js
+++ b/tests/integration-contracts.test.js
@@ -41,9 +41,20 @@ import { resolve, join } from 'node:path';
 const integrationsDir = resolve(__dirname, '../src/integrations');
 
 function listIntegrationFiles() {
-  return readdirSync(integrationsDir)
-    .filter((f) => f.endsWith('.mjs') || f.endsWith('.js'))
-    .map((f) => join(integrationsDir, f));
+  // Recursive walk so integrations nested under subdirectories
+  // (e.g. src/integrations/og/index.mjs) are also covered. The
+  // top-level-only version of this would silently skip a new
+  // integration that organized itself into a folder — exactly the
+  // kind of drift this test file is meant to prevent.
+  const walk = (dir) =>
+    readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) return walk(fullPath);
+      const isIntegrationSource =
+        entry.isFile() && (entry.name.endsWith('.mjs') || entry.name.endsWith('.js'));
+      return isIntegrationSource ? [fullPath] : [];
+    });
+  return walk(integrationsDir);
 }
 
 /**
@@ -74,7 +85,10 @@ describe('Astro integration contracts (Windows portability)', () => {
   describe.each(integrationFiles.map((file) => [file]))('%s', (file) => {
     const source = readFileSync(file, 'utf-8');
     const runtime = stripComments(source);
-    const usesBuildDoneHook = source.includes('astro:build:done');
+    // Check the comment-stripped runtime, not raw source — otherwise a
+    // comment mentioning `astro:build:done` could falsely trigger the
+    // import assertion on a file that never actually hooks the build.
+    const usesBuildDoneHook = runtime.includes('astro:build:done');
 
     it('does not reference dir.pathname in runtime code', () => {
       // The explanatory comments (`// dir.pathname yields /C:/path/...`)

--- a/tests/integration-contracts.test.js
+++ b/tests/integration-contracts.test.js
@@ -106,8 +106,11 @@ describe('Astro integration contracts (Windows portability)', () => {
     it.runIf(usesBuildDoneHook)(
       'imports fileURLToPath from node:url when it uses astro:build:done',
       () => {
+        // Match against the comment-stripped runtime so a commented-out
+        // `// import { fileURLToPath } from 'node:url'` can't falsely
+        // satisfy the contract.
         expect(
-          source,
+          runtime,
           `${file} uses the astro:build:done hook but does not import ` +
             `fileURLToPath. Every integration that consumes the 'dir' ` +
             `parameter must convert it via fileURLToPath(dir) — see ` +

--- a/tests/integration-contracts.test.js
+++ b/tests/integration-contracts.test.js
@@ -1,0 +1,105 @@
+/**
+ * Integration contract tests — Windows portability enforcement.
+ *
+ * Astro's `astro:build:done` hook passes `dir` as a URL object. Reading
+ * `dir.pathname` directly produces `/C:/path/...` on Windows, which
+ * breaks `path.join` downstream and generates malformed paths like
+ * `C:\C:\path\to\dist`. The documented cross-platform pattern is
+ * `fileURLToPath(dir)` from `node:url`.
+ *
+ * #171 applied this fix to `robots-sitemap.mjs`. #173 applied it to
+ * `og-images.mjs`. This test file enforces the contract for every
+ * current and future integration — cross-platform, so it catches a
+ * regression at `npm test` time on macOS/Linux without needing a
+ * Windows CI runner.
+ *
+ * The cheapest implementation would be a grep, but that trips on the
+ * explanatory comments (`// dir.pathname yields /C:/path/...`) each
+ * integration carries. Instead, strip comments before matching, and
+ * run two independent assertions per integration:
+ *
+ *   1. The runtime (comment-stripped) source must not contain
+ *      `dir.pathname`.
+ *   2. Any integration that uses `astro:build:done` must also import
+ *      `fileURLToPath` from `node:url`.
+ *
+ * A new integration that touches `astro:build:done` without using
+ * `fileURLToPath` will fail this test immediately. A contributor who
+ * regresses one of the existing integrations back to `dir.pathname`
+ * will fail (1) on that file. Either way, the Windows bug can't
+ * silently re-enter the repo.
+ *
+ * @see Issue #171 — robots-sitemap drift prevention (original Windows fix)
+ * @see Issue #173 — og-images Windows portability follow-up
+ * @see https://docs.astro.build/en/reference/integrations-reference/
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+const integrationsDir = resolve(__dirname, '../src/integrations');
+
+function listIntegrationFiles() {
+  return readdirSync(integrationsDir)
+    .filter((f) => f.endsWith('.mjs') || f.endsWith('.js'))
+    .map((f) => join(integrationsDir, f));
+}
+
+/**
+ * Strip block and line comments from JavaScript source so contract
+ * assertions run against only the runtime code path.
+ *
+ * This is not a full parser — it doesn't correctly handle comment-like
+ * syntax inside string or template literals. That's acceptable here
+ * because the repo's integration files don't have any `dir.pathname`
+ * or `fileURLToPath` inside strings, and the test would catch any
+ * regression that did try to hide the bug inside a string literal.
+ */
+function stripComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
+    .replace(/\/\/.*$/gm, '');         // line comments
+}
+
+const integrationFiles = listIntegrationFiles();
+
+describe('Astro integration contracts (Windows portability)', () => {
+  it('finds at least one integration file', () => {
+    // Canary: if the integrations directory goes empty or gets renamed,
+    // fail loudly rather than passing an empty suite.
+    expect(integrationFiles.length).toBeGreaterThan(0);
+  });
+
+  describe.each(integrationFiles.map((file) => [file]))('%s', (file) => {
+    const source = readFileSync(file, 'utf-8');
+    const runtime = stripComments(source);
+    const usesBuildDoneHook = source.includes('astro:build:done');
+
+    it('does not reference dir.pathname in runtime code', () => {
+      // The explanatory comments (`// dir.pathname yields /C:/path/...`)
+      // are allowed — they document WHY we use fileURLToPath. Only the
+      // runtime code path is checked, after stripping comments.
+      expect(
+        runtime,
+        `${file} still references dir.pathname in runtime code. ` +
+          `Use fileURLToPath(dir) from node:url instead — dir.pathname ` +
+          `yields /C:/path/... on Windows and breaks path.join. ` +
+          `See #171 / #173 for the documented pattern.`
+      ).not.toMatch(/\bdir\.pathname\b/);
+    });
+
+    it.runIf(usesBuildDoneHook)(
+      'imports fileURLToPath from node:url when it uses astro:build:done',
+      () => {
+        expect(
+          source,
+          `${file} uses the astro:build:done hook but does not import ` +
+            `fileURLToPath. Every integration that consumes the 'dir' ` +
+            `parameter must convert it via fileURLToPath(dir) — see ` +
+            `specs/seo-metadata.md requirement 16.`
+        ).toMatch(/import\s*\{[^}]*\bfileURLToPath\b[^}]*\}\s*from\s*['"]node:url['"]/);
+      }
+    );
+  });
+});


### PR DESCRIPTION
Addresses the CodeRabbit nitpick on #174: "Add CI coverage for the known Windows regression class."

**Authoring-Agent:** claude

## Summary

CodeRabbit flagged one 🧹 nitpick on #174 asking for CI coverage of the `dir.pathname` → `fileURLToPath` contract, to prevent regression of the Windows bug #171 and #173 both closed. The original disposition was "dismiss, file a separate issue if the team wants Windows CI," but on reflection a full Windows CI runner is overkill — the contract is cross-platform by construction and can be enforced by a unit test that runs on the existing macOS CI lane.

This PR adds `tests/integration-contracts.test.js`. It lists every file under `src/integrations/` and runs two assertions against each:

1. **No runtime `dir.pathname`.** The file's source is parsed to strip block and line comments (so the explanatory `// dir.pathname yields /C:/path/...` comments in both integrations are allowed), then the stripped runtime code is regex-checked against `\bdir\.pathname\b`. Match → fail with a message pointing at #171 / #173 for the documented pattern.
2. **`fileURLToPath` imported when `astro:build:done` is used.** If the file mentions the build hook, it must also import `fileURLToPath` from `node:url`. Match → fail with a message pointing at `specs/seo-metadata.md` requirement 16.

A contributor reintroducing `dir.pathname` in any integration fails (1). A new integration that consumes the `dir` parameter without the documented import fails (2). Either way, the Windows portability bug is caught at `npm test` time.

## Why not a Windows CI runner

CodeRabbit's original suggestion was to add a `windows-latest` GitHub Actions job. I considered this and decided against it for this PR, with the following trade-offs:

| Windows CI runner | This contract test |
|---|---|
| Requires configuring `windows-latest` matrix, Playwright Chromium for Windows, the full `npm run build` pipeline | One new test file, zero infrastructure |
| Doubles CI cost per PR | Zero additional CI cost — runs inside the existing vitest suite |
| Fixes latent Windows bugs as they surface (good long-term) | Only fixes the *known* bug class (narrower) |
| Hardening against unknown-unknowns | Hardening against the specific regression we just paid to fix |

The contract test is the **minimum viable Windows regression guard**. If the team later wants a full Windows CI lane to catch unknown bugs (worth doing if contributors start running Windows), file it as a separate issue and scope it incrementally: lint-only → test-only → build-only. That's a conversation and infrastructure change; this PR is a targeted test.

## Verification

```
$ npx vitest run tests/integration-contracts.test.js
 Test Files  1 passed (1)
      Tests  5 passed (5)

$ npm run build && npx vitest run
…
 Test Files  16 passed (16)
      Tests  127 passed (127)
```

5 new tests (1 canary + 2 assertions × 2 current integrations). Full suite: 127 passed (up from 122 on main).

Also ran a negative sanity check with a tiny node repro to verify the comment-stripping regex catches runtime `dir.pathname` and correctly ignores the same pattern in comments:

```
$ node -e "…"
stripped (bad code): 'const x = dir.pathname;'
match dir.pathname: true
stripped (good code): 'const x = fileURLToPath(dir);'  (after stripping `// dir.pathname yields…` comment)
match dir.pathname: false
```

## Self-Review

- **Correctness.** The test has two failure modes and a canary. I walked through the regex logic manually and verified with a negative repro. The assertion messages name the failing file and point at #171 / #173 / the spec for the fix pattern — a future contributor failing this test gets an actionable error immediately. The comment-stripping is a deliberate simplification, not a full parser — I documented the tradeoff in the file header and it is acceptable because the repo's integration files do not put `dir.pathname` or `fileURLToPath` inside string or template literals.
- **Regression risk.** Zero. Test-only change. No runtime code touched. A false positive would be a new integration file that mentions `dir.pathname` in a non-runtime context (e.g. a string literal in error messages) — I spot-checked both existing integrations and neither does this. If it ever happens, the test file header explains the limitation and the workaround is to move the string into a named constant.
- **Style.** Mirrors the existing `tests/*.test.js` style (vitest, `describe` / `it`, `readFileSync`, JSDoc header explaining the "why"). `describe.each` over integration files follows the same shape as the fixture iteration in `tests/robots-sitemap-integration.test.js`.
- **Test coverage.** 5 new tests covering both the canary and both assertions for each of the two current integrations. A new integration added in the future will automatically be picked up by the `describe.each` iteration — no manual list maintenance.
- **Security / dependency hygiene.** No new dependencies. No network calls. No secrets. `.github/**` untouched, so the protected-paths external-review trigger does not fire.

## External review threshold

Diff is **105 lines added** (1 new file). Policy threshold is **300**. No `.github/**` / secret / credential path matches. **External review is not required.** Ready to peer-approve and auto-merge.

## Test plan

- [x] `npx vitest run tests/integration-contracts.test.js` — 5 passed
- [x] `npm run build && npx vitest run` — 127 passed (no regressions)
- [x] Negative repro verifying the comment-stripping regex behavior
- [ ] CodeRabbit review (Phase 2.5) addressed
- [ ] Internal peer review as `nathanpayne-claude`

## Related

- Follow-up to CodeRabbit's nitpick on #174
- Closes the Windows regression class identified in #173 via test enforcement instead of a CI infrastructure change
- Does not close any issue on its own (#173 is already closed by #174)

🤖 Generated with [Claude Code](https://claude.com/claude-code)