### PR TITLE
mux(phase-4): document the Mux GIF refresher

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -356,11 +356,21 @@ The site uses Astro to generate static HTML/CSS/JS into `dist/`. **Always build 
 npm run build
 ```
 
-This runs `astro build`, which:
+`npm run build` runs `prebuild` first, then `astro build`.
+
+**`prebuild`** (chained via `&&` in [package.json](package.json)):
+
+1. `node scripts/refresh-hero-images.mjs` — for every project with `heroRefresh: github-social` in its frontmatter, re-fetches the repo's current GitHub social preview and writes it to `public/<screenshotSrc>`. Fails soft on any error; keeps the existing image.
+2. `node scripts/refresh-mux-gifs.mjs` — for every project with a `muxPlaybackId`, fetches an animated GIF from `image.mux.com` and writes it to `public/<screenshotSrc>`. Fails **loud** on any network error (non-zero exit halts the build); the Mux GIF is the only authoritative source for the hero fallback on Mux-backed projects, so a silent miss would ship stale content. See [specs/project-pages.md § Fallback GIF regeneration](specs/project-pages.md#fallback-gif-regeneration) for the full contract.
+
+The two refreshers never race for the same output path — `refresh-hero-images.mjs` explicitly skips any project with `muxPlaybackId`.
+
+**`astro build`** then:
+
 1. Compiles all `.astro` pages and layouts into static HTML
 2. Processes Markdown blog posts via Content Collections
 3. Generates the sitemap via `@astrojs/sitemap`
-4. Generates OG images via the custom Playwright integration
+4. Generates OG images via the custom Playwright integration (OG templates consume the freshly-regenerated GIFs from step 2 of prebuild, so OG images and hero images stay in sync)
 5. Outputs everything to `dist/`
 
 Astro handles asset fingerprinting automatically — no manual cache-busting is needed.

--- a/specs/project-pages.md
+++ b/specs/project-pages.md
@@ -162,6 +162,24 @@ The player auto-sizes from the asset's video metadata. There is **no per-project
 
 [src/components/ProjectMuxPlayer.astro](../src/components/ProjectMuxPlayer.astro). Add new props to that component when a per-project override is needed (custom alt text, different fallback, etc.).
 
+### Fallback GIF regeneration
+
+`screenshotSrc` is the JS-disabled fallback and the OG image source. For projects with `muxPlaybackId`, the GIF at that path is **regenerated from Mux on every build** by [scripts/refresh-mux-gifs.mjs](../scripts/refresh-mux-gifs.mjs), which runs as part of `prebuild`. The script fetches `https://image.mux.com/{playbackId}/animated.gif?width=320&fps=15&end=8` and writes the response directly to `public/<screenshotSrc>`.
+
+Key behaviors:
+
+- **Strict failure on network errors.** Any non-200 response or network timeout exits non-zero and halts the build. The design note in the script header explains why: Mux is the only source for a project's fallback frame once `muxPlaybackId` is set, so a silent miss would serve stale content indefinitely.
+- **Per-project config errors warn, don't halt.** A malformed frontmatter (e.g. relative `screenshotSrc`) logs a warning and skips that project — the build still completes.
+- **Co-exists with the GitHub-social refresher.** [scripts/refresh-hero-images.mjs](../scripts/refresh-hero-images.mjs) (which refreshes `heroRefresh: github-social` projects) skips any project with `muxPlaybackId` so the two refreshers can never race for the same output path.
+
+To regenerate a Mux GIF manually without a full build:
+
+```bash
+node scripts/refresh-mux-gifs.mjs
+```
+
+Rendering knobs (width, fps, duration) live at the top of the script. If a future project needs different framing, either pass URL params from within the script or split to per-project config — don't hardcode a second call site.
+
 ---
 
 ## Color System


### PR DESCRIPTION
## Summary

- [specs/project-pages.md](specs/project-pages.md): new "Fallback GIF regeneration" subsection under the Mux video docs. Covers the strict-network / soft-config failure split, the co-existence contract with `refresh-hero-images.mjs`, and the manual regeneration command.
- [DEPLOYMENT.md](DEPLOYMENT.md): expanded the Build Process section with the two-stage prebuild chain (GitHub-social soft-fail + Mux hard-fail) and a forward-link to the spec section.

Closes [#229](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/229).

Docs-only. No code changes. Part of [MUX Video Integration — Phase 4](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/225).

## Why both docs

Two audiences:

- **Project authors** (`specs/project-pages.md`): "I'm adding a new project with a Mux video — what happens to the GIF?" Answer: it's regenerated on every build, and here's the strict-vs-soft contract.
- **Operators** (`DEPLOYMENT.md`): "What runs when I `npm run build`?" Answer: prebuild chains two refreshers, here's the order and failure-mode split, forward-link to the spec for the detailed contract.

The divide is the same as the existing split between `specs/` (authoring / product contract) and `DEPLOYMENT.md` (operator / build contract). The Mux env-key docs already live in both places for the same reason.

## Self-Review

**Accuracy.** Every claim in both doc sections traces back to the code merged in [#240](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/240):

- "Fails loud on network errors, soft on config" — matches [scripts/refresh-mux-gifs.mjs](scripts/refresh-mux-gifs.mjs)'s `main().catch()` handler and the per-project `screenshotSrc` branch.
- "Two refreshers never race" — matches [scripts/refresh-hero-images.mjs](scripts/refresh-hero-images.mjs)'s `skippedMuxBacked` branch.
- "prebuild chains both" — matches [package.json](package.json)'s `"prebuild": "node scripts/refresh-hero-images.mjs && node scripts/refresh-mux-gifs.mjs"`.
- "Rendering knobs at the top of the script" — `GIF_WIDTH`, `GIF_FPS`, `GIF_END` constants in `refresh-mux-gifs.mjs`.

**Regression risk.** None — docs only.

**Style.** Matches the existing tone in both docs. The new subsection in `specs/project-pages.md` sits under the "Adding a Mux video" umbrella next to the existing "Aspect ratio" and "Component source" subsections, which is the right nesting level. The `DEPLOYMENT.md` change keeps the existing numbered "astro build then" list and adds a separate "prebuild" paragraph before it, preserving the document's flow.

**Not in scope.** Phase 4 QA ([#230](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/230)) — handled as the next step.

Authoring-Agent: claude

## Test plan

- [x] No code changes; zero build-regression risk
- [x] Every behavior claim traced to a specific line in [#240](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/240)'s merged code
- [ ] Reviewer to sanity-check that the two-audience split (spec for authors, DEPLOYMENT.md for operators) is the right framing
