### PR TITLE
content: add ai-agent-repo-template to homepage Vibe Coding section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -99,10 +99,10 @@ const homepageJsonLd = {
             <div class="project-list">
               <div class="project-item">
                 <div class="p-head">
-                  <a class="p-name p-name-link" href="/projects/device-source-of-truth/" aria-label="Read the Device Source of Truth project page">Device Source of Truth</a>
-                  <span class="p-tag">Enterprise × Data</span>
+                  <a class="p-name p-name-link" href="/projects/ai-agent-repo-template/" aria-label="Read the AI Agent Repository Template project page">AI Agent Repository Template</a>
+                  <span class="p-tag">Infrastructure × AI Tooling</span>
                 </div>
-                <p>A single web application for understanding partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN. <a href="https://device-source-of-truth.web.app" target="_blank" rel="noopener" class="p-link" aria-label="View the live Device Source of Truth app">Live ↗</a></p>
+                <p>A deterministic repository standard that keeps humans and AI coding agents aligned—the enforcement layer underneath every other project on this site. <a href="https://github.com/nathanjohnpayne/ai_agent_repo_template" target="_blank" rel="noopener" class="p-link" aria-label="View the ai-agent-repo-template repository on GitHub">Live ↗</a></p>
               </div>
               <div class="project-item">
                 <div class="p-head">
@@ -110,6 +110,13 @@ const homepageJsonLd = {
                   <span class="p-tag">Finance × Theater</span>
                 </div>
                 <p>The financial operating system for Broadway productions. Structure your capitalization, model investor returns, manage ownership, and share live deals with backers—without spreadsheets or PDF workflows. <a href="https://overridebroadway.com" target="_blank" rel="noopener" class="p-link" aria-label="View the live Override app">Live ↗</a></p>
+              </div>
+              <div class="project-item">
+                <div class="p-head">
+                  <a class="p-name p-name-link" href="/projects/device-source-of-truth/" aria-label="Read the Device Source of Truth project page">Device Source of Truth</a>
+                  <span class="p-tag">Enterprise × Data</span>
+                </div>
+                <p>A single web application for understanding partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN. <a href="https://device-source-of-truth.web.app" target="_blank" rel="noopener" class="p-link" aria-label="View the live Device Source of Truth app">Live ↗</a></p>
               </div>
               <div class="project-item">
                 <div class="p-head">
@@ -128,7 +135,7 @@ const homepageJsonLd = {
             </div>
             <div class="stack-ribbon">
               <span class="stack-label">Stack</span>
-              <span class="stack-items">React · TypeScript · Vite · Tailwind CSS · Firebase · Vanilla JS · Claude Code · Codex · Cursor</span>
+              <span class="stack-items">Bash · Python · GitHub Actions · React · TypeScript · Vite · Tailwind CSS · Firebase · Vanilla JS · Claude Code · Codex · Cursor</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Matches the homepage Vibe Coding project list to the Projects index order. AI Agent Repository Template goes first as the infrastructure underneath the others, followed by Override, DST, Swipe Watch, FFB.

The homepage was showing four projects while \`/projects/\` showed five after PR #193 landed. This PR closes that gap.

## Changes

- Add an \`AI Agent Repository Template\` \`.project-item\` as the first entry, linking to the existing \`/projects/ai-agent-repo-template/\` detail page and the GitHub repo for \`Live ↗\`.
- Reorder the existing four items to match the index (ai-agent, Override, DST, Swipe Watch, FFB).
- Extend the stack ribbon with \`Bash · Python · GitHub Actions\` so the template repo's tooling is represented.

## Self-Review

- **Correctness** — Order matches \`/projects/\` (sorted by \`order\` in frontmatter: 0, 1, 2, 3, 4). Existing copy for the four prior items is unchanged.
- **Regression risk** — Very low. Additive + reorder of sibling elements within a static \`project-list\`. The hover/panel JS indexes elements by \`data-panel\`, not by list position.
- **Style** — New \`.project-item\` follows the exact markup pattern (aria-label, p-tag, p-link with target/rel) as siblings.
- **Test coverage** — All 134 tests pass. Homepage render tests don't assert specific project order, so no update needed.
- **Security / dependency hygiene** — N/A.