### PR TITLE
Remove CI-side invoke-reviewer job

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -236,100 +236,19 @@ jobs:
               console.log(`Assigned ${reviewer} for internal self-peer review.`);
             }
 
-  # ──────────────────────────────────────────────
-  # Job 4: Trigger subagent to perform the review
-  # ──────────────────────────────────────────────
-  invoke-reviewer:
-    needs: [assign]
-    if: >
-      always() &&
-      github.event_name == 'pull_request' &&
-      (github.event.action == 'opened' || github.event.action == 'ready_for_review')
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - agent: claude
-            username: nathanpayne-claude
-          - agent: codex
-            username: nathanpayne-codex
-          - agent: cursor
-            username: nathanpayne-cursor
-    steps:
-      - name: Check if this agent is assigned
-        id: check-assigned
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        with:
-          github-token: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
-          script: |
-            const { data: reviewers } = await github.rest.pulls.listRequestedReviewers({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-            });
-            const assigned = reviewers.users.some(
-              u => u.login === '${{ matrix.username }}'
-            );
-            core.setOutput('assigned', assigned.toString());
-
-      # ── Claude: headless CLI ──
-      - name: Checkout repo
-        if: steps.check-assigned.outputs.assigned == 'true' && matrix.agent == 'claude'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
-
-      - name: Install Claude Code
-        if: steps.check-assigned.outputs.assigned == 'true' && matrix.agent == 'claude'
-        run: npm install -g @anthropic-ai/claude-code
-
-      - name: Invoke Claude Code
-        if: steps.check-assigned.outputs.assigned == 'true' && matrix.agent == 'claude'
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.CLAUDE_PAT }}
-        run: |
-          claude -p "Review PR #${{ github.event.pull_request.number }} on ${{ github.repository }}. \
-            Read REVIEW_POLICY.md for the review workflow. \
-            Read the diff, check for correctness, security issues, style violations, and test coverage. \
-            Post your review via the GitHub API using the GITHUB_TOKEN env var. \
-            Authenticate as nathanpayne-claude." \
-            --allowedTools "Bash,Read,Glob,Grep,WebFetch"
-
-      # ── Codex: OpenAI Codex CLI ──
-      - name: Checkout repo for Codex
-        if: steps.check-assigned.outputs.assigned == 'true' && matrix.agent == 'codex'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
-
-      - name: Invoke Codex
-        if: steps.check-assigned.outputs.assigned == 'true' && matrix.agent == 'codex'
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.CODEX_PAT }}
-        run: |
-          # TODO: Replace with actual Codex CLI invocation once available
-          echo "Codex headless review invocation — pending CLI availability"
-
-      # ── Cursor: no headless mode yet ──
-      - name: Notify for manual Cursor review
-        if: steps.check-assigned.outputs.assigned == 'true' && matrix.agent == 'cursor'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        with:
-          github-token: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: '**@nathanpayne-cursor** has been assigned to review this PR. Cursor does not support headless invocation — please open this PR in Cursor to perform the review manually.',
-            });
+  # Note: no CI-side invoke-reviewer job exists. Phase 2 internal
+  # self-peer review is performed by the authoring agent in its own
+  # session — the agent switches its identity to its reviewer account
+  # (e.g., nathanpayne-claude) via a PAT from 1Password and posts the
+  # review with that PAT. See REVIEW_POLICY.md § Phase 2 and CLAUDE.md
+  # "After opening the PR" steps 4–7. A headless Claude/Codex CLI
+  # invocation in CI is intentionally NOT used: it (a) bypasses the
+  # in-session tool context the agent already has, (b) adds a stale
+  # API-key failure surface unrelated to the PR, and (c) duplicates
+  # work the agent is already doing as part of the PR loop.
 
   # ──────────────────────────────────────────────
-  # Job 5: Detect agent disagreement → escalate
+  # Job 4: Detect agent disagreement → escalate
   # ──────────────────────────────────────────────
   detect-disagreement:
     if: github.event_name == 'pull_request_review'
@@ -426,7 +345,7 @@ jobs:
             }
 
   # ──────────────────────────────────────────────
-  # Job 6: Block self-approval
+  # Job 5: Block self-approval
   # ──────────────────────────────────────────────
   block-self-approval:
     if: >
@@ -488,7 +407,7 @@ jobs:
             }
 
   # ──────────────────────────────────────────────
-  # Job 7: Auto-merge on approval (if no external review required)
+  # Job 6: Auto-merge on approval (if no external review required)
   # ──────────────────────────────────────────────
   # Must `needs:` on detect-disagreement and block-self-approval to force
   # those sibling jobs to COMPLETE before this one starts. Both siblings

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -168,29 +168,29 @@ Go to the new repo → Settings → Secrets and variables → Actions → New re
 
 | Secret name | Value | PAT type |
 |---|---|---|
-| `CLAUDE_PAT` | Classic PAT for `nathanpayne-claude` with `repo` scope | **Classic** (not fine-grained) |
-| `CODEX_PAT` | Classic PAT for `nathanpayne-codex` with `repo` scope | **Classic** (not fine-grained) |
-| `CURSOR_PAT` | Classic PAT for `nathanpayne-cursor` with `repo` scope | **Classic** (not fine-grained) |
 | `REVIEWER_ASSIGNMENT_TOKEN` | PAT for `nathanjohnpayne` | Fine-grained OK (owns repo) |
-| `ANTHROPIC_API_KEY` | Anthropic API key for Claude Code headless review | — |
-| `OPENAI_API_KEY` | OpenAI API key for Codex headless review | — |
-
-**Why classic PATs?** Machine users are collaborators, not repo owners. Fine-grained
-PATs on personal (non-org) GitHub accounts only cover repos the account *owns*.
-The "All repositories" scope means all owned repos (zero for collaborators), and
-"Only select repositories" does not list collaborator repos.
 
 Or use the CLI (faster):
 
 ```bash
-# Use exact 1Password item IDs (avoids shell issues with parentheses in item titles):
-gh secret set CLAUDE_PAT --repo {owner}/{repo} --body "$(op read 'op://Private/pvbq24vl2h6gl7yjclxy2hbote/token')"
-gh secret set CURSOR_PAT --repo {owner}/{repo} --body "$(op read 'op://Private/bslrih4spwxgookzfy6zedz5g4/token')"
-gh secret set CODEX_PAT --repo {owner}/{repo} --body "$(op read 'op://Private/o6ekjxjjl5gq6rmcneomrjahpu/token')"
 gh secret set REVIEWER_ASSIGNMENT_TOKEN --repo {owner}/{repo} --body "$(op read 'op://Private/sm5kopwk6t6p3xmu2igesndzhe/token')"
-gh secret set ANTHROPIC_API_KEY --repo {owner}/{repo} --body "$(op read 'op://Private/ey6stbr75px3mx6nzthh6z54o4/credential')"  # Claude API Key (Test/Dev) — generate a project-specific key for long-term use
-gh secret set OPENAI_API_KEY --repo {owner}/{repo} --body "$(op read 'op://Private/ooj5vq25ynj5n56mqm7xrmumsq/credential')"  # ChatGPT API Key (Test/Dev) — generate a project-specific key for long-term use
 ```
+
+**Reviewer identity PATs (`nathanpayne-claude`, `nathanpayne-codex`,
+`nathanpayne-cursor`) are intentionally NOT stored as repo CI secrets.**
+Phase 2 internal self-peer review runs in the agent's own session: the
+agent switches its Git identity to its reviewer account with a PAT
+read directly from 1Password (`op read 'op://Private/<item-id>/token'`)
+and posts the review with that PAT. See REVIEW_POLICY.md § Phase 2 and
+each repo's `CLAUDE.md` / `AGENTS.md` for the identity-switch procedure.
+
+**Do NOT add `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `CLAUDE_PAT` /
+`CODEX_PAT` / `CURSOR_PAT` as repo secrets.** An earlier iteration of
+`agent-review.yml` had an `invoke-reviewer` job that ran the Claude
+Code CLI headlessly as a CI-side reviewer; this was the wrong flow
+(parallel to the authoring session, stale-API-key failure surface,
+duplicate work) and was removed. Phase 2 now lives entirely inside
+the authoring agent's session.
 
 ### 4. Configure branch protection
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -328,15 +328,23 @@ GH_TOKEN="$(op read 'op://Private/pvbq24vl2h6gl7yjclxy2hbote/token')" \
 
 ### Token rotation (as needed)
 
-The current PATs are set to never expire. If you ever need to rotate them:
+The current PATs are set to never expire. If you ever need to rotate
+a reviewer identity PAT (`nathanpayne-claude`, `nathanpayne-codex`,
+`nathanpayne-cursor`):
 
-1. Generate new **classic** PATs with `repo` scope for each machine user account
-2. Update the tokens in 1Password (field name: `token`)
-3. Update `CLAUDE_PAT`, `CODEX_PAT`, `CURSOR_PAT` secrets on every repo
-4. Revoke the old tokens
-5. Verify agent access still works
+1. Generate a new **classic** PAT with `repo` scope for the machine user account
+2. Update the `token` field on the corresponding 1Password item
+3. Revoke the old token in GitHub
+4. Verify agent access still works: `GH_TOKEN="$(op read 'op://Private/<item-id>/token')" gh api user`
 
-The `REVIEWER_ASSIGNMENT_TOKEN` (Nathan's PAT) follows the same rotation process.
+Note: reviewer identity PATs are NOT stored as repo CI secrets. They are
+read from 1Password per-session by the authoring agent for the in-session
+identity switch, so rotation does not require updating any repo secrets.
+
+The `REVIEWER_ASSIGNMENT_TOKEN` repo secret (Nathan's PAT used by the
+Agent Review Pipeline workflow) follows a similar process but also
+needs a `gh secret set REVIEWER_ASSIGNMENT_TOKEN --repo {owner}/{repo}`
+call on every repo after rotating the 1Password item.
 
 ---
 


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Removes the `invoke-reviewer` job from `.github/workflows/agent-review.yml`. That job ran the Claude Code CLI headlessly as a parallel CI-side reviewer, which duplicated the in-session Phase 2 self-peer review the authoring agent is already supposed to do (REVIEW_POLICY.md § Phase 2; CLAUDE.md § "After opening the PR" steps 4–7).

It also added a stale-API-key failure surface unrelated to the PR under review. The concrete incident: a recent PR's `invoke-reviewer (claude, nathanpayne-claude)` job failed with `Invalid API key · Fix external API key` because the `ANTHROPIC_API_KEY` repo secret had expired. The merge wasn't blocked (an approval from the in-session flow already existed), but CI was noisy for a reason that had nothing to do with the change under review.

Updates `DEPLOYMENT.md` to:
- Remove the obsolete secret rows (`CLAUDE_PAT`, `CODEX_PAT`, `CURSOR_PAT`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) and their `gh secret set` commands.
- Explicitly document that reviewer PATs are NOT repo CI secrets — they're read from 1Password per-session for the in-session identity switch.
- Explicitly forbid re-adding those secrets, with a short history note explaining why.

Identical workflow + DEPLOYMENT.md changes are being propagated across all 7 agent repos; the PRD in `docs/prds/mergepath.md` gets a parallel update.

## Self-Review

**Correctness.** The `invoke-reviewer` job was self-contained — no other job in the workflow depended on its outputs. Downstream jobs are all triggered by `pull_request_review` events, not by `invoke-reviewer` completing. Verified with `yaml.safe_load` that the remaining workflow parses cleanly. The `assign` job is unchanged and still requests the correct reviewer identity.

**Regression risk.** Low. The removed job was a matrix of three branches; claude was the only one doing real work (and doing it wrong), codex was a TODO stub, cursor posted a static comment that the `assign` job's reviewer request already conveys natively.

**Style.** Job comments renumbered (5→4, 6→5, 7→6) to match the new job count.

**Test coverage.** N/A — workflow change. Validated YAML parse across all 7 repos.

**Security / dependency hygiene.** Net-positive: five stale repo secrets per repo can be deleted once this lands.

## Test plan

- [ ] Agent Review Pipeline runs without `invoke-reviewer` job on this PR
- [ ] `assign` still requests `nathanpayne-claude` as reviewer
- [ ] `auto-merge-on-approval` still fires correctly on approval
- [ ] YAML parses (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)