### PR TITLE
fix: add box-shadow to blog post pages

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1883,7 +1883,7 @@ a.tag:hover {
   background: var(--ink);
   width: min(100%, 72rem);
   margin: 0 auto;
-  border: 1px solid var(--grid-border);
+  box-shadow: 14px 14px 0 rgba(17, 16, 13, 0.12);
   /* Use clip instead of hidden — hidden creates a scroll container
      which breaks position:sticky on .blog-sidebar-inner. clip
      provides the same visual clipping without a new scroll context. */


### PR DESCRIPTION
## Summary

Blog post pages (`.blog-canvas`) were missing the `box-shadow` that the blog
listing page (`.frame`) has. The grid's outer `var(--line)` tracks already
provide the visual border, so the redundant `1px` CSS border was replaced with
the matching `box-shadow: 14px 14px 0 rgba(17, 16, 13, 0.12)`.

Authoring-Agent: claude

## Self-Review

- **Correctness**: The `.blog-canvas` grid uses `var(--line)` outer tracks with
  `background: var(--ink)` as its visual border. Adding the same `box-shadow` as
  `.frame` completes visual parity. Removing the 1px border avoids a subtle
  extra line that doesn't exist on the listing page.
- **Regression risk**: Minimal — single CSS property swap on one selector.
  Verified in local preview that both blog posts render correctly with matching
  borders and shadow.
- **Style**: Matches existing Mondrian design system conventions.
- **Test coverage**: Visual-only change; verified via preview screenshot.
- **Security/dependency hygiene**: N/A — no deps, no user input.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>