### PR TITLE
chore: standardize .gitignore with agent directory hygiene policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,24 @@ playwright-report/
 package-lock.json
 .claude/worktrees/
 screenshots/
+
+# Logs
+*.log
+logs/
+
+# Editor
+.vscode/
+!.vscode/extensions.json
+.idea/
+
+# Cursor runtime artifacts
+.cursor/cache/
+.cursor/state/
+.cursor/plans/
+
+# Coverage
+coverage/
+
+# Misc
+tmp/
+.cache/


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

- Adds logs (`*.log`, `logs/`), editor dirs (`.vscode/` with `!.vscode/extensions.json`, `.idea/`)
- Adds `.cursor/plans/`, `.cursor/cache/`, `.cursor/state/` — runtime artifacts
- Adds `coverage/`, `tmp/`, `.cache/`

Part of cross-repo gitignore standardization. Tracked in nathanjohnpayne/ai_agent_repo_template#18.

## Self-Review

- **Correctness**: Gitignore-only change. No application logic affected.
- **Regression risk**: None.
- **Security**: N/A
- **Test coverage**: N/A
- **Dependency hygiene**: N/A