### PR TITLE
fix(home): Vibe Coding panel height, arrow rendering, mobile hero accent

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -151,17 +151,17 @@ const homepageJsonLd = {
             <p>Community organizing—identifying shared stakes, building coalitions, and sustaining momentum—is a form of product management. I’ve raised over $105,000 for three causes.</p>
             <ul class="effort-list">
               <li>
-                <a class="effort-link" href="https://donate.larkinstreetyouth.org/campaign/653966/donate" target="_blank" rel="noopener">Larkin Street Youth Services ↗</a>
+                <a class="effort-link" href="https://donate.larkinstreetyouth.org/campaign/653966/donate" target="_blank" rel="noopener">Larkin Street Youth Services ↗︎</a>
                 <div class="effort-amount">$16,684 raised</div>
                 <div class="effort-desc">$16,684 raised for Safe &amp; Seen—a campaign for LGBTQ+ youth experiencing homelessness in San Francisco, providing housing, education, and healthcare through Larkin Street Youth Services.</div>
               </li>
               <li>
-                <a class="effort-link" href="https://www.sfaf.org" target="_blank" rel="noopener">San Francisco AIDS Foundation ↗</a>
+                <a class="effort-link" href="https://www.sfaf.org" target="_blank" rel="noopener">San Francisco AIDS Foundation ↗︎</a>
                 <div class="effort-amount">$80,195 raised</div>
                 <div class="effort-desc">Three AIDS/LifeCycle rides. $9,166 in 2023. $45,646 in 2024. $25,383 in 2025. $80,195 total for HIV prevention, care services, and housing stability through the San Francisco AIDS Foundation.</div>
               </li>
               <li>
-                <a class="effort-link" href="https://jewishfed.org/what-we-do/our-programs/giving-circles/jewish-pride-fund/" target="_blank" rel="noopener">Jewish Pride Fund ↗</a>
+                <a class="effort-link" href="https://jewishfed.org/what-we-do/our-programs/giving-circles/jewish-pride-fund/" target="_blank" rel="noopener">Jewish Pride Fund ↗︎</a>
                 <div class="effort-amount">$8,959 raised</div>
                 <div class="effort-desc">Raised $8,959 and stayed involved after the check cleared—joining one of the few LGBTQ+ Jewish giving circles in the nation to interview grant applicants and help direct where the fund’s dollars land.</div>
               </li>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -107,6 +107,10 @@ html, body {
     minmax(2.8rem, 0.78fr) var(--line);
 }
 
+.mondrian[data-focus="projects"] .panel--yellow {
+  grid-row: 2 / 5;
+}
+
 .mondrian[data-focus="community"] {
   grid-template-columns:
     var(--line) minmax(11rem, 4.1fr) var(--line)
@@ -2656,7 +2660,7 @@ a:focus-visible {
 }
 
 @media (max-width: 480px) {
-  .project-hero {
+  .project-hero__header {
     padding: 1rem 1rem 1.15rem;
   }
 


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Three small visual-fidelity fixes on the homepage and project hero, verified in preview at multiple viewports (mobile 375px, tablet 720/900px, desktop 1280/1700/2000px):

- **Vibe Coding panel fits all content at all widths.** In `data-focus=\"projects\"`, the yellow panel now spans rows 2–4 instead of only row 2. At wider viewports where clamp-scaled text grew taller than the single row could hold, the stack ribbon's \"Codex · Cursor\" line was being clipped / forced into the content-inner scroll area. Yellow (z-index 4) sits on top of the two small decorative white blocks (z-index 2) underneath while it's open; the blocks reappear when the panel closes, so the default Mondrian grid is unchanged.
- **Community-section link arrows render as text on iOS.** Appended U+FE0E (text variation selector) after the U+2197 `↗` glyph in the three `.effort-link` anchors. Those anchors use `Cormorant Garamond` (serif), which has no glyph for U+2197, so iOS Safari was falling back to Apple Color Emoji and rendering a blue rounded-square — visually inconsistent with the Vibe Coding `.p-link` arrows, which inherit a sans-serif font that has the text glyph.
- **Project hero accent stripe aligns to the card edge on phones.** At `@media (max-width: 480px)`, moved `padding: 1rem 1rem 1.15rem` from `.project-hero` to `.project-hero__header`. The outer padding was leftover from the pre-`__gradient` layout. With the refactored structure, the color accent is a `border-left` on `.project-hero__gradient`, so any padding on the outer `.project-hero` pushes the stripe inward from the card edge and shortens it by the vertical padding. `--wide`/`--narrow` variants set `padding: 0` on the outer correctly, but the equal-specificity mobile media query landed later in the cascade and won.

## Self-Review

**Correctness.** Three independent fixes; verified each in `preview_screenshot` at multiple widths. For (1), checked default/closed state renders identically to before (the new selector is scoped to `.mondrian[data-focus=\"projects\"]` so it only applies when yellow is open). For (2), ran a text-presentation check — U+FE0E is the standards-defined signal honored by WebKit, broadly supported elsewhere. For (3), verified the outer `.project-hero` has `padding: 0` on `--wide`/`--narrow` variants at every viewport after the change, and the accent stripe runs full card height flush with the left edge on mobile (375), tablet (720), and desktop (1280).

**Regression risk.** Low.
- (1) The added selector only fires for `data-focus=\"projects\"`; all other focus states (about, community, connect) and the default state untouched.
- (2) HTML text change only; U+FE0E is ignored by fonts that already have a text glyph — zero effect on platforms that were already rendering correctly (macOS/Chromium/Android), visible fix on iOS Safari.
- (3) Moved a declaration one selector deeper. The `__header` already has its own `padding: clamp(1.15rem, 3vw, 2.5rem)` at desktop; the mobile override takes precedence via cascade order as before, just on the right element now.

**Style.** Matches existing patterns in the file (scoped `.mondrian[data-focus=…]` overrides, existing inner-element `padding-left: 0.5rem` tweaks in the same mobile block, existing arrow styling via HTML text).

**Test coverage.** No unit tests for these presentation tweaks — verified via preview screenshots at 375/720/900/1280/1700/2000px.

**Security/dependency hygiene.** No dependency changes. Pure CSS + static HTML text edits.

## Test plan

- [x] Homepage default (closed) Mondrian grid unchanged at 1280px+.
- [x] Vibe Coding panel opened at 375 / 720 / 1100 / 1700 / 2000 — full content + stack ribbon visible with headroom, no clipped text.
- [x] Community links (`Larkin Street Youth Services ↗`, `San Francisco AIDS Foundation ↗`, `Jewish Pride Fund ↗`) render the arrow consistently with Vibe Coding links on desktop Chromium (no regression).
- [ ] Community arrow text presentation on iOS Safari — not reproducible in Chromium preview; relying on spec compliance of U+FE0E. (Original visual bug was iOS-only per user screenshot.)
- [x] `/projects/friends-and-family-billing/` hero accent stripe flush with card edge + full height at 375 / 720 / 1280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)