### PR TITLE
style: FFB index row right cell → light blue #2080ca

### DIFF
--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -95,10 +95,13 @@ const jsonLd = {
             </div>
           );
           // Projects 5+ use alternating overflow rows
+          const accentStyle = project.data.slug === 'friends-and-family-billing'
+            ? 'background: #2080ca;'
+            : undefined;
           return (
             <div class={i % 2 === 0 ? 'grid-row--overflow-a' : 'grid-row--overflow-b'}>
               {card}
-              <div class="accent-paper" aria-hidden="true"></div>
+              <div class="accent-paper" style={accentStyle} aria-hidden="true"></div>
             </div>
           );
         })}


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Sets the right-cell accent color on the Friends & Family Billing row of `/projects/` to light blue `#2080ca` (rgb 32, 128, 202).

## Implementation

Slug-scoped inline style on the overflow-row accent block. Implemented as a ternary on the project slug rather than a CSS override or an `accent-paper--ffb` modifier class because the styling is unique to this one project row — no second consumer, no need for an abstraction.

```astro
const accentStyle = project.data.slug === 'friends-and-family-billing'
  ? 'background: #2080ca;'
  : undefined;
```

Other overflow rows (hypothetical 6th+ projects) continue to use the default `accent-paper` background.

## Self-Review

- **Correctness** — Verified in dev: the FFB row right cell is now rgb(32, 128, 202); other rows unchanged.
- **Regression risk** — Minimal. Inline style is the narrowest possible change; no new CSS, no cascade implications. Full vitest suite (134/134) passes.
- **Style** — Consistent with how astro template inline styles are already used in `ProjectLayout.astro` for the project-accent vars. If you add another per-row accent later, we can promote this to a frontmatter `indexAccentColor` field.
- **Test coverage** — No new tests; existing `project-pages.test.js` doesn't assert accent colors on the index, and this is a pure visual tweak.
- **Security / dependency hygiene** — N/A.