### PR TITLE
mux(phase-1): wire MuxPlayer into Swipe Watch hero with GIF fallback

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -37,8 +37,9 @@ const projects = defineCollection({
 
     // Mux Playback ID. When set, the project page renders a MUX video
     // in the hero slot; `screenshotSrc` still serves as the JS-disabled
-    // fallback and as the OG image source.
-    muxPlaybackId: z.string().optional(),
+    // fallback and as the OG image source. Rejects empty strings so a
+    // blank frontmatter value is a schema error, not a broken URL.
+    muxPlaybackId: z.string().trim().min(1).optional(),
   }),
 });
 

--- a/src/content/projects/swipe-watch.md
+++ b/src/content/projects/swipe-watch.md
@@ -6,6 +6,7 @@ kicker: "AI × Consumer × Streaming"
 order: 3
 screenshotAspect: "narrow"
 screenshotSrc: "/images/projects/swipe-watch-hero.gif"
+muxPlaybackId: "wNCRY97981o2uDAJrJ3ExPeK379yldRRFJgUIgSYz00k"
 accentColor: "#c11d19"
 accentColorClass: "project-page--red"
 gradientFrom: "#f5ddd4"

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -165,12 +165,12 @@ const {
 
     </article>
   </main>
-</BaseLayout>
 
-<script>
-  // Register <mux-player> only on pages that actually contain one.
-  // Keeps the bundle cost off of projects without a Mux video.
-  if (document.querySelector('mux-player')) {
-    import('@mux/mux-player');
-  }
-</script>
+  <script>
+    // Register <mux-player> only on pages that actually contain one.
+    // Keeps the bundle cost off of projects without a Mux video.
+    if (document.querySelector('mux-player')) {
+      import('@mux/mux-player');
+    }
+  </script>
+</BaseLayout>

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -23,6 +23,7 @@ interface Props {
   gradientTo: string;
   screenshotAspect: 'wide' | 'narrow';
   screenshotSrc: string;
+  muxPlaybackId?: string;
   liveUrl: string;
   githubUrl: string;
   metadata: {
@@ -54,6 +55,7 @@ const {
   gradientTo,
   screenshotAspect,
   screenshotSrc,
+  muxPlaybackId,
   liveUrl,
   githubUrl,
   metadata,
@@ -113,7 +115,21 @@ const {
         />
         <figure class={`project-screenshot project-screenshot--${screenshotAspect}`}>
           <div class="project-screenshot__inner">
-            <img src={screenshotSrc} alt={`${headline} product screenshot`} loading="eager" />
+            {muxPlaybackId ? (
+              <mux-player
+                playback-id={muxPlaybackId}
+                autoplay="muted"
+                muted
+                loop
+                playsinline
+                class="project-screenshot__mux"
+                style="--media-accent-color: var(--project-accent); --media-primary-color: var(--project-accent);"
+              >
+                <img slot="poster" src={screenshotSrc} alt={`${headline} product screenshot`} />
+              </mux-player>
+            ) : (
+              <img src={screenshotSrc} alt={`${headline} product screenshot`} loading="eager" />
+            )}
           </div>
           {stack && (
             <figcaption class="project-stack">
@@ -150,3 +166,11 @@ const {
     </article>
   </main>
 </BaseLayout>
+
+<script>
+  // Register <mux-player> only on pages that actually contain one.
+  // Keeps the bundle cost off of projects without a Mux video.
+  if (document.querySelector('mux-player')) {
+    import('@mux/mux-player');
+  }
+</script>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -68,6 +68,7 @@ const jsonLd = {
   gradientTo={data.gradientTo}
   screenshotAspect={data.screenshotAspect}
   screenshotSrc={data.screenshotSrc}
+  muxPlaybackId={data.muxPlaybackId}
   liveUrl={data.liveUrl}
   githubUrl={data.githubUrl}
   metadata={data.metadata}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1109,6 +1109,31 @@ body.blog-page {
   border: 1px solid var(--rule, rgba(17, 16, 13, 0.12));
 }
 
+/* <mux-player> rendered in the hero slot. The player picks its own
+   aspect ratio from the asset's video metadata — we deliberately don't
+   hardcode one here, because different clips (e.g. 9:19.5 modern phone
+   captures vs. true 9:16) would otherwise render with letterbox bars.
+   Width is capped by the surrounding .project-screenshot--narrow
+   container's 320px max-width so pages stay visually consistent
+   between img and video modes. */
+.project-screenshot__mux {
+  display: block;
+  width: 100%;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+/* Poster frame slotted into the player. Before JS upgrades the custom
+   element, this img renders as light-DOM content and fills the player
+   area so the GIF still shows — the graceful-degradation fallback the
+   plan calls for. */
+.project-screenshot__mux img[slot="poster"] {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 12px;
+}
+
 /* Stack line — rendered as a <figcaption> inside the screenshot figure.
    Single horizontal row with a small-caps label and the stack values.
    Aligned to the inner wrapper, so narrow layouts align with the


### PR DESCRIPTION
## Summary

- Renders `<mux-player>` in the project hero when `muxPlaybackId` is set in frontmatter; otherwise renders the existing `<img>` — no behavior change for projects without a video.
- Adds `muxPlaybackId: "wNCRY97981o2uDAJrJ3ExPeK379yldRRFJgUIgSYz00k"` to [src/content/projects/swipe-watch.md](src/content/projects/swipe-watch.md) so Swipe Watch picks up the new renderer.
- Themes the player via `--media-accent-color` + `--media-primary-color` reading from the existing `--project-accent` CSS var — red (`#c11d19`) resolves automatically on Swipe Watch and will work for any future project using any `project-page--*` class without extra config.
- Player auto-sizes from the asset's video dimensions (hardcoding `aspect-ratio: 9/16` earlier caused letterbox bars because the Swipe Watch asset was captured at modern phone ratio `~9:19.5`, not true `9:16`).
- Loads `@mux/mux-player` only on pages that actually contain a `<mux-player>` element — zero bundle cost for projects without video.
- Hardens the projects schema to reject empty-string `muxPlaybackId` values (CodeRabbit finding from [#233](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/233) that auto-merged before the fix could land — see [nathanjohnpayne/mergepath#136](https://github.com/nathanjohnpayne/mergepath/issues/136) for the workflow gap that caused it).

Closes [#213](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/213).

Part of the [MUX Video Integration](https://github.com/users/nathanjohnpayne/projects/5) initiative.

## Fallback story

The `<img slot="poster">` inside `<mux-player>` serves three purposes:

1. **Poster frame** — shown while the video buffers or before autoplay engages.
2. **Brief pre-upgrade render** — unknown custom elements render their light-DOM children as inline content, so users on slow connections see the GIF before `@mux/mux-player` upgrades the element.
3. **No-JS fallback** — the same unknown-element behavior means the GIF still shows in browsers with JS disabled.

Two visible images are impossible here because there's only one image in the DOM — the slotted child — and it does triple duty.

## Self-Review

**Correctness.** Verified live in the dev preview:

- `<mux-player>` upgrades cleanly (`constructor.name` changes from `HTMLElement`).
- Video element resolves in the nested shadow DOM, plays muted + loops, `currentTime` advances.
- Player dimensions match video intrinsic ratio exactly (both 0.4604), no letterbox.
- Computed `--media-accent-color` resolves to `#c11d19` — themes pulled from `--project-accent` work as designed.
- No console errors.
- Full `npm run build` completes cleanly (21 pages + 10 OG images regenerated).

**Regression risk.** Low.

- `ProjectLayout.astro` only branches on `muxPlaybackId`; existing projects without the field render the old `<img>` identically.
- No changes to OG template generation — `screenshotSrc` is still the source of truth for OG images.
- No changes to `scripts/refresh-hero-images.mjs` — Phase 4 handles the Mux GIF refresh separately.

**Style.** CSS rules sit next to the existing `.project-screenshot` rules. Astro component conditional uses the same ternary shape as surrounding code. No new abstractions; `ProjectMuxPlayer` extraction is deliberately deferred to Phase 3 ([#220](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/220)) since there's only one call site today.

**Test coverage.** No unit tests; the build + preview verification is authoritative for this change.

**Security / dependency hygiene.** No new deps — `@mux/mux-player` was installed in [#233](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/233). The conditional dynamic import (`import('@mux/mux-player')`) is the standard Astro pattern for browser-only module loading.

**Not in scope.** Mux Data analytics (Phase 2), reusable component extraction (Phase 3), Mux-generated GIF fallback (Phase 4). The current `screenshotSrc` GIF stays as the fallback until Phase 4.

Authoring-Agent: claude

## Test plan

- [x] `npm run build` completes cleanly (21 pages + 10 OG images)
- [x] Dev preview: vertical player renders, autoplays muted, loops, no letterbox bars
- [x] Accent color (`#c11d19`) resolves from `--project-accent` into the player's shadow DOM
- [x] No console errors on page load
- [x] Schema rejects empty-string `muxPlaybackId` (CodeRabbit finding carried from [#233](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/233))
- [ ] Reviewer to sanity-check the `document.querySelector('mux-player')` gate on the script import — acceptable cost for non-video projects?
- [ ] Reviewer to confirm the no-JS fallback story (unknown custom element renders light-DOM children inline) is acceptable or if a separate `<noscript>` block is preferred
