### PR TITLE
fix(home): shorten availability CTA and fix mobile link visibility

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -192,7 +192,7 @@ const homepageJsonLd = {
                  synchronously after the element is parsed, so the window
                  between page paint and href assembly is negligible. */}
             <p class="availability-signal">
-              Open to new roles and collaborations. I read every email.
+              Open to new roles and collaborations.
               {' '}
               <a
                 id="availability-mailto"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2781,6 +2781,19 @@ a:focus-visible {
     color: rgba(240, 244, 255, 0.82);
   }
 
+  .panel--blue .availability-signal {
+    color: rgba(240, 244, 255, 0.82);
+  }
+
+  .panel--blue .availability-signal .p-link {
+    color: #f0f4ff;
+    border-bottom-color: rgba(240, 244, 255, 0.48);
+  }
+
+  .panel--blue .availability-signal .p-link:hover {
+    border-bottom-color: #f0f4ff;
+  }
+
   .panel--blue .social-row {
     border-color: rgba(240, 244, 255, 0.18);
   }


### PR DESCRIPTION
## Summary
- Shorten the Connect panel availability signal from "Open to new roles and collaborations. I read every email. Get in touch →" to "Open to new roles and collaborations. Get in touch →".
- Fix a mobile regression where the "Get in touch →" link was invisible on the blue Connect panel (the link color `var(--blue)` matched the panel background because mobile never enters the `is-open` cream state).

## Changes
- `src/pages/index.astro` — drop the "I read every email." sentence from the `.availability-signal` paragraph.
- `src/styles/global.css` — inside the existing `@media (max-width: 920px)` block (next to the other `.panel--blue` mobile overrides), add rules to render `.availability-signal` text in `rgba(240, 244, 255, 0.82)` and its `.p-link` in `#f0f4ff` with a translucent cream bottom border (and opaque cream on hover).

Desktop behavior is unchanged: when the Connect panel opens, the background flips to cream and the link reverts to `var(--blue)` via the existing `.p-link` rule.

## Self-Review
- **Correctness:** Verified in the preview server at 375×812 that the shortened text and the "Get in touch →" link now render visibly on the blue panel (link color `rgb(240, 244, 255)`). Verified at 1280×900 that opening the Connect panel still produces the cream background with dark ink text and `var(--blue)` link color — the new rules are scoped to `max-width: 920px` and do not affect desktop.
- **Regression risk:** Low. The only edited paragraph is the Connect panel availability signal, and the new CSS rules live inside the existing mobile media query, co-located with the other `.panel--blue` mobile color overrides. No selectors outside that block were touched. The `<noscript>` fallback copy and the client-side mailto-assembly script are unchanged.
- **Style:** Matches the pattern of adjacent rules (`.panel--blue .connect-label`, `.panel--blue .social-row`) — same color tokens (`rgba(240, 244, 255, …)`, `#f0f4ff`) and the same media-query scoping.
- **Test coverage:** No automated tests cover this copy/CSS; manually verified in the preview server at mobile and desktop viewports. No new JS paths.
- **Security/deps:** No dependency changes. Pure copy + CSS edit. The obfuscated mailto-assembly script is untouched.

Authoring-Agent: claude