### PR TITLE
fix(mux): bare autoplay + preload=auto for Safari autoplay

### DIFF
--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -26,7 +26,7 @@ const altText = `${title} product screenshot`;
 {playbackId ? (
   <mux-player
     playback-id={playbackId}
-    autoplay
+    autoplay="muted"
     muted
     loop
     playsinline

--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -26,10 +26,11 @@ const altText = `${title} product screenshot`;
 {playbackId ? (
   <mux-player
     playback-id={playbackId}
-    autoplay="muted"
+    autoplay
     muted
     loop
     playsinline
+    preload="auto"
     env-key={muxEnvKey}
     metadata-video-title={title}
     metadata-video-id={slug}


### PR DESCRIPTION
## Summary

Attempt 1 at [#237](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/237) — Safari doesn't autoplay the Mux player on `/projects/swipe-watch/` while Chrome does.

Two small changes on `<mux-player>` in [src/components/ProjectMuxPlayer.astro](src/components/ProjectMuxPlayer.astro):

1. **`autoplay="muted"` → `autoplay` (bare boolean).** `autoplay="muted"` is Mux-specific shorthand for "try autoplay, fall back to muted autoplay if denied." The HTML standard is a boolean `autoplay` attribute, and Safari's autoplay-policy gate reads the attribute via the standard path. `muted` is already set separately so playback stays silent. This matches [Mux's documented example](https://www.mux.com/docs/guides/autoplay-your-videos).
2. **Added `preload="auto"`.** Safari in some versions only attempts autoplay after metadata is available, and the default `preload="metadata"` can defer the first HLS segment. Explicit `preload="auto"` nudges Safari to fetch eagerly, closing a small timing window where `play()` fires before the player has anything to play.

## Verification

- Chromium baseline preserved. Built HTML emits `autoplay="true" preload="auto"` on `<mux-player>`; dev preview confirms video plays (`paused: false`, `currentTime` advances), muted, loops.
- Safari verification is on you — live deploy needed.

## Self-Review

**Correctness.** Two low-risk attribute changes, well-documented in the HTML / Mux spec references. The bare-boolean form `autoplay` JSX-renders to `autoplay="true"` in Astro (boolean attrs on custom elements are stringified), which is still treated as truthy by browsers per HTML spec.

**Regression risk.** Low.

- The `muted` attribute was already present, so removing `autoplay="muted"` doesn't change "is the video muted on autoplay" behavior.
- `preload="auto"` only accelerates fetch; it doesn't change what the player does post-fetch.
- Chromium verified unaffected.

**If this doesn't fix Safari.** Next attempts ranked:

1. Drop the animated GIF from `<img slot="poster">`. Safari has documented issues deferring `play()` when the poster is an ever-changing animated source. Swap for a static PNG extracted from the GIF's first frame.
2. Add a client-side `play()` fallback on the `canplay` event to force-start playback once the player has bufferable content.
3. Remove the `<img slot="poster">` entirely and let Mux's default poster (the Mux Player's auto-generated thumbnail) render instead.

Will iterate based on what Web Inspector shows when you test.

**Not in scope.** The separate "video quality looks worse in Safari" observation is a side-effect of autoplay failure (Safari shows the 320px GIF poster instead of the HLS video) — resolves once autoplay works.

Authoring-Agent: claude

## Test plan

- [x] `npm run build` succeeds; built HTML has `autoplay="true" preload="auto"`
- [x] Dev preview (Chromium): video autoplays, muted, loops, `currentTime` advances
- [ ] **Live Safari test after merge + deploy** — load `/projects/swipe-watch/` on Safari (default profile, not Private Browsing), confirm video starts playing silently within ~1s of page load
- [ ] If Safari still blocks autoplay: open Web Inspector → Media panel and share what `play()` returns / why
