### PR TITLE
fix(index): rename homepage Mergepath CTA from "Live ↗" to "GitHub ↗"

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -102,7 +102,7 @@ const homepageJsonLd = {
                   <a class="p-name p-name-link" href="/projects/mergepath/" aria-label="Read the Mergepath project page">Mergepath</a>
                   <span class="p-tag">Infrastructure × AI Tooling</span>
                 </div>
-                <p>A deterministic repository standard that keeps humans and AI coding agents aligned—the enforcement layer underneath every other project on this site. <a href="https://github.com/nathanjohnpayne/mergepath" target="_blank" rel="noopener" class="p-link" aria-label="View the Mergepath repository on GitHub">Live ↗</a></p>
+                <p>A deterministic repository standard that keeps humans and AI coding agents aligned—the enforcement layer underneath every other project on this site. <a href="https://github.com/nathanjohnpayne/mergepath" target="_blank" rel="noopener" class="p-link" aria-label="View the Mergepath repository on GitHub">GitHub ↗</a></p>
               </div>
               <div class="project-item">
                 <div class="p-head">


### PR DESCRIPTION
Authoring-Agent: claude

CodeRabbit follow-up from [#206](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/206) ([inline comment](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/206#discussion)). The homepage project card for Mergepath had a "Live ↗" label on a link going to the GitHub repo — stale from when the repo URL was itself the "live" destination. Renames the visible text to "GitHub ↗"; target, rel, and aria-label untouched.

The fix was committed to the Phase 5 branch after [#206](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/206) auto-merged on approval, so it needed a separate PR.

## Self-Review

**Correctness.** Single-character-class label swap. No routing or aria changes.

**Regression risk.** None. Visible CTA text only.

**Style.** No new abstractions.

**Test coverage.** `npm test` still passes 134/134.

**Security / dependency hygiene.** No dependency changes. Below threshold, no protected paths.