### PR TITLE
mux(phase-1): install @mux/mux-player + extend projects schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "jsdom": "^29.0.2",
     "unist-util-visit": "^5.1.0",
     "vitest": "^4.1.4"
+  },
+  "dependencies": {
+    "@mux/mux-player": "^3.11.8"
   }
 }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -34,6 +34,11 @@ const projects = defineCollection({
     // Opt-in: refresh `screenshotSrc` on each build from the GitHub
     // social preview of `githubUrl`. See scripts/refresh-hero-images.mjs.
     heroRefresh: z.enum(['github-social']).optional(),
+
+    // Mux Playback ID. When set, the project page renders a MUX video
+    // in the hero slot; `screenshotSrc` still serves as the JS-disabled
+    // fallback and as the OG image source.
+    muxPlaybackId: z.string().optional(),
   }),
 });
 


### PR DESCRIPTION
## Summary

- Installs `@mux/mux-player@^3.11.8` as a runtime dependency.
- Extends the projects collection schema in [src/content.config.ts](src/content.config.ts) with an optional `muxPlaybackId` field.
- No renderer, no page changes, no visual impact. The next PR ([#213](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/213)) consumes the field.

Closes [#211](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/211) and [#212](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/212).

Part of the [MUX Video Integration](https://github.com/users/nathanjohnpayne/projects/5) initiative.

## Pivot from @mux/mux-player-astro to @mux/mux-player

The Phase 1 plan originally called for installing [`@mux/mux-player-astro`](https://www.npmjs.com/package/@mux/mux-player-astro), the official Astro wrapper referenced in the [Astro Mux guide](https://docs.astro.build/en/guides/media/mux/). That package's latest release (`3.11.8`) pins `peerDependencies: { astro: "^4.0.0 || ^5.0.0" }`, which refuses to install on this repo (Astro `^6.1.0`). The Mux team is tracking the peer-range bump at [muxinc/elements#1314](https://github.com/muxinc/elements/issues/1314); I've added a supportive comment there.

Rather than ship `--legacy-peer-deps` or an `overrides` entry (both of which would need to be audited out once the peer range is bumped), this PR installs `@mux/mux-player` directly — the underlying web component that the Astro wrapper uses internally. The later renderer PR ([#213](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/213)) will use it in an Astro component via a client-side import, producing an equivalent `<mux-player>` element in the DOM. No user-facing difference vs. what the Astro wrapper would have emitted.

## Self-Review

**Correctness.** Schema field is `z.string().optional()` — existing projects without `muxPlaybackId` continue to validate. `npm run build` completes successfully and regenerates all 21 pages + 10 OG images with no schema errors.

**Regression risk.** Low — this PR adds one optional frontmatter field and one runtime dependency. No file under `src/pages`, `src/layouts`, or `src/components` is touched. No existing project markdown is touched.

**Style.** Matches the surrounding schema style in [src/content.config.ts](src/content.config.ts) — short inline comment describing the field's purpose and its fallback story (screenshotSrc remains for OG + no-JS).

**Test coverage.** No unit tests in this repo for schema validation; the build-time check is authoritative, and it passes. The field is exercised end-to-end in PR [#213](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/213).

**Security / dependency hygiene.** `@mux/mux-player` has no peer dependencies and no install-time scripts. `npm audit` reports one pre-existing high-severity Vite finding ([GHSA-v2wj-q39q-566r](https://github.com/advisories/GHSA-v2wj-q39q-566r)) unrelated to this change — Vite is a transitive dep of Astro, not introduced here. Not in scope.

**Not in scope.** Renderer, CSS, swipe-watch frontmatter, Mux Data analytics, GIF refresher — all tracked as subsequent sub-issues of Phase 1 or as separate Phase 2+ parents.

Authoring-Agent: claude

## Test plan

- [x] `npm install @mux/mux-player` completes without peer-dep errors
- [x] `npm run build` completes cleanly (21 pages + 10 OG images rebuilt)
- [x] `package.json` has `@mux/mux-player: ^3.11.8` under `dependencies`
- [x] `src/content.config.ts` declares `muxPlaybackId: z.string().optional()`
- [ ] Reviewer to confirm the pivot from `@mux/mux-player-astro` is the right call given the peer-dep block
