### PR TITLE
fix(mux): switch to <mux-video> for chromeless hero (Safari autoplay)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "vitest": "^4.1.4"
   },
   "dependencies": {
-    "@mux/mux-player": "^3.11.8"
+    "@mux/mux-player": "^3.11.8",
+    "@mux/mux-video": "^0.30.6"
   }
 }

--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -1,11 +1,13 @@
 ---
 // Hero video slot for project pages. When `playbackId` is set, renders a
-// MUX video themed by the surrounding page's --project-accent CSS var.
-// When unset, falls back to the `fallbackSrc` image so the hero never
-// goes blank. Accent theming flows through the documented mux-player
-// CSS vars (`--media-accent-color`, `--media-primary-color`), so any
-// project page that sets `--project-accent` on its container inherits
-// the tint automatically.
+// chromeless <mux-video> element — Mux's bare video primitive with HLS +
+// Mux Data wiring but no UI chrome. This matches the "GIF-alike" hero
+// experience: silent autoplay, looping, no controls, no play button
+// overlay. For pages that need a real video player (scrubber, volume,
+// fullscreen), use <mux-player> instead — that's a different component.
+//
+// When `playbackId` is unset, falls back to the `fallbackSrc` image so
+// the hero never goes blank.
 
 interface Props {
   playbackId?: string;
@@ -24,30 +26,29 @@ const altText = `${title} product screenshot`;
 ---
 
 {playbackId ? (
-  <mux-player
+  <mux-video
     playback-id={playbackId}
     autoplay="muted"
     muted
     loop
     playsinline
     preload="auto"
+    poster={fallbackSrc}
     env-key={muxEnvKey}
     metadata-video-title={title}
     metadata-video-id={slug}
-    nohotkeys
     class="project-screenshot__mux"
-    style="--media-accent-color: var(--project-accent); --media-primary-color: var(--project-accent); --controls: none; --center-controls: none;"
   >
-    <img slot="poster" src={fallbackSrc} alt={altText} />
-  </mux-player>
+    <img src={fallbackSrc} alt={altText} />
+  </mux-video>
 ) : (
   <img src={fallbackSrc} alt={altText} loading="eager" />
 )}
 
 <script>
-  // Register <mux-player> only on pages that actually contain one.
+  // Register <mux-video> only on pages that actually contain one.
   // Keeps the bundle cost off of projects without a Mux video.
-  if (document.querySelector('mux-player')) {
-    import('@mux/mux-player');
+  if (document.querySelector('mux-video')) {
+    import('@mux/mux-video');
   }
 </script>


### PR DESCRIPTION
Follow-up to #243. Hiding controls on `<mux-player>` via `--controls: none` regressed Safari autoplay (user confirmed on normal + private Safari after #243 deployed). Switching to `<mux-video>` — Mux's bare HTML5-like video primitive with HLS + Mux Data wiring but zero UI chrome. No controls to hide → no conflict with autoplay.

All attributes preserved (`autoplay="muted"`, `muted`, `loop`, `playsinline`, `preload="auto"`, `env-key`, `metadata-video-title`, `metadata-video-id`). Chromium preview verified: video upgrades, plays, loops, muted, no UI chrome.

Authoring-Agent: claude

## Self-Review

Scope: `ProjectMuxPlayer.astro` swaps the `<mux-player>` tag for `<mux-video>`, drops the now-irrelevant `--media-accent-color` / `--controls` / `nohotkeys` attributes, replaces the `<img slot="poster">` pattern with the standard HTML `poster` attribute (plus a bare `<img>` child for no-JS fallback via unknown-custom-element light-DOM rendering), and updates the runtime import gate. `@mux/mux-video` promoted from transitive to direct dep. Not removing `@mux/mux-player` — deferred in case a future project wants the full UI.