### PR TITLE
fix(mux): hide player chrome for GIF-alike hero (#237 follow-up)

### DIFF
--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -34,8 +34,9 @@ const altText = `${title} product screenshot`;
     env-key={muxEnvKey}
     metadata-video-title={title}
     metadata-video-id={slug}
+    nohotkeys
     class="project-screenshot__mux"
-    style="--media-accent-color: var(--project-accent); --media-primary-color: var(--project-accent);"
+    style="--media-accent-color: var(--project-accent); --media-primary-color: var(--project-accent); --controls: none; --center-controls: none;"
   >
     <img slot="poster" src={fallbackSrc} alt={altText} />
   </mux-player>


### PR DESCRIPTION
Follow-up to #242: Safari now autoplays (confirmed by user), but the player chrome (control bar + center play button) doesn't match the intended GIF-like hero.

Sets Mux's documented CSS vars `--controls: none` + `--center-controls: none` on the mux-player inline style, plus the `nohotkeys` attribute. Net effect: silent autoplay-loop video with no UI chrome, matching the feel the static GIF had before Phase 1.

Human authorized skipping the full review loop on this PR — fast-track merge + deploy to unblock Safari parity.

Authoring-Agent: claude

## Self-Review

Two changes: inline `style` gets `--controls: none; --center-controls: none;`, plus the `nohotkeys` boolean attr. No logic change, no new deps. Chromium path unaffected. Scope is one file, 1 insertion / 1 modified line.