### PR TITLE
mux(phase-2): wire PUBLIC_MUX_ENV_KEY + metadata into MuxPlayer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Mux Data environment key. Exposed to client code via Vite's PUBLIC_ prefix.
+# Safe to publish — Mux Data env keys are designed to be client-visible.
+# Find yours at https://dashboard.mux.com/ under Settings -> Data -> Env Keys.
+# Omit or leave blank to disable analytics; the player keeps working.
+PUBLIC_MUX_ENV_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 .firebase/
 .env
 .env.*
+!.env.example
 !*.tpl
 *.key
 service-account.json

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -24,6 +24,7 @@ interface Props {
   screenshotAspect: 'wide' | 'narrow';
   screenshotSrc: string;
   muxPlaybackId?: string;
+  slug: string;
   liveUrl: string;
   githubUrl: string;
   metadata: {
@@ -56,6 +57,7 @@ const {
   screenshotAspect,
   screenshotSrc,
   muxPlaybackId,
+  slug,
   liveUrl,
   githubUrl,
   metadata,
@@ -67,6 +69,10 @@ const {
   ogImageHeight,
   ogImageAlt,
 } = Astro.props;
+
+// Mux Data env key. When unset, the player still runs but emits no
+// analytics — the attribute is conditionally omitted below.
+const muxEnvKey = import.meta.env.PUBLIC_MUX_ENV_KEY;
 ---
 
 <BaseLayout
@@ -122,6 +128,9 @@ const {
                 muted
                 loop
                 playsinline
+                env-key={muxEnvKey}
+                metadata-video-title={headline}
+                metadata-video-id={slug}
                 class="project-screenshot__mux"
                 style="--media-accent-color: var(--project-accent); --media-primary-color: var(--project-accent);"
               >

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -69,6 +69,7 @@ const jsonLd = {
   screenshotAspect={data.screenshotAspect}
   screenshotSrc={data.screenshotSrc}
   muxPlaybackId={data.muxPlaybackId}
+  slug={data.slug}
   liveUrl={data.liveUrl}
   githubUrl={data.githubUrl}
   metadata={data.metadata}


### PR DESCRIPTION
## Summary

- Adds [`.env.example`](.env.example) documenting `PUBLIC_MUX_ENV_KEY` — the client-safe Mux Data env key.
- In [src/layouts/ProjectLayout.astro](src/layouts/ProjectLayout.astro), reads `import.meta.env.PUBLIC_MUX_ENV_KEY` and passes three attributes to `<mux-player>`:
  - `env-key={muxEnvKey}` — when set, telemetry goes to Mux Data; when unset, the attribute is omitted entirely and the player emits nothing.
  - `metadata-video-title={headline}` — the project title.
  - `metadata-video-id={slug}` — the project slug (e.g. `swipe-watch`).
- Adds a `slug` prop to `ProjectLayout` and wires `data.slug` through from [src/pages/projects/[slug].astro](src/pages/projects/[slug].astro).
- Adds `!.env.example` to [.gitignore](.gitignore) so the template file clears the existing `.env.*` ignore rule.

Closes [#216](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/216) and [#217](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/217).

Part of [MUX Video Integration — Phase 2](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/215). The remaining sub-issues — provisioning the key in 1Password + Firebase ([#218](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/218)) and QA that views register in Mux Data ([#219](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/219)) — are blocked on human action and handled separately.

## Graceful-degrade behavior

With `PUBLIC_MUX_ENV_KEY` **unset** (dev preview, local machines without `.env.local`):

```html
<mux-player
  playback-id="wNCRY97981o2uDAJrJ3ExPeK379yldRRFJgUIgSYz00k"
  autoplay="muted" muted loop playsinline
  metadata-video-title="Swipe Watch"
  metadata-video-id="swipe-watch"
  …
/>
```

No `env-key` attribute → no analytics events → no console errors → player works identically.

With `PUBLIC_MUX_ENV_KEY` set (post-provisioning in Firebase):

```html
<mux-player
  env-key="XXXXXXXX"
  playback-id="…"
  metadata-video-title="Swipe Watch"
  metadata-video-id="swipe-watch"
  …
/>
```

Views register in the Mux Data dashboard with correct title + id attribution.

## Self-Review

**Correctness.** Verified in dev preview:

- `env_key_attr_present: false` when unset → confirmed Astro omits the attribute for `undefined` values (vs rendering `env-key="undefined"` as a literal, which Mux would reject).
- `metadata-video-title="Swipe Watch"` and `metadata-video-id="swipe-watch"` both present.
- No console errors.
- Full `npm run build` completes cleanly.

**Regression risk.** Low.

- Three attributes added to an existing `<mux-player>` conditional. None of them affect layout or render when unset.
- `slug` is threaded as a new required prop; every call site (only `[slug].astro`) is updated in the same PR.
- `.gitignore` change is purely additive (a negation).

**Style.** The `muxEnvKey` const sits next to the other frontmatter prop destructuring with a short comment explaining the graceful-degrade contract.

**Test coverage.** No unit tests; dev-preview verification and build success are authoritative.

**Security / dependency hygiene.** `PUBLIC_MUX_ENV_KEY` uses Astro+Vite's standard `PUBLIC_` prefix for client-visible env vars. Mux Data env keys are designed to be public (unlike API tokens) — safe to ship in the built client bundle. No new deps.

**Not in scope.** Provisioning the key in 1Password or Firebase ([#218](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/218)). Mux Data dashboard QA ([#219](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/219)). Both are blocked on human action.

Authoring-Agent: claude

## Test plan

- [x] `npm run build` completes cleanly (21 pages + 10 OG images)
- [x] Dev preview: `env-key` attribute absent when unset; metadata attrs populated
- [x] No console errors
- [ ] Reviewer to confirm `env-key={undefined}` → omitted attribute is the desired contract (alternative: conditional rendering of the attr with a ternary at the call site)
