### PR TITLE
mux(phase-3): document muxPlaybackId + ProjectMuxPlayer in project-pages spec

### DIFF
--- a/specs/project-pages.md
+++ b/specs/project-pages.md
@@ -75,6 +75,7 @@ draft: false
 | `metadata.status` | string | yes | Metadata strip: project status |
 | `stack` | string | no | Tech stack values separated by ` · ` (e.g., `"React · TypeScript · Vite · Firebase · Vitest"`). Rendered as a figcaption below the screenshot. Optional — projects without a stack field render without the caption |
 | `related` | array | no | Related links with `label` and `href` |
+| `muxPlaybackId` | string | no | Mux public Playback ID. When set, the hero renders a themed `<mux-player>` video and `screenshotSrc` is used as the poster + JS-disabled fallback. See "Adding a Mux video" below |
 | `draft` | boolean | no | `true` to exclude from builds (default: `false`) |
 
 ### Body content structure
@@ -126,6 +127,40 @@ Used for phone/mobile screenshots. The figure's inner wrapper (`.project-screens
 | Phone (≤480px) | Collapses to single column | Full-width image (unchanged) | Inner wrapper and stack caption stay at the tablet 280px cap; natural wrapping |
 
 The `.metadata-strip--grid-2x2` variant from the previous architecture has been removed — the metadata strip no longer varies by screenshot aspect. Wide and narrow differ only in how the figure sizes the image.
+
+---
+
+## Adding a Mux video
+
+Any project can render a vertical Mux video in the hero instead of a static screenshot. The existing `screenshotSrc` stays in the frontmatter — it's still used as the player's poster frame and as the no-JS fallback.
+
+### Steps
+
+1. Upload the video to the [Mux dashboard](https://dashboard.mux.com/).
+2. Copy the **public Playback ID** (not the Asset ID — they look similar but the Asset ID is a different namespace).
+3. Add one line to the project's frontmatter:
+
+   ```yaml
+   muxPlaybackId: "abc123defGHI456..."
+   ```
+
+4. Build and deploy. That's it — the `<ProjectMuxPlayer>` component handles rendering, theming, analytics, and fallback.
+
+### What happens automatically
+
+- **Theming**: the player's progress bar, scrubber, and accent ornaments pick up the page's `--project-accent` CSS var. Any `project-page--*` class (red, yellow, blue, etc.) themes the player with no extra config.
+- **Autoplay + loop**: `autoplay="muted" muted loop playsinline` match the feel of the animated GIFs that the static hero slot previously used.
+- **Analytics**: if `PUBLIC_MUX_ENV_KEY` is provisioned (see [DEPLOYMENT.md](../DEPLOYMENT.md#client-side-env-vars)), the player reports views to Mux Data tagged with `video_title` = project title and `video_id` = project slug. Without the env key, the player runs identically but emits no analytics.
+- **Fallback**: the existing `screenshotSrc` image renders as the `<img slot="poster">` inside `<mux-player>`. Browsers with JS disabled render the poster directly (unknown custom elements render their light-DOM children inline).
+- **Bundle cost**: `@mux/mux-player` only downloads on pages that actually contain a `<mux-player>` element — projects without `muxPlaybackId` pay zero cost.
+
+### Aspect ratio
+
+Don't hardcode one. The player auto-sizes from the asset's metadata. The Swipe Watch asset is captured at a modern phone ratio (~9:19.5), not true 9:16 — forcing 9:16 earlier produced letterbox bars. Record or export the source video at the final aspect you want.
+
+### Component source
+
+[src/components/ProjectMuxPlayer.astro](../src/components/ProjectMuxPlayer.astro). Add new props to that component when a per-project override is needed (custom alt text, different fallback, etc.).
 
 ---
 

--- a/specs/project-pages.md
+++ b/specs/project-pages.md
@@ -75,7 +75,7 @@ draft: false
 | `metadata.status` | string | yes | Metadata strip: project status |
 | `stack` | string | no | Tech stack values separated by ` · ` (e.g., `"React · TypeScript · Vite · Firebase · Vitest"`). Rendered as a figcaption below the screenshot. Optional — projects without a stack field render without the caption |
 | `related` | array | no | Related links with `label` and `href` |
-| `muxPlaybackId` | string | no | Mux public Playback ID. When set, the hero renders a themed `<mux-player>` video and `screenshotSrc` is used as the poster + JS-disabled fallback. See "Adding a Mux video" below |
+| `muxPlaybackId` | non-empty string | no | Mux public Playback ID. When set, the hero renders a themed `<mux-player>` video and `screenshotSrc` is used as the poster + JS-disabled fallback. Schema rejects blank / whitespace-only values so a stray empty string fails build-time rather than producing a broken URL. See "Adding a Mux video" below |
 | `draft` | boolean | no | `true` to exclude from builds (default: `false`) |
 
 ### Body content structure
@@ -156,7 +156,7 @@ Any project can render a vertical Mux video in the hero instead of a static scre
 
 ### Aspect ratio
 
-Don't hardcode one. The player auto-sizes from the asset's metadata. The Swipe Watch asset is captured at a modern phone ratio (~9:19.5), not true 9:16 — forcing 9:16 earlier produced letterbox bars. Record or export the source video at the final aspect you want.
+The player auto-sizes from the asset's video metadata. There is **no per-project frontmatter override** — record or export the source video at the final aspect you want and it renders at that shape. Earlier revisions hardcoded `9/16` in CSS and produced letterbox bars on the Swipe Watch asset, which is captured at a modern phone ratio (~9:19.5) rather than true 9:16. If a future project needs a different aspect treatment (e.g. a `cover`-style crop, or a container-driven ratio override), add a prop to [ProjectMuxPlayer.astro](../src/components/ProjectMuxPlayer.astro) at that point.
 
 ### Component source
 


### PR DESCRIPTION
## Summary

- Adds a `muxPlaybackId` entry to the frontmatter field reference table in [specs/project-pages.md](specs/project-pages.md).
- Adds an "Adding a Mux video" section covering the one-line recipe, what the component handles automatically (theming, autoplay/loop, analytics gating, fallback, bundle cost), the deliberate no-hardcoded-aspect-ratio decision, and a pointer to [src/components/ProjectMuxPlayer.astro](src/components/ProjectMuxPlayer.astro).

Closes [#223](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/223).

Docs-only. No code changes.

## Why `specs/project-pages.md`, not `AGENTS.md`

The [Phase 3 plan](https://github.com/users/nathanjohnpayne/projects/5) originally pointed at `AGENTS.md`, but `AGENTS.md` is explicitly the code-review-policy doc — it describes the agent workflow for opening and reviewing PRs, not how to author content. `specs/project-pages.md` is the project-authoring spec; it already documents the frontmatter schema and layout variants, so the Mux recipe slots in next to the fields a contributor would be reading when they add a new project.

The spec is the right place for a few more reasons:

- It's the file a future contributor would grep for when they need to know what frontmatter fields exist.
- The section links to [DEPLOYMENT.md § Client-side env vars](DEPLOYMENT.md#client-side-env-vars) for the `PUBLIC_MUX_ENV_KEY` story, so the divide-of-labor between specs (authoring contract) and DEPLOYMENT (operator contract) stays clean.
- It lives next to the existing "Color System" documentation that the Mux theming story naturally extends (the player picks up `--project-accent` the same way bullet markers and hover states do).

## Self-Review

**Correctness.** Every claim in the new section maps to observed behavior from [#234](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/234), [#235](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/235), [#236](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/236), and [#238](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/238):

- Theming flow: `--media-accent-color` + `--media-primary-color` → `--project-accent` — verified live on Swipe Watch (`#c11d19` resolves through the shadow DOM).
- Autoplay + loop attributes: what `ProjectMuxPlayer.astro:30-33` actually emits.
- Analytics gating: `env-key` attribute is omitted when `PUBLIC_MUX_ENV_KEY` is undefined — verified in both dev (env absent) and prod (env present) preview runs.
- Fallback: `<img slot="poster">` rendered as light-DOM child — the "unknown custom elements render their children inline" behavior was verified in the no-JS branch of Phase 1 QA.
- Bundle cost: the component's `<script>` tag checks `document.querySelector('mux-player')` before dynamically importing — verified by building and inspecting `dist/projects/mergepath/index.html` which emits no `<mux-player>`.
- Aspect-ratio guidance: the letterbox issue was literally hit during [#234](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/234); the followup commit removed the hardcoded `9/16`.

**Regression risk.** None — docs only, no code touched.

**Style.** Matches the existing spec's tone (terse intro sentences, bullet lists for behaviors, fenced code blocks for snippets). The new section sits between "Layout Variants" and "Color System" so the document flow goes: how to structure the page → what it looks like → how to add a video → how colors work.

**Not in scope.** Theming QA ([#224](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/224)) — manual verification against each accent class, handled separately. Safari autoplay ([#237](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/237)) — still tracked.

Authoring-Agent: claude

## Test plan

- [x] No code changes; no build regression possible
- [x] Every behavior claim traced to a specific prior PR and verified live
- [ ] Reviewer to sanity-check that specs/project-pages.md is the right home (vs AGENTS.md as the original plan said)
