### PR TITLE
fix(mux): dedupe stacked hero render (#237 follow-up)

### DIFF
--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -26,21 +26,24 @@ const altText = `${title} product screenshot`;
 ---
 
 {playbackId ? (
-  <mux-video
-    playback-id={playbackId}
-    autoplay="muted"
-    muted
-    loop
-    playsinline
-    preload="auto"
-    poster={fallbackSrc}
-    env-key={muxEnvKey}
-    metadata-video-title={title}
-    metadata-video-id={slug}
-    class="project-screenshot__mux"
-  >
-    <img src={fallbackSrc} alt={altText} />
-  </mux-video>
+  <>
+    <mux-video
+      playback-id={playbackId}
+      autoplay="muted"
+      muted
+      loop
+      playsinline
+      preload="auto"
+      poster={fallbackSrc}
+      env-key={muxEnvKey}
+      metadata-video-title={title}
+      metadata-video-id={slug}
+      class="project-screenshot__mux"
+    />
+    <noscript>
+      <img src={fallbackSrc} alt={altText} loading="eager" />
+    </noscript>
+  </>
 ) : (
   <img src={fallbackSrc} alt={altText} loading="eager" />
 )}


### PR DESCRIPTION
User reported stacked double-render of the video hero after #244 — two video elements visible in Safari, one showing Firefly content, one showing the full Swipe Watch phone UI.

Root cause: `<mux-video>` does not treat its light-DOM `<img>` child as `<video>`-style fallback content (hide when video plays). It renders the video in shadow DOM AND leaks the light-DOM `<img>` through, producing the doubled render.

Fix: close `<mux-video>` as self-contained and move the no-JS fallback `<img>` into an explicit `<noscript>` block. Browsers with JS render only the mux-video; without JS, noscript renders the img.

Verified in dev preview: one `<mux-video>`, zero hero imgs, video playing.

Authoring-Agent: claude

## Self-Review

One file, two changes: wrapping fragment → self-closing mux-video + sibling noscript. Keeps the no-JS fallback intact without the shadow-DOM-vs-light-DOM leak.