### PR TITLE
mux(phase-3): extract ProjectMuxPlayer.astro + swap in ProjectLayout

### DIFF
--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -1,0 +1,51 @@
+---
+// Hero video slot for project pages. When `playbackId` is set, renders a
+// MUX video themed by the surrounding page's --project-accent CSS var.
+// When unset, falls back to the `fallbackSrc` image so the hero never
+// goes blank. Accent theming flows through the documented mux-player
+// CSS vars (`--media-accent-color`, `--media-primary-color`), so any
+// project page that sets `--project-accent` on its container inherits
+// the tint automatically.
+
+interface Props {
+  playbackId?: string;
+  fallbackSrc: string;
+  title: string;
+  slug: string;
+}
+
+const { playbackId, fallbackSrc, title, slug } = Astro.props;
+
+// Mux Data env key. Baked into the build via `import.meta.env`; when
+// unset, Astro omits the attribute and the player emits no analytics.
+const muxEnvKey = import.meta.env.PUBLIC_MUX_ENV_KEY;
+
+const altText = `${title} product screenshot`;
+---
+
+{playbackId ? (
+  <mux-player
+    playback-id={playbackId}
+    autoplay="muted"
+    muted
+    loop
+    playsinline
+    env-key={muxEnvKey}
+    metadata-video-title={title}
+    metadata-video-id={slug}
+    class="project-screenshot__mux"
+    style="--media-accent-color: var(--project-accent); --media-primary-color: var(--project-accent);"
+  >
+    <img slot="poster" src={fallbackSrc} alt={altText} />
+  </mux-player>
+) : (
+  <img src={fallbackSrc} alt={altText} loading="eager" />
+)}
+
+<script>
+  // Register <mux-player> only on pages that actually contain one.
+  // Keeps the bundle cost off of projects without a Mux video.
+  if (document.querySelector('mux-player')) {
+    import('@mux/mux-player');
+  }
+</script>

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -3,6 +3,7 @@ import BaseLayout from './BaseLayout.astro';
 import HeroWide from '../components/HeroWide.astro';
 import HeroNarrow from '../components/HeroNarrow.astro';
 import MetadataStrip from '../components/MetadataStrip.astro';
+import ProjectMuxPlayer from '../components/ProjectMuxPlayer.astro';
 
 interface RelatedLink {
   label: string;
@@ -69,10 +70,6 @@ const {
   ogImageHeight,
   ogImageAlt,
 } = Astro.props;
-
-// Mux Data env key. When unset, the player still runs but emits no
-// analytics — the attribute is conditionally omitted below.
-const muxEnvKey = import.meta.env.PUBLIC_MUX_ENV_KEY;
 ---
 
 <BaseLayout
@@ -121,24 +118,12 @@ const muxEnvKey = import.meta.env.PUBLIC_MUX_ENV_KEY;
         />
         <figure class={`project-screenshot project-screenshot--${screenshotAspect}`}>
           <div class="project-screenshot__inner">
-            {muxPlaybackId ? (
-              <mux-player
-                playback-id={muxPlaybackId}
-                autoplay="muted"
-                muted
-                loop
-                playsinline
-                env-key={muxEnvKey}
-                metadata-video-title={headline}
-                metadata-video-id={slug}
-                class="project-screenshot__mux"
-                style="--media-accent-color: var(--project-accent); --media-primary-color: var(--project-accent);"
-              >
-                <img slot="poster" src={screenshotSrc} alt={`${headline} product screenshot`} />
-              </mux-player>
-            ) : (
-              <img src={screenshotSrc} alt={`${headline} product screenshot`} loading="eager" />
-            )}
+            <ProjectMuxPlayer
+              playbackId={muxPlaybackId}
+              fallbackSrc={screenshotSrc}
+              title={headline}
+              slug={slug}
+            />
           </div>
           {stack && (
             <figcaption class="project-stack">
@@ -174,12 +159,4 @@ const muxEnvKey = import.meta.env.PUBLIC_MUX_ENV_KEY;
 
     </article>
   </main>
-
-  <script>
-    // Register <mux-player> only on pages that actually contain one.
-    // Keeps the bundle cost off of projects without a Mux video.
-    if (document.querySelector('mux-player')) {
-      import('@mux/mux-player');
-    }
-  </script>
 </BaseLayout>


### PR DESCRIPTION
## Summary

- Extracts MUX-specific render logic out of [src/layouts/ProjectLayout.astro](src/layouts/ProjectLayout.astro) into a dedicated [src/components/ProjectMuxPlayer.astro](src/components/ProjectMuxPlayer.astro).
- The component owns: conditional `<mux-player>` vs `<img>` render, CSS-var theming passthrough, Mux Data wiring (`env-key` + metadata), and the runtime script that imports `@mux/mux-player` only on pages with a player.
- `ProjectLayout.astro` now calls `<ProjectMuxPlayer />` with four props and no longer touches `PUBLIC_MUX_ENV_KEY` directly.

Closes [#221](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/221) and [#222](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/222).

Part of [MUX Video Integration — Phase 3](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/220).

## Why this shape

Any future project page that wants a MUX video now adds **one frontmatter field** (`muxPlaybackId`). The component handles theming automatically via `--project-accent`, so the red/yellow/blue/etc. project-page classes light up the player's progress bar without any per-page config. That's the Phase 3 exit criterion.

The component's `<script>` tag with the `document.querySelector('mux-player')` gate is preserved inside the component — Astro hoists it once per page that renders `<ProjectMuxPlayer>`, and the runtime check ensures the heavy `@mux/mux-player` module only downloads on pages where a `<mux-player>` tag was actually emitted (i.e. only Swipe Watch today). Bundle cost stays zero on every other project page.

## Verification (dev preview, local)

Swipe Watch (`/projects/swipe-watch/`):

```json
{
  "playback_id": "wNCRY97981o2uDAJrJ3ExPeK379yldRRFJgUIgSYz00k",
  "env_key":     "6e3df7ilf13pn04stchr551h3",
  "metadata_title": "Swipe Watch",
  "metadata_id":    "swipe-watch",
  "poster_img":     "/images/projects/swipe-watch-hero.gif",
  "accent_resolved": "#c11d19",
  "upgraded": true
}
```

All six attributes match the pre-refactor values exactly. `--media-accent-color` still resolves through the shadow DOM to the page's `--project-accent`.

Mergepath (`/projects/mergepath/`, no playbackId):

```json
{
  "has_mux_player": false,
  "has_img":        true,
  "img_src":        "/images/projects/mergepath.png",
  "img_loading":    "eager"
}
```

Fallback path unchanged. No `<mux-player>` emitted. No console errors on either page. Full `npm run build` completes cleanly (21 pages + 10 OG images), with `dist/projects/swipe-watch/index.html` containing one `mux-player` and `dist/projects/mergepath/index.html` containing zero.

## Self-Review

**Correctness.** The component's prop surface (`playbackId?`, `fallbackSrc`, `title`, `slug`) is minimal and matches what ProjectLayout already had. Optional `playbackId` keeps the component safe to call unconditionally from the layout; the conditional lives inside the component now. `fallbackSrc` is always required — it's the only image source available for the no-MUX path, so "required" is correct.

**Regression risk.** Low.

- Pure refactor: no attribute values, no CSS, no JS behavior changed — only the source file where each thing lives.
- Verified byte-for-byte at the attribute level (all 6 live-checked values match pre-refactor).
- Tested both MUX (Swipe Watch) and non-MUX (Mergepath) paths.
- `import.meta.env.PUBLIC_MUX_ENV_KEY` now read inside the component; behaves identically since Astro resolves env vars at build time regardless of which file reads them.

**Style.** The component's doc-comment header explains what it does, how accent theming flows, and why it's safe to call unconditionally. The body matches the existing Astro component patterns elsewhere in `src/components/`.

**Test coverage.** No unit tests; dev-preview + build-diff verification are authoritative for this refactor.

**Security / dependency hygiene.** No new deps. The script-tag import gate is preserved.

**Not in scope.** Documentation of the "how to add a MUX video" recipe ([#223](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/223)) and theming QA across all accent classes ([#224](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/224)) stay as separate sub-issues. Also not in scope: Safari autoplay fix ([#237](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/237)) — tracked separately, unchanged by this PR.

Authoring-Agent: claude

## Test plan

- [x] `npm run build` completes cleanly
- [x] Swipe Watch renders player with all 6 attributes matching pre-refactor
- [x] Mergepath renders plain `<img loading="eager">`, no `<mux-player>` in DOM or built HTML
- [x] No console errors on either page
- [x] Accent color `#c11d19` resolves to `--media-accent-color` inside the player's shadow DOM
- [ ] Reviewer to eyeball the `<script>` relocation — is "script lives in the component that emits the element it registers" the right ergonomic, or would a layout-level script be clearer?
