### PR TITLE
fix(mux): static Mux JPEG poster disambiguates autoplay in Safari

### DIFF
--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -23,6 +23,14 @@ const { playbackId, fallbackSrc, title, slug } = Astro.props;
 const muxEnvKey = import.meta.env.PUBLIC_MUX_ENV_KEY;
 
 const altText = `${title} product screenshot`;
+
+// Static first-frame poster from Mux's image API. Using a JPEG instead
+// of the animated GIF disambiguates autoplay: Safari animates GIF
+// posters, which visually mimics video playback even when autoplay is
+// blocked. A still frame makes "did autoplay succeed?" a clear signal.
+const posterSrc = playbackId
+  ? `https://image.mux.com/${playbackId}/thumbnail.jpg?width=640&time=0`
+  : undefined;
 ---
 
 {playbackId ? (
@@ -34,7 +42,7 @@ const altText = `${title} product screenshot`;
       loop
       playsinline
       preload="auto"
-      poster={fallbackSrc}
+      poster={posterSrc}
       env-key={muxEnvKey}
       metadata-video-title={title}
       metadata-video-id={slug}


### PR DESCRIPTION
Swaps the animated GIF poster for Mux's static first-frame thumbnail (`image.mux.com/{id}/thumbnail.jpg?width=640&time=0`). Safari animates animated-GIF posters on `<video>`, making autoplay-succeeded visually indistinguishable from autoplay-blocked-but-poster-animating. A static JPEG removes the ambiguity: motion = video playing, frozen = autoplay blocked.

Chromium baseline preserved (video.currentTime advances, readyState 4).

Refs #237.

Authoring-Agent: claude

## Self-Review

One file, one attribute swap. Derives the JPEG URL from playbackId; no new dep, no new script. Keeps the GIF around for the noscript fallback.