### PR TITLE
chore(sync): propagate op-preflight.sh + coderabbit-wait.sh from mergepath

### DIFF
--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -1,0 +1,499 @@
+#!/usr/bin/env bash
+# scripts/coderabbit-wait.sh — Phase 2.5 CodeRabbit wait + rate-limit retry
+#
+# Polls a pull request for a CodeRabbit review anchored on the current HEAD
+# commit. Handles two CodeRabbit behaviors that the naive "just wait"
+# pattern in AGENTS.md step 5 does not:
+#
+#   1. **Rate-limit state.** CodeRabbit posts a comment matching
+#      "Rate limit exceeded" with a specific retry window
+#      ("Please wait X minutes and Y seconds before requesting another
+#      review") and then does NOT auto-retry when the window elapses.
+#      This script detects that state, sleeps the window + buffer, posts
+#      `@coderabbitai, try again.` to re-trigger, and continues polling.
+#      See nathanjohnpayne/mergepath#138.
+#
+#   2. **HEAD freshness.** Auto-merge-on-approval workflows in downstream
+#      repos race CodeRabbit: an internal reviewer can post APPROVED before
+#      CodeRabbit's ~2–3 minute review lands, and the PR auto-merges
+#      pre-review. The script only returns "cleared" when CodeRabbit has
+#      posted a non-rate-limited, non-in-progress comment on or after the
+#      HEAD committer date. See nathanjohnpayne/mergepath#136.
+#
+# Usage:
+#   scripts/coderabbit-wait.sh <PR_NUMBER> [REPO]
+#
+# Arguments:
+#   PR_NUMBER  Required. The pull request number (integer).
+#   REPO       Optional. Fully-qualified "owner/repo". Defaults to the
+#              current repository detected by `gh repo view`.
+#
+# Environment:
+#   GH_TOKEN   Required. GitHub token with pull_requests:write to post the
+#              retry trigger and read comments. In the template flow this
+#              is set to $OP_PREFLIGHT_AUTHOR_PAT after running preflight,
+#              or via inline `op read` per REVIEW_POLICY.md § PAT lookup.
+#
+# Behavior:
+#   1. Reads coderabbit.max_wait_seconds (default 300) and
+#      coderabbit.max_rate_limit_retries (default 2) from
+#      .github/review-policy.yml.
+#   2. Fetches PR HEAD SHA + committer date.
+#   3. Polls issue + review comments every 15s. For each CodeRabbit
+#      comment newer than HEAD committer date, classifies as:
+#        - rate_limit  — body matches /Rate limit exceeded/i
+#        - in_progress — body matches /review in progress|currently reviewing/i
+#        - review      — anything else authored by coderabbitai[bot]
+#   4. On rate_limit: parse "X minutes and Y seconds" (or "X seconds"),
+#      sleep that duration + 30s buffer, post `@coderabbitai, try again.`,
+#      increment retry counter, continue polling.
+#   5. On review (non-rate-limit, non-in-progress): emit JSON, exit 0.
+#      Also scans inline diff comments for "Potential issue" / "⚠️"
+#      markers and surfaces them in the JSON so callers can decide.
+#   6. If total elapsed > max_wait_seconds: exit 4 (TIMEOUT), emit JSON
+#      with status=timeout.
+#   7. If rate_limit_retries > max_rate_limit_retries: exit 5 (STALLED),
+#      emit JSON with status=rate_limit_stalled.
+#
+# Output JSON shape (stdout):
+#   {
+#     "pr_number": 123,
+#     "repo": "owner/repo",
+#     "head_sha": "<full sha>",
+#     "head_committer_date": "<iso-8601>",
+#     "bot_login": "coderabbitai[bot]",
+#     "status": "cleared" | "findings" | "timeout" | "rate_limit_stalled",
+#     "review": null | {
+#       "id": N,
+#       "created_at": "<iso-8601>",
+#       "endpoint": "issues" | "pulls",
+#       "body_excerpt": "<first 200 chars>"
+#     },
+#     "potential_issue_count": N,
+#     "rate_limit_retries": N,
+#     "waited_seconds": N
+#   }
+#
+# Exit codes:
+#   0   CodeRabbit posted a real review on current HEAD with no
+#       "Potential issue"/⚠️ markers. Safe to proceed.
+#   2   CodeRabbit posted a real review with at least one P0/P1-equivalent
+#       marker. Caller should address before proceeding.
+#   3   API / infrastructure error. Error on stderr.
+#   4   Timeout — max_wait_seconds elapsed without a real review. Caller
+#       may log a warning and proceed (CodeRabbit is advisory), or block.
+#   5   Rate-limit stalled — max_rate_limit_retries exceeded. Distinct
+#       from timeout so callers can alert the human instead of proceeding.
+#
+# Design notes:
+#   - Read-only except for retry-trigger comments. Does not push commits,
+#     does not modify labels, does not merge.
+#   - Idempotent across reruns on the same HEAD. A freshly-landed review
+#     is detected on the next poll regardless of how many times the script
+#     has been run.
+#   - JSON emission uses `jq`. Pattern matching on CodeRabbit comment
+#     bodies is intentionally heuristic — the bot's output format is not
+#     versioned and may drift. See nathanjohnpayne/mergepath#138 for the
+#     observed rate-limit string.
+
+set -euo pipefail
+
+# --- argument parsing -------------------------------------------------------
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  echo "Usage: $0 <PR_NUMBER> [REPO]" >&2
+  exit 3
+fi
+
+PR_NUMBER=$1
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: PR_NUMBER must be an integer; got '$PR_NUMBER'" >&2
+  exit 3
+fi
+
+REPO=${2:-}
+if [ -z "$REPO" ]; then
+  REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)
+  if [ -z "$REPO" ]; then
+    echo "ERROR: could not detect current repo via 'gh repo view'. Pass REPO explicitly." >&2
+    exit 3
+  fi
+fi
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "ERROR: GH_TOKEN is required. See REVIEW_POLICY.md § PAT lookup table." >&2
+  exit 3
+fi
+
+# --- config readers ---------------------------------------------------------
+
+CONFIG=".github/review-policy.yml"
+
+# Extract a scalar field from the coderabbit: block in review-policy.yml.
+# Mirrors the state-machine pattern used by codex-review-request.sh: stops
+# at the next top-level key, tolerates column-0 comments. Empty string if
+# field missing — caller turns into default.
+coderabbit_field() {
+  local field=$1
+  [ -f "$CONFIG" ] || return 0
+  awk -v field="$field" '
+    /^coderabbit:/ {in_block=1; next}
+    in_block && /^[^[:space:]#]/ {in_block=0}
+    in_block {
+      if ($1 == field":") {
+        sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+        gsub(/^"/, "", $0)
+        gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+        gsub(/[[:space:]]*#.*$/, "", $0)
+        sub(/[[:space:]]+$/, "", $0)
+        print
+        exit
+      }
+    }
+  ' "$CONFIG"
+}
+
+MAX_WAIT_SECONDS=$(coderabbit_field max_wait_seconds)
+MAX_WAIT_SECONDS=${MAX_WAIT_SECONDS:-300}
+if ! [[ "$MAX_WAIT_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: coderabbit.max_wait_seconds must be an integer; got '$MAX_WAIT_SECONDS'" >&2
+  exit 3
+fi
+
+MAX_RATE_LIMIT_RETRIES=$(coderabbit_field max_rate_limit_retries)
+MAX_RATE_LIMIT_RETRIES=${MAX_RATE_LIMIT_RETRIES:-2}
+if ! [[ "$MAX_RATE_LIMIT_RETRIES" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: coderabbit.max_rate_limit_retries must be an integer; got '$MAX_RATE_LIMIT_RETRIES'" >&2
+  exit 3
+fi
+
+BOT_LOGIN=$(coderabbit_field bot_login)
+BOT_LOGIN=${BOT_LOGIN:-"coderabbitai[bot]"}
+POLL_INTERVAL_SECONDS=15
+RATE_LIMIT_BUFFER_SECONDS=30
+
+# --- logging helpers --------------------------------------------------------
+
+log() {
+  echo "[coderabbit-wait] $*" >&2
+}
+
+die() {
+  local code=$1
+  shift
+  echo "[coderabbit-wait] ERROR: $*" >&2
+  exit "$code"
+}
+
+fetch_api_array() {
+  local endpoint=$1
+  local label=$2
+  local raw
+  raw=$(gh api --paginate "$endpoint" 2>&1) || die 3 "failed to fetch $label: $raw"
+  echo "$raw" | jq -s 'add // []' 2>/dev/null \
+    || die 3 "failed to flatten $label pagination output"
+}
+
+# --- fetch PR metadata ------------------------------------------------------
+
+log "PR $REPO#$PR_NUMBER — fetching HEAD commit metadata"
+
+PR_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER" 2>&1) || die 3 "failed to fetch PR metadata: $PR_JSON"
+
+HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
+if [ -z "$HEAD_SHA" ] || [ "$HEAD_SHA" = "null" ]; then
+  die 3 "could not determine HEAD sha for PR #$PR_NUMBER"
+fi
+
+HEAD_COMMITTER_DATE=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date' 2>&1) \
+  || die 3 "failed to fetch commit date for $HEAD_SHA: $HEAD_COMMITTER_DATE"
+
+# HEAD freshness anchor. Committer date alone is unreliable — force-push of
+# an older commit, cherry-pick, or rebase with `--committer-date-is-author-date`
+# can produce a HEAD whose committer date predates prior CodeRabbit comments
+# on this PR. Filtering `comments.created_at >= HEAD_COMMITTER_DATE` would
+# then treat stale review-round comments as current and return a false
+# "cleared"/"findings" signal. Mirrors the Layer-1 anchor advance in
+# codex-review-request.sh: advance the anchor past any `head_ref_force_pushed`
+# timeline event. See nathanjohnpayne/mergepath#140 round-2 Codex finding
+# (P1, line 270) for the specific exposure this closes.
+HEAD_ANCHOR="$HEAD_COMMITTER_DATE"
+ANCHOR_SOURCE="HEAD committer date"
+TIMELINE_JSON=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/timeline" "PR timeline")
+LATEST_FORCE_PUSH_TIME=$(echo "$TIMELINE_JSON" | jq -r '
+  [ .[] | select(.event == "head_ref_force_pushed") | .created_at ]
+  | max // ""
+')
+if [ -n "$LATEST_FORCE_PUSH_TIME" ] && [[ "$LATEST_FORCE_PUSH_TIME" > "$HEAD_ANCHOR" ]]; then
+  HEAD_ANCHOR="$LATEST_FORCE_PUSH_TIME"
+  ANCHOR_SOURCE="head_ref_force_pushed @ $LATEST_FORCE_PUSH_TIME"
+fi
+
+log "HEAD = $HEAD_SHA committed at $HEAD_COMMITTER_DATE"
+log "anchor = $HEAD_ANCHOR (source: $ANCHOR_SOURCE)"
+log "max_wait = ${MAX_WAIT_SECONDS}s   max_rate_limit_retries = $MAX_RATE_LIMIT_RETRIES"
+
+# --- state machine ----------------------------------------------------------
+
+# Parse a rate-limit wait window from a CodeRabbit comment body.
+# Emits seconds on stdout. Returns 1 if no window found.
+parse_rate_limit_window() {
+  local body=$1
+  # "Please wait X minutes and Y seconds before requesting another review"
+  local mins secs total
+  if [[ "$body" =~ [Pp]lease\ wait\ +\*?\*?([0-9]+)\*?\*?\ +minutes?\ +and\ +\*?\*?([0-9]+)\*?\*?\ +seconds? ]]; then
+    mins=${BASH_REMATCH[1]}
+    secs=${BASH_REMATCH[2]}
+    total=$((mins * 60 + secs))
+    echo "$total"
+    return 0
+  fi
+  if [[ "$body" =~ [Pp]lease\ wait\ +\*?\*?([0-9]+)\*?\*?\ +seconds? ]]; then
+    secs=${BASH_REMATCH[1]}
+    echo "$secs"
+    return 0
+  fi
+  if [[ "$body" =~ [Pp]lease\ wait\ +\*?\*?([0-9]+)\*?\*?\ +minutes? ]]; then
+    mins=${BASH_REMATCH[1]}
+    total=$((mins * 60))
+    echo "$total"
+    return 0
+  fi
+  return 1
+}
+
+# Classify a CodeRabbit comment body. Emits one of:
+#   rate_limit | in_progress | review
+classify_comment() {
+  local body=$1
+  if echo "$body" | grep -qiE 'rate[- ]limit exceeded'; then
+    echo "rate_limit"
+    return
+  fi
+  if echo "$body" | grep -qiE 'review in progress|currently reviewing|commits? under review'; then
+    echo "in_progress"
+    return
+  fi
+  echo "review"
+}
+
+# Scan the PR-level `issues/{pr}/comments` endpoint for the latest
+# CodeRabbit comment on or after HEAD_ANCHOR. Emits JSON to stdout.
+# Empty object {} if nothing qualifying yet.
+#
+# Only the issues endpoint is the terminal-state source. CodeRabbit's
+# PR-level summary/status comments (walkthrough, "No actionable
+# comments generated", rate-limit WARNING, in-progress markers) all
+# land here. Inline `pulls/{pr}/comments` are per-line findings that
+# CodeRabbit can emit BEFORE the PR-level summary lands during a
+# single review cycle — treating an inline comment as terminal state
+# could cause a "cleared"/"findings" exit while the bot is still
+# writing more findings or still mid-walkthrough. See #140 round-3
+# Codex finding (P1, line 285). Inline findings are instead scanned
+# separately by count_potential_issues() only after this function
+# reports a PR-level terminal state.
+scan_latest_comment() {
+  local issue_comments latest
+  issue_comments=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/comments" "issue comments")
+
+  latest=$(echo "$issue_comments" | jq --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" '
+    [ .[]
+      | select(.user.login == $bot)
+      | select(.created_at >= $after)
+    ]
+    | sort_by(.created_at)
+    | last // null
+  ')
+
+  if [ "$latest" = "null" ]; then
+    echo '{}'
+    return
+  fi
+  echo "$latest" | jq '{id, created_at, endpoint: "issues", body}'
+}
+
+# Count "Potential issue" / ⚠️ markers in the pulls inline comment list
+# on or after HEAD_ANCHOR. Used for exit code 2 when a real review
+# surfaces high-severity findings.
+count_potential_issues() {
+  local pulls_comments
+  pulls_comments=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "pulls comments")
+  echo "$pulls_comments" | jq --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" '
+    [ .[]
+      | select(.user.login == $bot)
+      | select(.created_at >= $after)
+      | select((.body // "") | test("Potential issue|⚠️"; "i"))
+    ] | length
+  '
+}
+
+post_retry_trigger() {
+  # Strip the `[bot]` suffix that GitHub REST uses for App logins —
+  # @-mentions address the user-facing handle (`@coderabbitai`), not
+  # the API login (`coderabbitai[bot]`). Using the configured
+  # BOT_LOGIN here instead of a hardcoded string means a repo that
+  # overrides `coderabbit.bot_login` (e.g., to point at a fork or a
+  # differently-named review bot) gets consistent polling and
+  # triggering identities. See #140 round-3 Codex finding (P2, line 320).
+  local mention="@${BOT_LOGIN%\[bot\]}"
+  local body="${mention}, try again."
+  log "posting retry trigger comment to PR #$PR_NUMBER as $mention"
+  gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" \
+    -f body="$body" >/dev/null 2>&1 \
+    || die 3 "failed to post retry trigger comment"
+}
+
+# --- poll loop --------------------------------------------------------------
+
+START_EPOCH=$(date +%s)
+RATE_LIMIT_RETRIES=0
+LAST_RATE_LIMIT_COMMENT_ID=""
+
+emit_json_and_exit() {
+  local status=$1 exit_code=$2 review_json=$3 potential_issues=$4
+  local now_epoch waited
+  now_epoch=$(date +%s)
+  waited=$((now_epoch - START_EPOCH))
+
+  jq -n \
+    --argjson pr_number "$PR_NUMBER" \
+    --arg repo "$REPO" \
+    --arg head_sha "$HEAD_SHA" \
+    --arg head_committer_date "$HEAD_COMMITTER_DATE" \
+    --arg bot_login "$BOT_LOGIN" \
+    --arg status "$status" \
+    --argjson review "$review_json" \
+    --argjson potential_issue_count "$potential_issues" \
+    --argjson rate_limit_retries "$RATE_LIMIT_RETRIES" \
+    --argjson waited_seconds "$waited" \
+    '{
+      pr_number: $pr_number,
+      repo: $repo,
+      head_sha: $head_sha,
+      head_committer_date: $head_committer_date,
+      bot_login: $bot_login,
+      status: $status,
+      review: $review,
+      potential_issue_count: $potential_issue_count,
+      rate_limit_retries: $rate_limit_retries,
+      waited_seconds: $waited_seconds
+    }'
+
+  exit "$exit_code"
+}
+
+# Sleep for up to `requested` seconds, clamped to the remaining
+# max_wait_seconds budget. Without this guard, fixed 15s polling
+# sleeps could overshoot the configured budget (caller sees
+# `waited_seconds > max_wait_seconds`). An earlier version of this
+# helper exited early whenever `requested >= remaining` to avoid the
+# overshoot — but that shortens the effective budget by up to one
+# poll interval (iterations at elapsed 286..299 exit immediately
+# for a 300s budget, missing a review that lands right before the
+# deadline). The right shape: sleep min(requested, remaining), then
+# let the next iteration's top-of-loop check hit the exact-elapsed
+# timeout. See #140 round-3 CodeRabbit finding (Major, line 380)
+# and #140 round-4 Codex finding (P2, line 391).
+sleep_or_timeout() {
+  local requested=$1
+  local now elapsed remaining actual
+  now=$(date +%s)
+  elapsed=$((now - START_EPOCH))
+  remaining=$((MAX_WAIT_SECONDS - elapsed))
+  if [ "$remaining" -le 0 ]; then
+    log "budget exhausted (remaining=${remaining}s) — timing out"
+    emit_json_and_exit "timeout" 4 "null" 0
+  fi
+  actual=$requested
+  if [ "$actual" -gt "$remaining" ]; then
+    actual=$remaining
+    log "clamping sleep from ${requested}s to remaining budget ${remaining}s"
+  fi
+  sleep "$actual"
+}
+
+while :; do
+  NOW_EPOCH=$(date +%s)
+  ELAPSED=$((NOW_EPOCH - START_EPOCH))
+  if [ "$ELAPSED" -ge "$MAX_WAIT_SECONDS" ]; then
+    log "max_wait_seconds ($MAX_WAIT_SECONDS) exceeded after ${ELAPSED}s — timing out"
+    emit_json_and_exit "timeout" 4 "null" 0
+  fi
+
+  LATEST=$(scan_latest_comment)
+
+  if [ "$(echo "$LATEST" | jq 'length')" = "0" ]; then
+    log "no CodeRabbit comment yet (elapsed ${ELAPSED}s); sleeping ${POLL_INTERVAL_SECONDS}s"
+    sleep_or_timeout "$POLL_INTERVAL_SECONDS"
+    continue
+  fi
+
+  COMMENT_ID=$(echo "$LATEST" | jq -r '.id')
+  COMMENT_BODY=$(echo "$LATEST" | jq -r '.body')
+  COMMENT_ENDPOINT=$(echo "$LATEST" | jq -r '.endpoint')
+  COMMENT_CREATED=$(echo "$LATEST" | jq -r '.created_at')
+
+  CLASS=$(classify_comment "$COMMENT_BODY")
+  log "latest CodeRabbit comment id=$COMMENT_ID endpoint=$COMMENT_ENDPOINT class=$CLASS created=$COMMENT_CREATED"
+
+  case "$CLASS" in
+    rate_limit)
+      if [ "$COMMENT_ID" = "$LAST_RATE_LIMIT_COMMENT_ID" ]; then
+        # Same rate-limit comment as last iteration — still sleeping/waiting
+        # through our own retry window. Don't double-count retries.
+        log "still inside prior rate-limit window; sleeping ${POLL_INTERVAL_SECONDS}s"
+        sleep_or_timeout "$POLL_INTERVAL_SECONDS"
+        continue
+      fi
+      LAST_RATE_LIMIT_COMMENT_ID=$COMMENT_ID
+
+      if [ "$RATE_LIMIT_RETRIES" -ge "$MAX_RATE_LIMIT_RETRIES" ]; then
+        log "max_rate_limit_retries ($MAX_RATE_LIMIT_RETRIES) exceeded — stalling"
+        RATE_LIMIT_REVIEW=$(echo "$LATEST" | jq '{id, created_at, endpoint, body_excerpt: (.body[0:200])}')
+        emit_json_and_exit "rate_limit_stalled" 5 "$RATE_LIMIT_REVIEW" 0
+      fi
+
+      WINDOW_SECONDS=$(parse_rate_limit_window "$COMMENT_BODY" || echo "")
+      if [ -z "$WINDOW_SECONDS" ]; then
+        log "could not parse rate-limit window from comment; falling back to 60s"
+        WINDOW_SECONDS=60
+      fi
+      SLEEP_FOR=$((WINDOW_SECONDS + RATE_LIMIT_BUFFER_SECONDS))
+      # Clamp against remaining budget — if the published rate-limit
+      # window exceeds max_wait_seconds anyway, there's no point
+      # burning through the entire sleep only to time out on the next
+      # iteration. Time out immediately instead so the caller sees a
+      # prompt, well-formed timeout rather than a stalled process.
+      # See #140 round-2 Codex finding (P2, line 392).
+      NOW_EPOCH=$(date +%s)
+      ELAPSED=$((NOW_EPOCH - START_EPOCH))
+      REMAINING=$((MAX_WAIT_SECONDS - ELAPSED))
+      if [ "$SLEEP_FOR" -ge "$REMAINING" ]; then
+        log "rate-limit window (${SLEEP_FOR}s) exceeds remaining budget (${REMAINING}s) — timing out"
+        RATE_LIMIT_REVIEW=$(echo "$LATEST" | jq '{id, created_at, endpoint, body_excerpt: (.body[0:200])}')
+        emit_json_and_exit "timeout" 4 "$RATE_LIMIT_REVIEW" 0
+      fi
+      log "rate-limited; sleeping ${SLEEP_FOR}s (window=${WINDOW_SECONDS}s + ${RATE_LIMIT_BUFFER_SECONDS}s buffer)"
+      sleep "$SLEEP_FOR"
+      post_retry_trigger
+      RATE_LIMIT_RETRIES=$((RATE_LIMIT_RETRIES + 1))
+      continue
+      ;;
+    in_progress)
+      log "CodeRabbit review in progress; sleeping ${POLL_INTERVAL_SECONDS}s"
+      sleep_or_timeout "$POLL_INTERVAL_SECONDS"
+      continue
+      ;;
+    review)
+      POTENTIAL_ISSUES=$(count_potential_issues)
+      REVIEW_JSON=$(echo "$LATEST" | jq '{id, created_at, endpoint, body_excerpt: (.body[0:200])}')
+      if [ "$POTENTIAL_ISSUES" -gt 0 ]; then
+        log "CodeRabbit review posted with $POTENTIAL_ISSUES Potential issue/⚠️ markers"
+        emit_json_and_exit "findings" 2 "$REVIEW_JSON" "$POTENTIAL_ISSUES"
+      else
+        log "CodeRabbit review posted with no high-severity markers — cleared"
+        emit_json_and_exit "cleared" 0 "$REVIEW_JSON" 0
+      fi
+      ;;
+  esac
+done

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -312,16 +312,39 @@ scan_latest_comment() {
   echo "$latest" | jq '{id, created_at, endpoint: "issues", body}'
 }
 
-# Count "Potential issue" / ⚠️ markers in the pulls inline comment list
-# on or after HEAD_ANCHOR. Used for exit code 2 when a real review
-# surfaces high-severity findings.
+# Count "Potential issue" / ⚠️ markers in the pulls inline comment list,
+# scoped to the LATEST CodeRabbit review on the current HEAD. The
+# naive "all bot comments after HEAD_ANCHOR" shape would keep stale
+# findings from an earlier review round (same HEAD, pre-retry) in the
+# count forever, so a PR could stay permanently in the `findings`
+# state even after the next review comes back clean. Mirror the
+# latest-review-scoping pattern codex-review-request.sh uses via
+# `pull_request_review_id`. See propagation-round Codex finding
+# (P1) on device-platform-reporting#51.
 count_potential_issues() {
-  local pulls_comments
-  pulls_comments=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "pulls comments")
-  echo "$pulls_comments" | jq --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" '
+  local reviews pulls_comments latest_review_id
+  reviews=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/reviews" "reviews")
+  latest_review_id=$(echo "$reviews" | jq --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" '
     [ .[]
       | select(.user.login == $bot)
-      | select(.created_at >= $after)
+      | select(.submitted_at >= $after)
+    ]
+    | sort_by(.submitted_at) | last
+    | if . == null then null else .id end
+  ')
+
+  if [ -z "$latest_review_id" ] || [ "$latest_review_id" = "null" ]; then
+    echo "0"
+    return
+  fi
+
+  pulls_comments=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "pulls comments")
+  echo "$pulls_comments" | jq \
+    --arg bot "$BOT_LOGIN" \
+    --argjson review_id "$latest_review_id" '
+    [ .[]
+      | select(.user.login == $bot)
+      | select(.pull_request_review_id == $review_id)
       | select((.body // "") | test("Potential issue|⚠️"; "i"))
     ] | length
   '

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -393,8 +393,19 @@ warm_ssh_keys() {
 
 # ── Fast path: reuse session file when fresh ──────────────────────────
 if ! $REFRESH && session_is_fresh; then
-  cached_exports=$(emit_from_session_file)
-  rc=$?
+  # Use if-condition to capture exit code without tripping `set -e`.
+  # Bare `cached_exports=$(emit_from_session_file); rc=$?` would be
+  # sensitive to errexit — a non-zero exit inside `$(...)` aborts the
+  # outer script before `rc=$?` runs, so the intended refresh-fallback
+  # path below never executes (reproducible: populate a review-only
+  # cache, invoke --mode deploy; old code exits 2 with zero exports,
+  # new code falls through to the full fetch). See the propagation-
+  # round Codex review across all 6 consumer PRs.
+  if cached_exports=$(emit_from_session_file); then
+    rc=0
+  else
+    rc=$?
+  fi
   if [[ "$rc" == "0" ]]; then
     echo "$cached_exports"
     age=$(( $(date +%s) - $(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" | cut -d= -f2- | tr -d "'\"") ))

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -327,30 +327,33 @@ emit_from_session_file() (
     fi
   fi
   if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
-    # Partial-cache allowance: if the caller asked for `--mode all`
-    # and the prior run captured PATs but could not read ADC (e.g.
-    # 1Password offline for the deploy vault), the session file has
-    # review-side fields only. Don't re-prompt biometric for PATs
-    # the file already has just because ADC is absent — treat it as
-    # "PATs cached, deploy credentials not available, downstream
-    # callers fall back" same as the full-fetch stale-ADC path. A
-    # literal `--mode deploy` still requires an ADC.
+    # Both `--mode deploy` and `--mode all` require a usable ADC from
+    # the cache to take the fast path. If the session file's ADC field
+    # is missing or the materialized file is unreadable, return 2 to
+    # trigger a full refresh.
     #
-    # The ADC-missing-and-mode-is-all case was surfaced by
-    # device-source-of-truth#52 round-5 Codex review (P2).
+    # An earlier iteration of this code treated missing-ADC on
+    # `--mode all` as a partial hit (emit PATs, skip ADC) to spare
+    # biometric re-prompts when 1Password had been offline during the
+    # original fetch. That violated the `all` contract: a later
+    # `--mode all` on a review-only cache would silently never load
+    # deploy credentials until TTL expiry, breaking deploy flows in
+    # the same session. `all` means "everything"; honor it. See
+    # friends-and-family-billing#227 round-3 Codex P1 — Codex's
+    # earlier P2 (round 1) asking for the partial-hit shape was a
+    # reversal it itself caught once I shipped it.
     if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] || [[ ! -s "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
-      if [[ "$MODE" == "deploy" ]]; then
-        exit 2
-      fi
-      # MODE=all with no ADC → emit PATs, skip ADC, continue.
-    elif ! adc_is_usable "${GOOGLE_APPLICATION_CREDENTIALS}"; then
-      # File exists but refresh token is rejected. Same behavior:
-      # warn, skip the export, let downstream fall back.
+      exit 2
+    fi
+    if ! adc_is_usable "${GOOGLE_APPLICATION_CREDENTIALS}"; then
+      # File exists but refresh token is rejected. Warn and skip the
+      # export so downstream deploy callers can fall back to local
+      # firebase-login / ADC. OP_PREFLIGHT_DONE stays 1 and PATs are
+      # still emitted below, because preflight itself succeeded —
+      # only the ADC-specific path is degraded, which matches what
+      # the user will see when they run `gcloud auth ...` manually.
       log_stale_adc_guidance
       unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
-      if [[ "$MODE" == "deploy" ]]; then
-        exit 2
-      fi
     fi
   fi
 

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -286,10 +286,31 @@ log_stale_adc_guidance() {
 }
 
 # Emit the session file's export statements to stdout. Caller eval's them.
-emit_from_session_file() {
+#
+# Runs in a subshell with the relevant variables pre-unset so the
+# sourced file's definitions are NOT aliased to whatever the parent
+# shell happened to have in scope. Without this isolation a prior
+# `--agent claude` invocation could leak its PATs into an
+# `--agent codex --mode review` fast-path check, making an
+# incomplete codex session file look valid and causing gh to run as
+# the wrong identity. See round-5 Codex finding on the propagation
+# PRs for the multi-agent repro.
+emit_from_session_file() (
+  # Subshell: the (  ... ) above means unset/source/return here do
+  # not escape back to the caller. We still "return" rc codes via
+  # stdout+exit; parent stays clean.
+  unset OP_PREFLIGHT_REVIEWER_PAT OP_PREFLIGHT_AUTHOR_PAT
+  unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
+  unset OP_PREFLIGHT_DONE OP_PREFLIGHT_AGENT OP_PREFLIGHT_MODE
+  unset OP_PREFLIGHT_CREATED_AT_EPOCH OP_PREFLIGHT_TTL_SECONDS
+
   # Source the session file and re-emit only the vars we own, so a
   # hand-edited file with arbitrary content cannot inject exports.
-  # Also drop CREATED_AT from the exported set; it's bookkeeping.
+  # Permissions are 0600 in a 0700 cache dir (enforced at write time
+  # and re-checked here via stat), so the source boundary is "file
+  # owner writes the file; we trust them." Rebuttal to the P2
+  # safe-parse finding on the propagation PRs — a reader that also
+  # writes the file cannot protect themselves from themselves.
   # shellcheck disable=SC1090
   . "$SESSION_FILE"
 
@@ -302,23 +323,34 @@ emit_from_session_file() {
   # each case. See #141 round-1 Codex finding (P1, line 223).
   if [[ "$MODE" == "review" || "$MODE" == "all" ]]; then
     if [[ -z "${OP_PREFLIGHT_REVIEWER_PAT:-}" ]] || [[ -z "${OP_PREFLIGHT_AUTHOR_PAT:-}" ]]; then
-      return 2
+      exit 2
     fi
   fi
   if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
-    # Both the cached-path pointer must be set AND the file it names
-    # must still be readable (non-empty) AND still mint a token. The
-    # usability check catches the case where the cached ADC was valid
-    # at write time but has since been revoked/expired by Google —
-    # without it, a fresh session file would keep re-emitting a dead
-    # GOOGLE_APPLICATION_CREDENTIALS export for up to TTL_SECONDS.
-    # See #137 failure mode B.
+    # Partial-cache allowance: if the caller asked for `--mode all`
+    # and the prior run captured PATs but could not read ADC (e.g.
+    # 1Password offline for the deploy vault), the session file has
+    # review-side fields only. Don't re-prompt biometric for PATs
+    # the file already has just because ADC is absent — treat it as
+    # "PATs cached, deploy credentials not available, downstream
+    # callers fall back" same as the full-fetch stale-ADC path. A
+    # literal `--mode deploy` still requires an ADC.
+    #
+    # The ADC-missing-and-mode-is-all case was surfaced by
+    # device-source-of-truth#52 round-5 Codex review (P2).
     if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] || [[ ! -s "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
-      return 2
-    fi
-    if ! adc_is_usable "${GOOGLE_APPLICATION_CREDENTIALS}"; then
+      if [[ "$MODE" == "deploy" ]]; then
+        exit 2
+      fi
+      # MODE=all with no ADC → emit PATs, skip ADC, continue.
+    elif ! adc_is_usable "${GOOGLE_APPLICATION_CREDENTIALS}"; then
+      # File exists but refresh token is rejected. Same behavior:
+      # warn, skip the export, let downstream fall back.
       log_stale_adc_guidance
-      return 2
+      unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
+      if [[ "$MODE" == "deploy" ]]; then
+        exit 2
+      fi
     fi
   fi
 
@@ -332,16 +364,54 @@ emit_from_session_file() {
     printf 'export OP_PREFLIGHT_ADC_TMPFILE=%q\n' "$OP_PREFLIGHT_ADC_TMPFILE"
   printf 'export OP_PREFLIGHT_DONE=1\n'
   printf 'export OP_PREFLIGHT_AGENT=%q\n' "$AGENT"
-  return 0
+  exit 0
+)
+
+# Warm author + reviewer SSH keys. Idempotent — each `ssh -T` exits
+# immediately with "You've successfully authenticated" when the agent
+# has the key, otherwise triggers the 1Password SSH-agent biometric
+# prompt for the underlying key. Called from both the full-fetch path
+# and the cache-hit fast path: skipping SSH warming on the fast path
+# means subsequent git/gh SSH operations can still block on auth even
+# after preflight reports success (friends-and-family-billing#227
+# round-5 Codex P2). Output goes to stderr so it's not eval'd.
+warm_ssh_keys() {
+  echo "# Preflight: warming SSH keys..." >&2
+  if ssh -T "git@${SSH_AUTHOR_HOST}" 2>&1 | grep -qi "successfully authenticated"; then
+    SUMMARY+=("SSH key ($SSH_AUTHOR_HOST): authorized")
+  else
+    SUMMARY+=("SSH key ($SSH_AUTHOR_HOST): warming attempted")
+  fi
+  local reviewer_host
+  reviewer_host="$(ssh_host_for "$AGENT")"
+  if ssh -T "git@${reviewer_host}" 2>&1 | grep -qi "successfully authenticated"; then
+    SUMMARY+=("SSH key ($reviewer_host): authorized")
+  else
+    SUMMARY+=("SSH key ($reviewer_host): warming attempted")
+  fi
 }
 
 # ── Fast path: reuse session file when fresh ──────────────────────────
 if ! $REFRESH && session_is_fresh; then
-  if emit_from_session_file; then
+  cached_exports=$(emit_from_session_file)
+  rc=$?
+  if [[ "$rc" == "0" ]]; then
+    echo "$cached_exports"
     age=$(( $(date +%s) - $(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" | cut -d= -f2- | tr -d "'\"") ))
+    # Warm SSH keys on the cache-hit path too. The cached PATs are
+    # worthless for git push/pull if SSH auth isn't also primed, and
+    # the prior implementation skipped this step entirely on cache
+    # hit — a repro surfaced on the consumer-repo propagation PRs.
+    SUMMARY=()
+    if [[ "$MODE" == "review" || "$MODE" == "all" ]] && ! $SKIP_SSH; then
+      warm_ssh_keys
+    fi
     echo "" >&2
     echo "# ── Preflight cached hit (age ${age}s / TTL ${TTL_SECONDS}s) ──" >&2
     echo "# Session file: $SESSION_FILE" >&2
+    for line in "${SUMMARY[@]}"; do
+      echo "#   $line" >&2
+    done
     echo "# Run with --refresh to force a new biometric fetch." >&2
     echo "# ──────────────────────────────────────────────────────────" >&2
     exit 0
@@ -430,22 +500,7 @@ fi
 
 # ── Phase 2: SSH key warming ──────────────────────────────────────────
 if [[ "$MODE" == "review" || "$MODE" == "all" ]] && ! $SKIP_SSH; then
-  echo "# Preflight: warming SSH keys..." >&2
-
-  # Author key
-  if ssh -T "git@${SSH_AUTHOR_HOST}" 2>&1 | grep -qi "successfully authenticated"; then
-    SUMMARY+=("SSH key ($SSH_AUTHOR_HOST): authorized")
-  else
-    SUMMARY+=("SSH key ($SSH_AUTHOR_HOST): warming attempted")
-  fi
-
-  # Reviewer key
-  reviewer_host="$(ssh_host_for "$AGENT")"
-  if ssh -T "git@${reviewer_host}" 2>&1 | grep -qi "successfully authenticated"; then
-    SUMMARY+=("SSH key ($reviewer_host): authorized")
-  else
-    SUMMARY+=("SSH key ($reviewer_host): warming attempted")
-  fi
+  warm_ssh_keys
 fi
 
 # ── Persist session file ──────────────────────────────────────────────

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -1,11 +1,28 @@
 #!/usr/bin/env bash
 # op-preflight.sh — Front-load all 1Password credential reads for a session.
 #
-# Triggers biometric prompts once at the start, then exports secrets as
-# environment variables so the rest of the session runs without prompting.
+# Triggers biometric prompts once at the start, then writes resolved secrets
+# to a chmod-600 session file under $XDG_CACHE_HOME/mergepath/ (default
+# $HOME/.cache/mergepath/). Subsequent invocations within the TTL window
+# read the session file and emit the same export statements WITHOUT
+# triggering biometric.
+#
+# This is what makes the script usable from agent drivers (Claude Code,
+# Cursor, Codex CLI) where each tool call spawns a fresh subshell and
+# cannot see env vars exported by a prior call. The first tool call in a
+# session warms the cache (one biometric prompt); every subsequent tool
+# call reuses the session file until it rotates. See
+# nathanjohnpayne/mergepath#139 for the observed failure mode that
+# motivated this design.
 #
 # Usage:
 #   eval "$(scripts/op-preflight.sh --agent claude --mode all)"
+#
+#   # Force a fresh fetch even if the session file is still warm:
+#   eval "$(scripts/op-preflight.sh --agent claude --mode all --refresh)"
+#
+#   # Delete the session file + ADC tempfile (end-of-session cleanup):
+#   scripts/op-preflight.sh --agent claude --purge
 #
 # Modes:
 #   review  — reviewer PAT + author PAT + SSH key warming
@@ -13,10 +30,27 @@
 #   all     — everything (default)
 #
 # Flags:
-#   --agent <name>   Agent name: claude, cursor, or codex (required for review)
+#   --agent <name>   Agent name: claude, cursor, or codex (required except --purge-all)
 #   --mode <mode>    review, deploy, or all (default: all)
 #   --dry-run        Show what would be fetched without prompting
 #   --skip-ssh       Skip SSH key warming (useful in CI or non-interactive)
+#   --refresh        Force biometric fetch even if session file is fresh
+#   --purge          Delete session file + ADC tempfile for the given --agent
+#   --purge-all      Delete ALL session files + ADC tempfiles under the cache dir
+#
+# Environment:
+#   OP_PREFLIGHT_TTL_SECONDS  Override default TTL (14400s = 4h). Age is
+#                             measured against the session file's embedded
+#                             timestamp, not file mtime, so `touch`-ing the
+#                             file does NOT extend its effective lifetime.
+#   OP_PREFLIGHT_CACHE_DIR    Override cache dir (default
+#                             $XDG_CACHE_HOME/mergepath or $HOME/.cache/mergepath).
+#
+# Session file:
+#   Path:        $cache_dir/op-preflight-<agent>.env
+#   Permissions: 600 (owner read/write only)
+#   Format:      bash-sourceable KEY='value' lines (printf %q-escaped)
+#   TTL anchor:  OP_PREFLIGHT_CREATED_AT_EPOCH (embedded in file, not mtime)
 #
 # After eval, downstream scripts and agent commands use the exported env
 # vars instead of calling op directly:
@@ -25,7 +59,7 @@
 #   # gcloud/firebase use GOOGLE_APPLICATION_CREDENTIALS automatically
 
 set -eo pipefail
-umask 077  # Restrict file permissions before any mktemp calls
+umask 077  # Restrict file permissions before any mktemp/cache writes
 
 # ── PAT lookup table ──────────────────────────────────────────────────
 # Must match REVIEW_POLICY.md § PAT lookup table.
@@ -49,6 +83,12 @@ ssh_host_for() {
   esac
 }
 
+# ── Cache layout ──────────────────────────────────────────────────────
+DEFAULT_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/mergepath"
+CACHE_DIR="${OP_PREFLIGHT_CACHE_DIR:-$DEFAULT_CACHE_DIR}"
+DEFAULT_TTL_SECONDS=14400  # 4 hours
+TTL_SECONDS="${OP_PREFLIGHT_TTL_SECONDS:-$DEFAULT_TTL_SECONDS}"
+
 # ── GCP ADC ───────────────────────────────────────────────────────────
 DEFAULT_ADC_OP_URI="${GCP_ADC_OP_URI:-op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential}"
 SSH_AUTHOR_HOST="github.com"
@@ -58,6 +98,9 @@ AGENT=""
 MODE="all"
 DRY_RUN=false
 SKIP_SSH=false
+REFRESH=false
+PURGE=false
+PURGE_ALL=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -65,6 +108,9 @@ while [[ $# -gt 0 ]]; do
     --mode)   MODE="$2"; shift 2 ;;
     --dry-run) DRY_RUN=true; shift ;;
     --skip-ssh) SKIP_SSH=true; shift ;;
+    --refresh) REFRESH=true; shift ;;
+    --purge) PURGE=true; shift ;;
+    --purge-all) PURGE_ALL=true; shift ;;
     *)
       echo "Error: unknown argument: $1" >&2
       echo "Usage: eval \"\$(scripts/op-preflight.sh --agent claude --mode all)\"" >&2
@@ -74,8 +120,16 @@ while [[ $# -gt 0 ]]; do
 done
 
 # ── Validate ──────────────────────────────────────────────────────────
-if [[ "$MODE" == "review" || "$MODE" == "all" ]] && [[ -z "$AGENT" ]]; then
-  echo "Error: --agent is required for review or all mode." >&2
+if $PURGE_ALL; then
+  if [[ -d "$CACHE_DIR" ]]; then
+    echo "# Purging all session files under $CACHE_DIR" >&2
+    find "$CACHE_DIR" -maxdepth 1 -type f \( -name 'op-preflight-*.env' -o -name 'op-preflight-*-adc.json' \) -print -delete >&2
+  fi
+  exit 0
+fi
+
+if [[ "$MODE" == "review" || "$MODE" == "all" || "$PURGE" == "true" ]] && [[ -z "$AGENT" ]]; then
+  echo "Error: --agent is required for review, all, or --purge mode." >&2
   echo "Usage: eval \"\$(scripts/op-preflight.sh --agent claude --mode all)\"" >&2
   exit 1
 fi
@@ -85,15 +139,37 @@ if [[ -n "$AGENT" ]] && [[ -z "$(reviewer_pat_item_for "$AGENT" 2>/dev/null || t
   exit 1
 fi
 
-# ── Preflight checks ─────────────────────────────────────────────────
-if ! command -v op &>/dev/null; then
-  echo "Error: 1Password CLI (op) not found." >&2
+if ! [[ "$TTL_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "Error: OP_PREFLIGHT_TTL_SECONDS must be an integer; got '$TTL_SECONDS'" >&2
   exit 1
+fi
+
+# ── Cache paths (deterministic per agent) ─────────────────────────────
+SESSION_FILE="$CACHE_DIR/op-preflight-$AGENT.env"
+ADC_TMPFILE="$CACHE_DIR/op-preflight-$AGENT-adc.json"
+
+# ── Purge mode ────────────────────────────────────────────────────────
+if $PURGE; then
+  rm -f "$SESSION_FILE" "$ADC_TMPFILE"
+  echo "# Purged session file + ADC tempfile for agent=$AGENT" >&2
+  exit 0
 fi
 
 # ── Dry run ───────────────────────────────────────────────────────────
 if $DRY_RUN; then
   echo "# op-preflight.sh --agent $AGENT --mode $MODE (dry run)" >&2
+  echo "#" >&2
+  echo "# Session file:   $SESSION_FILE" >&2
+  echo "# ADC tempfile:   $ADC_TMPFILE" >&2
+  echo "# TTL seconds:    $TTL_SECONDS" >&2
+  if [[ -f "$SESSION_FILE" ]]; then
+    embedded=$(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" | cut -d= -f2- | tr -d "'\"")
+    now=$(date +%s)
+    age=$((now - ${embedded:-0}))
+    echo "# Session age:    ${age}s (TTL ${TTL_SECONDS}s)" >&2
+  else
+    echo "# Session age:    n/a (no session file)" >&2
+  fi
   echo "#" >&2
   if [[ "$MODE" == "review" || "$MODE" == "all" ]]; then
     echo "# Would read: reviewer PAT ($(reviewer_pat_item_for "$AGENT"))" >&2
@@ -109,17 +185,190 @@ if $DRY_RUN; then
   exit 0
 fi
 
-# ── Collect export statements ─────────────────────────────────────────
+# ── Ensure cache dir exists (mode 0700) ───────────────────────────────
+mkdir -p "$CACHE_DIR"
+chmod 700 "$CACHE_DIR" 2>/dev/null || true
+
+# ── Session file freshness check ──────────────────────────────────────
+# Prefer an embedded CREATED_AT epoch over file mtime so `touch`-ing the
+# file cannot silently extend its effective lifetime.
+session_is_fresh() {
+  [[ -f "$SESSION_FILE" ]] || return 1
+  local created_at now age
+  created_at=$(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" 2>/dev/null | cut -d= -f2- | tr -d "'\"")
+  [[ -z "$created_at" ]] && return 1
+  [[ "$created_at" =~ ^[0-9]+$ ]] || return 1
+  now=$(date +%s)
+  age=$((now - created_at))
+  [[ "$age" -lt "$TTL_SECONDS" ]]
+}
+
+# Validate that a materialized ADC file still mints a token. Mirrors the
+# source_cred_is_usable check in scripts/firebase/op-firebase-deploy so a
+# stale 1Password ADC item (refresh_token expired by Google) gets caught
+# in preflight instead of inside firebase CLI after the user has already
+# eval'd the exports. See nathanjohnpayne/mergepath#137 failure mode B
+# for the concrete repro: 1Password holds an authorized_user cred whose
+# refresh_token has expired; op read succeeds and writes the file, but
+# the OAuth2 /token round-trip fails. Without this check, preflight
+# reports "GCP ADC: loaded" and downstream callers see
+# "GOOGLE_APPLICATION_CREDENTIALS points to an unusable credential file"
+# from inside op-firebase-deploy.
+#
+# Returns 0 if the file exists and mints a token (or is a self-contained
+# service_account key). Returns 1 otherwise — including when python3 is
+# unavailable or the oauth2 endpoint is unreachable in which case the
+# safer behavior is to treat the cred as stale and let downstream
+# callers fall back to their own auth path.
+adc_is_usable() {
+  local file="${1:-}"
+  [[ -n "$file" && -f "$file" && -s "$file" ]] || return 1
+  command -v python3 >/dev/null 2>&1 || return 1
+  python3 - "$file" <<'PY'
+import json, pathlib, sys, urllib.request, urllib.parse
+
+try:
+    cred = json.loads(pathlib.Path(sys.argv[1]).read_text())
+except Exception:
+    sys.exit(1)
+
+while cred.get("type") == "impersonated_service_account" and "source_credentials" in cred:
+    cred = cred["source_credentials"]
+
+if cred.get("type") == "service_account":
+    sys.exit(0)
+
+refresh_token = cred.get("refresh_token", "")
+client_id     = cred.get("client_id", "")
+client_secret = cred.get("client_secret", "")
+
+if not all([refresh_token, client_id, client_secret]):
+    sys.exit(1)
+
+data = urllib.parse.urlencode({
+    "client_id": client_id,
+    "client_secret": client_secret,
+    "refresh_token": refresh_token,
+    "grant_type": "refresh_token",
+}).encode()
+try:
+    req = urllib.request.Request("https://oauth2.googleapis.com/token", data=data)
+    urllib.request.urlopen(req, timeout=10)
+except Exception:
+    sys.exit(1)
+PY
+}
+
+# Emit the human-facing guidance for a stale 1Password ADC item. Called
+# from both the full-fetch path (after op read + adc_is_usable fails)
+# and the fast-path cache-hit path (when a cached ADC fails the same
+# check on the next invocation).
+log_stale_adc_guidance() {
+  echo "# ──────────────────────────────────────────────────────" >&2
+  echo "# WARNING: 1Password ADC item is stale (OAuth2 refresh rejected)." >&2
+  echo "#" >&2
+  echo "# The credential stored at $DEFAULT_ADC_OP_URI" >&2
+  echo "# was read successfully but Google rejected its refresh token —" >&2
+  echo "# typical causes: token revoked, expired (RAPT), or user account" >&2
+  echo "# password changed. Refresh it with:" >&2
+  echo "#" >&2
+  echo "#   gcloud auth application-default login" >&2
+  echo "#   op document edit 'GCP ADC' --vault=Private \\" >&2
+  echo "#     ~/.config/gcloud/application_default_credentials.json" >&2
+  echo "#" >&2
+  echo "# (use 'op item edit' if the ADC is stored as an item field instead)" >&2
+  echo "#" >&2
+  echo "# Preflight will NOT export GOOGLE_APPLICATION_CREDENTIALS this run" >&2
+  echo "# so downstream callers (op-firebase-deploy, gcloud wrappers) can" >&2
+  echo "# fall back to the local firebase-login / ADC path." >&2
+  echo "# See nathanjohnpayne/mergepath#137 for the failure mode this guards." >&2
+  echo "# ──────────────────────────────────────────────────────" >&2
+}
+
+# Emit the session file's export statements to stdout. Caller eval's them.
+emit_from_session_file() {
+  # Source the session file and re-emit only the vars we own, so a
+  # hand-edited file with arbitrary content cannot inject exports.
+  # Also drop CREATED_AT from the exported set; it's bookkeeping.
+  # shellcheck disable=SC1090
+  . "$SESSION_FILE"
+
+  # Validate the session file actually contains the credentials the
+  # CURRENT invocation's --mode is asking for. A stale cross-mode cache
+  # (e.g. a prior `--mode deploy` run wrote only ADC fields, and this
+  # run is `--mode review`) would otherwise hit the fast path and emit
+  # no PAT exports — downstream `gh` review commands then run
+  # unauthenticated. Return non-zero to trigger the refresh path in
+  # each case. See #141 round-1 Codex finding (P1, line 223).
+  if [[ "$MODE" == "review" || "$MODE" == "all" ]]; then
+    if [[ -z "${OP_PREFLIGHT_REVIEWER_PAT:-}" ]] || [[ -z "${OP_PREFLIGHT_AUTHOR_PAT:-}" ]]; then
+      return 2
+    fi
+  fi
+  if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
+    # Both the cached-path pointer must be set AND the file it names
+    # must still be readable (non-empty) AND still mint a token. The
+    # usability check catches the case where the cached ADC was valid
+    # at write time but has since been revoked/expired by Google —
+    # without it, a fresh session file would keep re-emitting a dead
+    # GOOGLE_APPLICATION_CREDENTIALS export for up to TTL_SECONDS.
+    # See #137 failure mode B.
+    if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] || [[ ! -s "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+      return 2
+    fi
+    if ! adc_is_usable "${GOOGLE_APPLICATION_CREDENTIALS}"; then
+      log_stale_adc_guidance
+      return 2
+    fi
+  fi
+
+  [[ -n "${OP_PREFLIGHT_REVIEWER_PAT:-}" ]] && \
+    printf 'export OP_PREFLIGHT_REVIEWER_PAT=%q\n' "$OP_PREFLIGHT_REVIEWER_PAT"
+  [[ -n "${OP_PREFLIGHT_AUTHOR_PAT:-}" ]] && \
+    printf 'export OP_PREFLIGHT_AUTHOR_PAT=%q\n' "$OP_PREFLIGHT_AUTHOR_PAT"
+  [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] && \
+    printf 'export GOOGLE_APPLICATION_CREDENTIALS=%q\n' "$GOOGLE_APPLICATION_CREDENTIALS"
+  [[ -n "${OP_PREFLIGHT_ADC_TMPFILE:-}" ]] && \
+    printf 'export OP_PREFLIGHT_ADC_TMPFILE=%q\n' "$OP_PREFLIGHT_ADC_TMPFILE"
+  printf 'export OP_PREFLIGHT_DONE=1\n'
+  printf 'export OP_PREFLIGHT_AGENT=%q\n' "$AGENT"
+  return 0
+}
+
+# ── Fast path: reuse session file when fresh ──────────────────────────
+if ! $REFRESH && session_is_fresh; then
+  if emit_from_session_file; then
+    age=$(( $(date +%s) - $(grep '^OP_PREFLIGHT_CREATED_AT_EPOCH=' "$SESSION_FILE" | cut -d= -f2- | tr -d "'\"") ))
+    echo "" >&2
+    echo "# ── Preflight cached hit (age ${age}s / TTL ${TTL_SECONDS}s) ──" >&2
+    echo "# Session file: $SESSION_FILE" >&2
+    echo "# Run with --refresh to force a new biometric fetch." >&2
+    echo "# ──────────────────────────────────────────────────────────" >&2
+    exit 0
+  fi
+  # emit_from_session_file returned non-zero (e.g. ADC file vanished).
+  # Fall through to full fetch.
+  echo "# Session file stale or incomplete — refreshing" >&2
+fi
+
+# ── Preflight checks for full fetch ──────────────────────────────────
+if ! command -v op &>/dev/null; then
+  echo "Error: 1Password CLI (op) not found." >&2
+  exit 1
+fi
+
+# ── Collect export statements + session-file lines ───────────────────
 EXPORTS=()
+SESSION_LINES=()
 SUMMARY=()
 
 # ── Phase 1: CLI credentials (one biometric prompt + session reuse) ───
 if [[ "$MODE" == "review" || "$MODE" == "all" ]]; then
   reviewer_item="$(reviewer_pat_item_for "$AGENT")"
 
-  # Build an op inject template for both PATs.
-  # op inject resolves all op:// references in a single process — one
-  # biometric prompt covers both reads.
+  # Build an op inject template for both PATs. op inject resolves all
+  # op:// references in a single process — one biometric prompt covers
+  # both reads.
   tpl_file="$(mktemp "${TMPDIR:-/tmp}/op-preflight-tpl-XXXXXX")"
   trap 'rm -f "$tpl_file"' EXIT
 
@@ -146,6 +395,8 @@ TPL
 
   EXPORTS+=("export OP_PREFLIGHT_REVIEWER_PAT=$(printf '%q' "$reviewer_pat")")
   EXPORTS+=("export OP_PREFLIGHT_AUTHOR_PAT=$(printf '%q' "$author_pat")")
+  SESSION_LINES+=("OP_PREFLIGHT_REVIEWER_PAT=$(printf '%q' "$reviewer_pat")")
+  SESSION_LINES+=("OP_PREFLIGHT_AUTHOR_PAT=$(printf '%q' "$author_pat")")
   SUMMARY+=("Reviewer PAT ($AGENT): loaded")
   SUMMARY+=("Author PAT: loaded")
 fi
@@ -153,14 +404,25 @@ fi
 if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
   echo "# Preflight: reading GCP ADC (reuses session)..." >&2
 
-  adc_tmpfile="$(mktemp "${TMPDIR:-/tmp}/op-preflight-adc-XXXXXX")"
+  # Deterministic path so subsequent invocations find the same file.
+  # Overwrite in place — chmod 600 before writing secret content.
+  touch "$ADC_TMPFILE"
+  chmod 600 "$ADC_TMPFILE"
 
-  if op read "$DEFAULT_ADC_OP_URI" > "$adc_tmpfile" 2>/dev/null && [[ -s "$adc_tmpfile" ]]; then
-    EXPORTS+=("export GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$adc_tmpfile")")
-    EXPORTS+=("export OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$adc_tmpfile")")
-    SUMMARY+=("GCP ADC: loaded -> $adc_tmpfile")
+  if op read "$DEFAULT_ADC_OP_URI" > "$ADC_TMPFILE" 2>/dev/null && [[ -s "$ADC_TMPFILE" ]]; then
+    if adc_is_usable "$ADC_TMPFILE"; then
+      EXPORTS+=("export GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")
+      EXPORTS+=("export OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$ADC_TMPFILE")")
+      SESSION_LINES+=("GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")
+      SESSION_LINES+=("OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$ADC_TMPFILE")")
+      SUMMARY+=("GCP ADC: loaded -> $ADC_TMPFILE")
+    else
+      rm -f "$ADC_TMPFILE"
+      log_stale_adc_guidance
+      SUMMARY+=("GCP ADC: STALE (refresh_token rejected — see warning above)")
+    fi
   else
-    rm -f "$adc_tmpfile"
+    rm -f "$ADC_TMPFILE"
     echo "# Warning: could not read GCP ADC. Deploy credentials not cached." >&2
     SUMMARY+=("GCP ADC: SKIPPED (not available)")
   fi
@@ -186,6 +448,25 @@ if [[ "$MODE" == "review" || "$MODE" == "all" ]] && ! $SKIP_SSH; then
   fi
 fi
 
+# ── Persist session file ──────────────────────────────────────────────
+CREATED_AT=$(date +%s)
+{
+  printf '# op-preflight session cache — do NOT edit by hand.\n'
+  printf '# Agent:      %s\n' "$AGENT"
+  printf '# Mode:       %s\n' "$MODE"
+  printf '# Created:    %s (epoch %s)\n' "$(date -u -r "$CREATED_AT" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "@$CREATED_AT" +%Y-%m-%dT%H:%M:%SZ)" "$CREATED_AT"
+  printf '# TTL:        %s seconds\n' "$TTL_SECONDS"
+  printf 'OP_PREFLIGHT_CREATED_AT_EPOCH=%s\n' "$CREATED_AT"
+  printf 'OP_PREFLIGHT_TTL_SECONDS=%s\n' "$TTL_SECONDS"
+  printf 'OP_PREFLIGHT_AGENT=%q\n' "$AGENT"
+  printf 'OP_PREFLIGHT_MODE=%q\n' "$MODE"
+  printf 'OP_PREFLIGHT_DONE=1\n'
+  for line in "${SESSION_LINES[@]}"; do
+    printf '%s\n' "$line"
+  done
+} > "$SESSION_FILE"
+chmod 600 "$SESSION_FILE"
+
 # ── Output ────────────────────────────────────────────────────────────
 EXPORTS+=("export OP_PREFLIGHT_DONE=1")
 EXPORTS+=("export OP_PREFLIGHT_AGENT=$(printf '%q' "$AGENT")")
@@ -201,6 +482,7 @@ echo "# ── Preflight complete ───────────────�
 for line in "${SUMMARY[@]}"; do
   echo "#   $line" >&2
 done
+echo "# Session file: $SESSION_FILE (TTL ${TTL_SECONDS}s)" >&2
 echo "# OP_PREFLIGHT_DONE=1" >&2
 echo "# Human can step away." >&2
 echo "# ──────────────────────────────────────────────────────" >&2


### PR DESCRIPTION
Authoring-Agent: claude

Propagates `scripts/op-preflight.sh` and new `scripts/coderabbit-wait.sh` from mergepath main after the 2026-04-19 review-tooling session. See mergepath#140 (coderabbit-wait.sh + auto-merge fix; closes mergepath #136 + #138), #141 (preflight session cache; closes mergepath #139), #142 (cross-mode validation), #143 (stale-ADC detector; mergepath #137 failure mode B).

Note: this repo's local op-preflight.sh had a one-line divergence from the old canonical (removing `"${adc_tmpfile:-}"` from the EXIT trap). The new mergepath version fully subsumes that patch — the ADC tempfile now lives at a deterministic cache path and isn't registered to any EXIT trap at all.

No changes to `.github/workflows/agent-review.yml` — that's a separate PR because each consumer's workflow has drifted differently from mergepath's. The new `coderabbit-wait.sh` is still usable from the agent-in-the-loop flow today.

## Self-Review

- Correctness: straight file copies from mergepath main; both `chmod +x` and `bash -n` clean. Exercised end-to-end via mergepath#140 → #143.
- Regression risk: op-preflight.sh is a significant rewrite with identical public interface — new cached-hit behavior (TTL 4h default), deterministic ADC tempfile path (fixes a latent bug where the prior EXIT trap deleted the file before `eval` could consume it). coderabbit-wait.sh is entirely additive.
- Style: matches the canonical mergepath copy.
- Test coverage: mergepath exercised both scripts; no new test harness here.
- Security: no new deps. Session file 0600 in cache dir 0700 — the tradeoff accepted in mergepath#139 for agent-driver ergonomics; `--purge`-able at session end.