### PR TITLE
style: apply .p-link to /projects/ intro blog link

### DIFF
--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -48,7 +48,7 @@ const jsonLd = {
         </nav>
         <p class="kicker">AI &times; Product &times; Engineering</p>
         <h1>Projects</h1>
-        <p class="deck">Every project started as a real problem. Each one became a systems design exercise&mdash;built with AI agents from first commit to deploy, on top of an enforcement system I designed to make agent output reliable. The infrastructure behind these projects is documented in <a href="/blog/agent-approval-workflow-genesis-of-ai-agent-repo-template/">Agent Approval Workflow and the Genesis of ai-agent-repo-template</a>.</p>
+        <p class="deck">Every project started as a real problem. Each one became a systems design exercise&mdash;built with AI agents from first commit to deploy, on top of an enforcement system I designed to make agent output reliable. The infrastructure behind these projects is documented in <a href="/blog/agent-approval-workflow-genesis-of-ai-agent-repo-template/" class="p-link">Agent Approval Workflow and the Genesis of ai-agent-repo-template</a>.</p>
       </header>
 
       {/* ── Project Grid ──


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Adds `class="p-link"` to the blog link in the `/projects/` intro deck. Missed this when I wrote the sentence in #193 — without the class the anchor renders as default browser blue/purple underlined text, which reads wrong next to every other prose link on the site.

## Self-Review

- Correctness: verified via computed styles — link now has color `rgb(34, 63, 137)` (site blue), weight 700, no default underline, 1px border-bottom in `rgba(34, 63, 137, 0.48)`. Matches the Vibe Coding / project-card `.p-link` treatment.
- Regression risk: single class attribute added on one anchor. No other links touched.
- Style: consistent with every other prose link on the site.
- Test coverage: no tests assert link styling at this granularity; manual computed-style check is the right layer.
- Security / dependency hygiene: N/A.