### PR TITLE
feat: add availability signal to homepage Connect section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -176,6 +176,41 @@ const homepageJsonLd = {
         <div class="panel-content">
           <div class="content-inner">
             <h2>Connect</h2>
+            {/* ── Availability signal ──────────────────────────────────
+                 The mailto address is assembled client-side from base64
+                 fragments so the string `hire@nathanpayne.com` never
+                 appears in the static HTML (protects against the simplest
+                 scrapers). The <noscript> fallback is plain text for
+                 JS-disabled users. The inline <script is:inline> runs
+                 synchronously after the element is parsed, so the window
+                 between page paint and href assembly is negligible. */}
+            <p class="availability-signal">
+              Open to new roles and collaborations. I read every email.
+              {' '}
+              <a
+                id="availability-mailto"
+                class="availability-mailto p-link"
+                href="#"
+                data-u="aGlyZQ=="
+                data-d="bmF0aGFucGF5bmUuY29t"
+                data-s="RnJvbSUyMG5hdGhhbnBheW5lLmNvbQ=="
+              >Get in touch &rarr;</a>
+            </p>
+            <noscript>
+              <p class="availability-noscript">Email: hire [at] nathanpayne [dot] com</p>
+            </noscript>
+            <script is:inline>
+              (function () {
+                var el = document.getElementById('availability-mailto');
+                if (!el) return;
+                try {
+                  var user = atob(el.dataset.u);
+                  var domain = atob(el.dataset.d);
+                  var subject = el.dataset.s ? atob(el.dataset.s) : '';
+                  el.href = 'mailto:' + user + '@' + domain + (subject ? '?subject=' + subject : '');
+                } catch (e) { /* leave href as "#" — noscript covers the fallback */ }
+              })();
+            </script>
             <span class="connect-label">Elsewhere</span>
             <div class="social-stack">
               <a href="https://www.linkedin.com/in/nathanpayne/" target="_blank" rel="noopener" class="social-row social-row--linkedin">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -318,6 +318,20 @@ html, body {
   color: rgba(25, 22, 17, 0.50);
 }
 
+.availability-signal {
+  margin: 0 0 var(--su);
+  font-size: clamp(0.78rem, 0.95vw, 0.88rem);
+  line-height: 1.45;
+  color: rgba(25, 22, 17, 0.82);
+}
+
+.availability-noscript {
+  display: block;
+  margin: 0 0 var(--su);
+  font-size: clamp(0.7rem, 0.85vw, 0.8rem);
+  color: rgba(25, 22, 17, 0.62);
+}
+
 .social-stack {
   margin-top: 0;
   gap: calc(var(--su) * 0.75);


### PR DESCRIPTION
Authoring-Agent: claude

Extracted from the post-disney-copy branch (#194, Task 7) per the decision to ship the availability signal now rather than bundle it with the June 21 post-Disney copy.

## Summary

Renders a single line above the Connect Elsewhere list: "Open to new roles and collaborations. I read every email. Get in touch ->".

The mailto is assembled client-side from base64 fragments so the literal string hire-at-nathanpayne-dot-com does NOT appear in the static HTML source. A noscript block renders a plain-text fallback.

Final assembled href: mailto:hire@nathanpayne.com?subject=From%20nathanpayne.com

## Verification

- Raw HTML has only the encoded base64 fragments, not the address.
- Post-JS DOM assembles the correct mailto with subject-line suffix.
- noscript block renders Email: hire [at] nathanpayne [dot] com for JS-disabled clients.
- Address is provisioned and forwarding to Nathan primary inbox (confirmed 2026-04-16).

## Changes

- src/pages/index.astro: availability-signal paragraph + noscript fallback + inline script above the existing connect-label.
- src/styles/global.css: .availability-signal and .availability-noscript rules next to .connect-label.

## Out of scope

- Meta-description reinforcing signal stays on #194 since it would clash with present-tense Disney copy until Task 6 ships June 21.
- JSON-LD seeking field explicitly forbidden by Task 7 ticket.
- LinkedIn Open to Work frame outside this repo.

## Self-Review

- Correctness: verified raw HTML has no literal address; post-JS DOM has the correct mailto. noscript fallback renders when JS disabled.
- Regression risk: additive only. Three failure modes all land gracefully (href stays #, noscript visible, try/catch keeps # on base64 failure).
- Style: CMOS em-dash, matches site voice. Inline JS is scoped by getElementById.
- Test coverage: 134/134 existing tests pass. No new tests added; manual source-HTML verification is the right layer for the "dont leak address" assertion (post-JS DOM has the full address).
- Security: no new deps, no eval, base64 is trivially reversible but the goal is scraper hygiene not secrecy.

## Post-merge

The post-disney-copy branch will be synced with main so PR #194 diff no longer contains the availability signal.