### PR TITLE
[codex] fix(mux): improve Swipe Watch background video quality

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "vitest": "^4.1.4"
   },
   "dependencies": {
-    "@mux/mux-background-video": "^0.2.3",
     "@mux/mux-player": "^3.11.8",
     "@mux/mux-video": "^0.30.6"
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "vitest": "^4.1.4"
   },
   "dependencies": {
-    "@mux/mux-player": "^3.11.8",
-    "@mux/mux-video": "^0.30.6"
+    "@mux/mux-background-video": "^0.2.3"
   }
 }

--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -1,21 +1,12 @@
 ---
 // Hero video slot for project pages. When `playbackId` is set, renders
-// Mux's dedicated background-video component — the one Mux built for
-// this exact use case (hero / GIF-replacement / autoplay-muted-loop).
+// <mux-player> with the conservative Safari-friendly autoplay config that
+// already worked in the #237 audit. The player UI stays available for
+// recovery, but CSS hides only the centered play overlay so the hero no
+// longer looks paused on top of an autoplaying clip.
 //
-// Why <mux-background-video> and not <mux-video> or <mux-player>?
-// - <mux-player> is a full player with controls; hiding the chrome
-//   via CSS vars regressed Safari autoplay.
-// - <mux-video> is a low-level HTML5-like primitive; on Safari the
-//   native HLS manifest load races against Safari's autoplay policy
-//   check, silently leaving the video paused on the poster.
-// - <mux-background-video> is purpose-built for hero videos: no UI
-//   chrome, internal autoplay orchestration that handles the HLS-on-
-//   Safari timing race, and the documented component for this
-//   use case in Mux's own docs.
-//
-// When `playbackId` is unset, falls back to the `fallbackSrc` image
-// so the hero never goes blank.
+// When `playbackId` is unset, falls back to the `fallbackSrc` image so the
+// hero never goes blank.
 
 interface Props {
   playbackId?: string;
@@ -26,43 +17,36 @@ interface Props {
 
 const { playbackId, fallbackSrc, title, slug } = Astro.props;
 
+// Mux Data env key. Baked into the build via `import.meta.env`; when unset,
+// Astro omits the attribute and the player emits no analytics.
+const muxEnvKey = import.meta.env.PUBLIC_MUX_ENV_KEY;
+
 const altText = `${title} product screenshot`;
-
-const streamSrc = playbackId
-  ? `https://stream.mux.com/${playbackId}.m3u8`
-  : undefined;
-
-// Static first-frame poster from Mux's image API. JPEG at 640px is
-// sharper than the GIF rendered at 320px and makes the autoplay-vs-
-// not-autoplaying signal unambiguous (motion = playing; frozen =
-// blocked).
-const posterSrc = playbackId
-  ? `https://image.mux.com/${playbackId}/thumbnail.jpg?width=640&time=0`
-  : undefined;
 ---
 
 {playbackId ? (
-  <>
-    <mux-background-video
-      src={streamSrc}
-      max-resolution="720p"
-      class="project-screenshot__mux"
-    >
-      <img src={posterSrc} alt={altText} />
-    </mux-background-video>
-    <noscript>
-      <img src={fallbackSrc} alt={altText} loading="eager" />
-    </noscript>
-  </>
+  <mux-player
+    playback-id={playbackId}
+    autoplay="muted"
+    muted
+    loop
+    playsinline
+    preload="auto"
+    env-key={muxEnvKey}
+    metadata-video-title={title}
+    metadata-video-id={slug}
+    class="project-screenshot__mux"
+    style="--media-accent-color: var(--project-accent); --media-primary-color: var(--project-accent);"
+  >
+    <img slot="poster" src={fallbackSrc} alt={altText} />
+  </mux-player>
 ) : (
   <img src={fallbackSrc} alt={altText} loading="eager" />
 )}
 
 <script>
-  // Register <mux-background-video> on pages that use it. Dropping
-  // mux-player and mux-video from the runtime on this page — this
-  // component is the sole consumer.
-  if (document.querySelector('mux-background-video')) {
-    import('@mux/mux-background-video/html');
+  // Register <mux-player> only on pages that actually contain one.
+  if (document.querySelector('mux-player')) {
+    import('@mux/mux-player');
   }
 </script>

--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -1,9 +1,17 @@
 ---
 // Hero video slot for project pages. When `playbackId` is set, renders
-// <mux-player> with the conservative Safari-friendly autoplay config that
-// already worked in the #237 audit. The player UI stays available for
-// recovery, but CSS hides only the centered play overlay so the hero no
-// longer looks paused on top of an autoplaying clip.
+// Mux's dedicated background-video component — the one Mux built for
+// this exact use case (hero / GIF-replacement / autoplay-muted-loop).
+//
+// Why <mux-background-video> and not <mux-video> or <mux-player>?
+// - <mux-player> is a full player with controls; hiding the chrome
+//   regressed Safari autoplay in real-device testing.
+// - <mux-video> is a low-level HTML5-like primitive; on Safari the
+//   native HLS manifest load races against Safari's autoplay policy
+//   check, silently leaving the video paused on the poster.
+// - <mux-background-video> is purpose-built for hero videos: no UI
+//   chrome, internal autoplay orchestration, and the Safari behavior
+//   this project actually needs.
 //
 // When `playbackId` is unset, falls back to the `fallbackSrc` image so the
 // hero never goes blank.
@@ -17,36 +25,39 @@ interface Props {
 
 const { playbackId, fallbackSrc, title, slug } = Astro.props;
 
-// Mux Data env key. Baked into the build via `import.meta.env`; when unset,
-// Astro omits the attribute and the player emits no analytics.
-const muxEnvKey = import.meta.env.PUBLIC_MUX_ENV_KEY?.trim() || undefined;
-
 const altText = `${title} product screenshot`;
+
+const streamSrc = playbackId
+  ? `https://stream.mux.com/${playbackId}.m3u8`
+  : undefined;
+
+// Use a higher-res still for the poster so the "loading / blocked" state
+// stays crisp on Retina/iPhone screens while the background video upgrades.
+const posterSrc = playbackId
+  ? `https://image.mux.com/${playbackId}/thumbnail.jpg?width=1280&time=0`
+  : undefined;
 ---
 
 {playbackId ? (
-  <mux-player
-    playback-id={playbackId}
-    autoplay="muted"
-    muted
-    loop
-    playsinline
-    preload="auto"
-    env-key={muxEnvKey}
-    metadata-video-title={title}
-    metadata-video-id={slug}
-    class="project-screenshot__mux"
-    style="--media-accent-color: var(--project-accent); --media-primary-color: var(--project-accent);"
-  >
-    <img slot="poster" src={fallbackSrc} alt={altText} />
-  </mux-player>
+  <>
+    <mux-background-video
+      src={streamSrc}
+      preload="auto"
+      class="project-screenshot__mux"
+    >
+      <img src={posterSrc} alt={altText} />
+    </mux-background-video>
+    <noscript>
+      <img src={fallbackSrc} alt={altText} loading="eager" />
+    </noscript>
+  </>
 ) : (
   <img src={fallbackSrc} alt={altText} loading="eager" />
 )}
 
 <script>
-  // Register <mux-player> only on pages that actually contain one.
-  if (document.querySelector('mux-player')) {
-    import('@mux/mux-player');
+  // Register <mux-background-video> only on pages that actually contain one.
+  if (document.querySelector('mux-background-video')) {
+    import('@mux/mux-background-video/html');
   }
 </script>

--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -19,7 +19,7 @@ const { playbackId, fallbackSrc, title, slug } = Astro.props;
 
 // Mux Data env key. Baked into the build via `import.meta.env`; when unset,
 // Astro omits the attribute and the player emits no analytics.
-const muxEnvKey = import.meta.env.PUBLIC_MUX_ENV_KEY;
+const muxEnvKey = import.meta.env.PUBLIC_MUX_ENV_KEY?.trim() || undefined;
 
 const altText = `${title} product screenshot`;
 ---

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1109,11 +1109,11 @@ body.blog-page {
   border: 1px solid var(--rule, rgba(17, 16, 13, 0.12));
 }
 
-/* <mux-player> rendered in the hero slot. The player picks its own
-   aspect ratio from the asset's video metadata — we deliberately don't
-   hardcode one here, because different clips (e.g. 9:19.5 modern phone
-   captures vs. true 9:16) would otherwise render with letterbox bars.
-   Width is capped by the surrounding .project-screenshot--narrow
+/* Mux background-video rendered in the hero slot. The component picks
+   its own aspect ratio from the asset's metadata — we deliberately
+   don't hardcode one here, because different clips (e.g. 9:19.5 modern
+   phone captures vs. true 9:16) would otherwise render with letterbox
+   bars. Width is capped by the surrounding .project-screenshot--narrow
    container's 320px max-width so pages stay visually consistent
    between img and video modes. */
 .project-screenshot__mux {
@@ -1123,18 +1123,10 @@ body.blog-page {
   overflow: hidden;
 }
 
-/* Keep player controls available, but remove the centered play overlay so
-   autoplaying project heroes do not look paused. Bottom controls remain for
-   manual recovery if Safari blocks autoplay due to browser/user policy. */
-.project-screenshot__mux::part(center play button) {
-  display: none;
-}
-
-/* Poster frame slotted into the player. Before JS upgrades the custom
-   element, this img renders as light-DOM content and fills the player
-   area so the GIF still shows — the graceful-degradation fallback the
-   plan calls for. */
-.project-screenshot__mux img[slot="poster"] {
+/* Poster frame inside the background-video element. Before JS upgrades
+   the custom element, this light-DOM image fills the hero slot so the
+   page never flashes blank. */
+.project-screenshot__mux > img {
   display: block;
   width: 100%;
   height: auto;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1123,6 +1123,13 @@ body.blog-page {
   overflow: hidden;
 }
 
+/* Keep player controls available, but remove the centered play overlay so
+   autoplaying project heroes do not look paused. Bottom controls remain for
+   manual recovery if Safari blocks autoplay due to browser/user policy. */
+.project-screenshot__mux::part(center play button) {
+  display: none;
+}
+
 /* Poster frame slotted into the player. Before JS upgrades the custom
    element, this img renders as light-DOM content and fills the player
    area so the GIF still shows — the graceful-degradation fallback the

--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -150,6 +150,23 @@ describe('Project Pages — screenshot aspect variants', () => {
     expect(figure.className).toContain('project-screenshot--narrow');
   });
 
+  it('Swipe Watch renders mux-player with the muted autoplay hero config', () => {
+    setupDOM(readDistHtml('projects/swipe-watch/index.html'));
+
+    const player = document.querySelector('mux-player.project-screenshot__mux');
+    expect(player, 'Swipe Watch mux-player not found').not.toBeNull();
+    expect(document.querySelector('mux-background-video')).toBeNull();
+    expect(player.getAttribute('autoplay')).toBe('muted');
+    expect(player.hasAttribute('muted')).toBe(true);
+    expect(player.hasAttribute('loop')).toBe(true);
+    expect(player.hasAttribute('playsinline')).toBe(true);
+    expect(player.getAttribute('preload')).toBe('auto');
+
+    const poster = player.querySelector('img[slot="poster"]');
+    expect(poster, 'Swipe Watch poster img not found').not.toBeNull();
+    expect(poster.getAttribute('src')).toBe('/images/projects/swipe-watch-hero.gif');
+  });
+
   it('Override, DST, and FFB use the wide screenshot variant', () => {
     const wideSlugs = ['override', 'device-source-of-truth', 'friends-and-family-billing'];
     for (const slug of wideSlugs) {

--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -150,21 +150,19 @@ describe('Project Pages — screenshot aspect variants', () => {
     expect(figure.className).toContain('project-screenshot--narrow');
   });
 
-  it('Swipe Watch renders mux-player with the muted autoplay hero config', () => {
+  it('Swipe Watch renders mux-background-video with the Safari-safe hero config', () => {
     setupDOM(readDistHtml('projects/swipe-watch/index.html'));
 
-    const player = document.querySelector('mux-player.project-screenshot__mux');
-    expect(player, 'Swipe Watch mux-player not found').not.toBeNull();
-    expect(document.querySelector('mux-background-video')).toBeNull();
-    expect(player.getAttribute('autoplay')).toBe('muted');
-    expect(player.hasAttribute('muted')).toBe(true);
-    expect(player.hasAttribute('loop')).toBe(true);
-    expect(player.hasAttribute('playsinline')).toBe(true);
+    const player = document.querySelector('mux-background-video.project-screenshot__mux');
+    expect(player, 'Swipe Watch mux-background-video not found').not.toBeNull();
+    expect(document.querySelector('mux-player')).toBeNull();
+    expect(player.getAttribute('src')).toBe('https://stream.mux.com/wNCRY97981o2uDAJrJ3ExPeK379yldRRFJgUIgSYz00k.m3u8');
     expect(player.getAttribute('preload')).toBe('auto');
+    expect(player.hasAttribute('max-resolution')).toBe(false);
 
-    const poster = player.querySelector('img[slot="poster"]');
+    const poster = player.querySelector('img');
     expect(poster, 'Swipe Watch poster img not found').not.toBeNull();
-    expect(poster.getAttribute('src')).toBe('/images/projects/swipe-watch-hero.gif');
+    expect(poster.getAttribute('src')).toBe('https://image.mux.com/wNCRY97981o2uDAJrJ3ExPeK379yldRRFJgUIgSYz00k/thumbnail.jpg?width=1280&time=0');
   });
 
   it('Override, DST, and FFB use the wide screenshot variant', () => {


### PR DESCRIPTION
## Summary

- restores the Swipe Watch hero to `mux-background-video`, the path that actually autoplayed in live Safari testing
- removes the previous `max-resolution="720p"` cap so Mux can select sharper portrait renditions for the narrow phone mockup
- upgrades the poster frame from a 640px still to a 1280px Mux thumbnail so the pre-upgrade / blocked state stays crisp on Retina screens
- removes the now-obsolete `mux-player` overlay-hiding path and updates the regression test to assert the background-video configuration instead

## Root Cause

The autoplay issue and the quality issue turned out to be separate problems.

Autoplay:
- live Safari testing showed the `mux-player` path still did not autoplay reliably enough for this page, even though Chromium and Playwright WebKit looked healthy
- `mux-background-video` remains the only implementation in this repo that has actually produced the desired GIF-like autoplay behavior in Safari for Swipe Watch

Quality:
- the working `mux-background-video` implementation in #247 explicitly limited the stream with `max-resolution="720p"`
- this asset's HLS manifest exposes much sharper portrait renditions than 720p, including 1178x2560 and 1206x2622 variants
- on a narrow phone mockup viewed on Retina/iPhone-class displays, that cap was the most likely reason the autoplaying video looked soft even though the playback path itself was correct

This PR keeps the Safari-safe playback path and removes the quality bottleneck instead of continuing to iterate on the failing `mux-player` path.

## Audit Of Prior Failed Fixes

### #242
- Changed `ProjectMuxPlayer` to use `mux-player` with `autoplay="muted"` and `preload="auto"`
- Result: seemed promising in non-Safari validation, but the user's live Safari preview still did not autoplay reliably enough
- Why insufficient: did not hold up in the browser that mattered most for this bug

### #243
- Added `nohotkeys` plus broad player-chrome suppression (`--controls: none; --center-controls: none;`)
- Result: autoplay regressed in Safari
- Why insufficient: coupled UI suppression to playback behavior and removed the recovery path

### #244
- Replaced `mux-player` with `mux-video` to pursue a chromeless hero primitive
- Result: autoplay still unreliable and a stacked double-render appeared
- Why insufficient: moved to a lower-level path without solving Safari autoplay and introduced a new rendering bug

### #245
- Moved fallback markup out of `mux-video` into `\<noscript\>` to stop the stacked render
- Result: duplicate rendering improved, but autoplay still did not reliably start
- Why insufficient: fixed a secondary fallback/rendering bug, not the main autoplay requirement

### #246
- Replaced the animated GIF poster with a static Mux JPEG poster to make autoplay success observable
- Result: clarified the autoplay failure on the `mux-video` path
- Why insufficient: improved diagnosis only; did not fix playback behavior

### #247
- Switched to `mux-background-video`, which restored autoplay in Safari
- Result: autoplay worked, but the video looked softer than desired
- Why insufficient: solved playback reliability, but the quality tuning (`max-resolution="720p"`) was too conservative for this asset and layout

### Shared assumption across the failed fixes

The shared assumption was that the next step had to keep pushing toward `mux-player` or another chromeless primitive.

The more accurate framing after live Safari verification is:
- `mux-background-video` is the correct playback surface for this page
- the remaining problem is stream/poster quality, not missing UI suppression
- the fix is to keep the working Safari path and remove the artificial quality cap

## Validation

Automated:
- `npm test`
- `npm run test:e2e`

Targeted technical checks:
- confirmed the live preview HTML now renders `mux-background-video` again, not `mux-player`
- confirmed the `max-resolution` attribute is gone from the rendered hero markup
- confirmed the poster now uses `https://image.mux.com/.../thumbnail.jpg?width=1280&time=0`
- inspected the Mux HLS master playlist for this playback ID and verified it exposes portrait renditions above 720p

User-facing preview:
- live Safari testing reported that the background-video path autoplayed, while the `mux-player` path did not
- local preview was refreshed onto the background-video branch state for another Safari check before merge/deploy

Fixes #237.

Authoring-Agent: codex
