### PR TITLE
mux(phase-2): provision PUBLIC_MUX_ENV_KEY via .env.tpl + 1Password

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -1,0 +1,7 @@
+# Template resolved by scripts/bootstrap.sh via `op inject`.
+# Never edit the generated .env.local directly — change this file and
+# re-run ./scripts/bootstrap.sh --force.
+
+# Mux Data environment key. Client-visible, safe to publish post-build.
+# Dashboard: https://dashboard.mux.com/ (Settings, Data, Environments)
+PUBLIC_MUX_ENV_KEY=op://Private/owk6d74z2ofmrcivmgju25pifm/env-key

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -365,6 +365,28 @@ This runs `astro build`, which:
 
 Astro handles asset fingerprinting automatically — no manual cache-busting is needed.
 
+### Client-side env vars
+
+Any `PUBLIC_*` env var read via `import.meta.env` during the build is baked into the emitted HTML/JS. These are resolved from `.env.local`, which `scripts/bootstrap.sh` generates from `.env.tpl` via `op inject`.
+
+**Workflow when adding a new client env var:**
+
+1. Add the line to `.env.tpl` with an `op://` reference:
+   ```
+   PUBLIC_FOO=op://Private/<1p-item-id>/<field>
+   ```
+2. Store the secret in 1Password at that path.
+3. Anyone on the team runs `./scripts/bootstrap.sh --force` to refresh their `.env.local`.
+4. `npm run build` picks up the new value automatically.
+
+**Current `PUBLIC_*` vars:**
+
+| Var | 1Password reference | Purpose |
+|---|---|---|
+| `PUBLIC_MUX_ENV_KEY` | `op://Private/owk6d74z2ofmrcivmgju25pifm/env-key` | Mux Data analytics env key (safe to publish; Mux env keys are client-visible by design). Unset = analytics off, player still works. |
+
+Mux env key is provisioned per Mux workspace, not per deploy target — the same key works for dev and prod. Rotate via the [Mux dashboard](https://dashboard.mux.com/) (Settings → Data → Environments) and update the 1Password item; the next bootstrap + build picks up the new value.
+
 ## Deployment Steps
 
 All deploys use `op-firebase-deploy` for keyless, non-interactive service account impersonation. **Never run `firebase deploy` directly.**

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -372,9 +372,11 @@ Any `PUBLIC_*` env var read via `import.meta.env` during the build is baked into
 **Workflow when adding a new client env var:**
 
 1. Add the line to `.env.tpl` with an `op://` reference:
-   ```
+
+   ```dotenv
    PUBLIC_FOO=op://Private/<1p-item-id>/<field>
    ```
+
 2. Store the secret in 1Password at that path.
 3. Anyone on the team runs `./scripts/bootstrap.sh --force` to refresh their `.env.local`.
 4. `npm run build` picks up the new value automatically.

--- a/scripts/bootstrap-config.sh
+++ b/scripts/bootstrap-config.sh
@@ -1,11 +1,21 @@
-# bootstrap-config.sh — Repo-specific 1Password item mappings
+# bootstrap-config.sh — Repo-specific 1Password mappings
 #
-# Each entry: "1password_item_id:relative_file_path"
-# The item's notesPlain field stores the file contents.
+# Two patterns supported:
 #
-# To add a new file:
-#   1. Store it: op item create --category="Secure Note" --title="<Repo> Local Config (<filename>)" --vault=Private --tags=bootstrap "notesPlain=$(cat <file>)"
-#   2. Copy the item ID and add an entry below.
+# 1. INJECT_FILES (preferred): `.env.tpl` files containing op:// references
+#    resolved by `op inject`. Each entry: "template/path:output/path"
+#    (both relative to repo root). Secrets stay in 1Password; only the
+#    template ships in git.
+#
+# 2. BOOTSTRAP_FILES (legacy): whole-file contents stored in a 1Password
+#    Secure Note's `notesPlain` field. Each entry:
+#    "1password_item_id:relative_file_path"
+#    Use only when a file can't easily be expressed as a template of
+#    op:// references.
+
+INJECT_FILES=(
+  ".env.tpl:.env.local"
+)
 
 BOOTSTRAP_FILES=(
 )


### PR DESCRIPTION
## Summary

- Adds [`.env.tpl`](.env.tpl) with an `op://` reference to the Mux Data env key stored in 1Password (item `owk6d74z2ofmrcivmgju25pifm`, field `env-key`).
- Populates `INJECT_FILES` in [scripts/bootstrap-config.sh](scripts/bootstrap-config.sh) so `./scripts/bootstrap.sh --force` materializes `.env.local` from the template via `op inject`.
- Documents the pattern + current `PUBLIC_*` vars in [DEPLOYMENT.md](DEPLOYMENT.md) under a new "Client-side env vars" subsection.

Closes [#218](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/218). Part of [MUX Video Integration — Phase 2](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/215).

## How it flows end-to-end

1. **Provisioning** (one-time per env key): secret stored in 1Password as a field on an API Credential item.
2. **Local dev**: `./scripts/bootstrap.sh --force` reads `.env.tpl`, resolves the op:// reference via `op inject`, writes `.env.local`. `.env.local` stays gitignored.
3. **Build**: `npm run build` reads `import.meta.env.PUBLIC_MUX_ENV_KEY` from `.env.local` and bakes it into the emitted HTML as the `env-key` attribute on `<mux-player>`.
4. **Deploy**: `op-firebase-deploy` ships `dist/` as-is — no Firebase-side env vars or CI secrets needed. Since Mux env keys are client-visible by design, baking at build time is the correct tradeoff.
5. **Rotation**: if the key ever changes, update the 1Password item; next bootstrap + build carries it through.

## Verification (done locally)

- `./scripts/bootstrap.sh --force` → "INJECT .env.tpl -> .env.local" followed by "Bootstrap complete."
- `.env.local` contains `PUBLIC_MUX_ENV_KEY=<25-char alphanumeric>` (verified via a `.isalnum()` check).
- `npm run build` completes cleanly (21 pages + 10 OG images).
- `grep -o 'env-key="[^"]*"' dist/projects/swipe-watch/index.html` → `env-key="<key>"` ✓
- Dev server (`npm run dev`): `document.querySelector('mux-player').getAttribute('env-key')` returns the 25-char key.
- `metadata-video-title="Swipe Watch"` and `metadata-video-id="swipe-watch"` both still populate.
- No console errors.

Mux Data dashboard QA ([#219](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/219)) is the last Phase 2 sub-issue — unblocked now, handled after this merges + deploys.

## Self-Review

**Correctness.** The `.env.tpl` contains only an op:// reference, no plaintext. `op inject` is the officially recommended 1Password CLI pattern (referenced in [scripts/bootstrap.sh](scripts/bootstrap.sh) header under "Best practices"). The PR pairs with what was already a documented-but-empty `INJECT_FILES` mechanism in [bootstrap-config.sh](scripts/bootstrap-config.sh) — this PR lights it up for the first time in this repo.

**Regression risk.** Low.

- No runtime code changes. Existing pages without `muxPlaybackId` are unaffected.
- Bootstrap.sh's INJECT_FILES loop pre-existed; this PR just adds its first entry.
- `.env.tpl` passes the existing `.gitignore`'s `!*.tpl` negation — no gitignore change needed.
- DEPLOYMENT.md change is documentation only.

**Style.** Matches the existing DEPLOYMENT.md tone and section structure (H2 + tables for reference lookup). The `.env.tpl` comment block avoids embedding `op://` in prose to sidestep `op inject`'s parser (it treats any `op://` substring as a reference and will fail if one isn't well-formed — hit during local verification, fixed by rewording the comments).

**Test coverage.** No unit tests; end-to-end verification is authoritative (bootstrap → build → serve → assert attr).

**Security / dependency hygiene.** No new deps. Mux env keys are designed to be client-visible (unlike API tokens); baking them into the built client bundle is the correct tradeoff and matches Mux's [published guidance](https://docs.mux.com/guides/data/track-your-data).

**Not in scope.** Mux Data dashboard QA ([#219](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/219)) — deferred until this PR merges and deploys.

Authoring-Agent: claude

## Test plan

- [x] `./scripts/bootstrap.sh --force` generates valid `.env.local` from `.env.tpl`
- [x] `.env.local` has `PUBLIC_MUX_ENV_KEY=<25-char alphanumeric>`
- [x] `npm run build` completes cleanly
- [x] `dist/projects/swipe-watch/index.html` has `env-key="<key>"` on `<mux-player>`
- [x] Dev server renders `env-key` + metadata attrs
- [x] No console errors
- [ ] Reviewer to sanity-check that the `op://` reference in `.env.tpl` matches the expected item ID format used elsewhere in the repo
