### PR TITLE
content(override): add Mergepath genesis post to Related section

### DIFF
--- a/src/content/projects/override.md
+++ b/src/content/projects/override.md
@@ -20,6 +20,8 @@ metadata:
   status: "Live product"
 stack: "Next.js · TypeScript · Firebase · Vitest"
 related:
+  - label: "Blog: Agent Approval Workflow and the Genesis of Mergepath"
+    href: "/blog/agent-approval-workflow-genesis-of-mergepath/"
   - label: "Blog: Six PRs, One Bug—What AI Agents Actually Get Wrong"
     href: "/blog/six-prs-one-bug-agent-failure-modes/"
   - label: "Project: Friends & Family Billing"


### PR DESCRIPTION
## Summary

- Adds *Agent Approval Workflow and the Genesis of Mergepath* to the `related` array on the Override project detail page.
- Surfaces the governance/approval-system story next to Override, which is the trust-sensitive financial project where the review system was first built — directly relevant to the "how careful are you with our money?" question Broadway backers raise.

Closes #201.

Authoring-Agent: claude

## Self-Review

- **Correctness:** Adds one entry to the `related` frontmatter array in [src/content/projects/override.md](src/content/projects/override.md). Href matches the canonical blog slug (`agent-approval-workflow-genesis-of-mergepath`, post-rename) and the post file exists at `src/content/blog/agent-approval-workflow-genesis-of-mergepath.md`. The original issue (#201) referenced the pre-rename slug `agent-approval-workflow-genesis-of-ai-agent-repo-template`; using the current canonical slug is the correct interpretation.
- **Regression risk:** None. Content-only change. Entry follows the same YAML shape used on every other project page. The detail template already renders arbitrary-length `related` arrays (see `device-source-of-truth.md`, `friends-and-family-billing.md`).
- **Style:** Label uses the full blog post title. Ordering places blog posts before project links, matching convention on other pages.
- **Test coverage:** No test change. Content collection schema validation runs at build; a malformed entry would fail the Astro build.
- **Security / dependencies:** No touchpoints.

## Test plan

- [x] `git diff` reviewed; change is two YAML lines inside the existing `related` array.
- [ ] Reviewer: confirm the blog post file exists at the referenced href.
- [ ] Reviewer: confirm the Related section renders three items on `/projects/override/` after merge.