### PR TITLE
fix(home): pin Vibe Coding panel text to fixed sizes

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -523,7 +523,7 @@ html, body {
 }
 
 .panel--yellow .content-inner h2 {
-  font-size: clamp(1.2rem, 1.9vw, 2.05rem);
+  font-size: 1.5rem;
   letter-spacing: 0.02em;
   margin-bottom: var(--su);
   line-height: 1.05;
@@ -531,7 +531,7 @@ html, body {
 
 .panel--yellow .content-inner p,
 .panel--yellow .content-inner a {
-  font-size: clamp(0.78rem, 0.88vw, 0.92rem);
+  font-size: 0.85rem;
   line-height: 1.48;
 }
 
@@ -540,11 +540,11 @@ html, body {
 }
 
 .panel--yellow .p-name {
-  font-size: clamp(0.92rem, 1.1vw, 1.14rem);
+  font-size: 1rem;
 }
 
 .panel--yellow .p-tag {
-  font-size: clamp(0.56rem, 0.68vw, 0.62rem);
+  font-size: 0.6rem;
 }
 
 .panel--yellow .project-list {
@@ -560,8 +560,8 @@ html, body {
 }
 
 .panel--yellow .content-inner {
-  padding-top: clamp(0.75rem, 1.6vw, 1.45rem);
-  padding-bottom: clamp(0.42rem, 1.2vw, 1.3rem);
+  padding-top: 1.1rem;
+  padding-bottom: 0.9rem;
 }
 
 .stack-ribbon,


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

The Mondrian grid is sized by `min(95vw, 95vh)` with `aspect-ratio: 1/1`, so on landscape screens (vh-bound) the grid stops growing past a point — but the yellow panel's `clamp(min, Xvw, max)` font sizes keep scaling with viewport width. Visible effect on wide monitors: text grew relative to the capped grid, Friends & Family Billing's \"Live\" link wrapped, and the Stack ribbon's second line clipped before PR #252's row-span fix; after that fix content fit, but the text/grid size mismatch remained.

Replace the six `clamp()` declarations in `.panel--yellow` (`h2`, `p`/`a`, `p-name`, `p-tag`, `content-inner` padding-top/-bottom) with fixed rem values. Above the 920px responsive breakpoint, the text sizes now stay constant; below it, the existing media-query stack layout handles narrow viewports. Values chosen to sit mid-clamp so nothing jumps significantly at either end.

## Self-Review

**Correctness.** Verified in preview at 1200×900 and 1900×1200. Text sizes are identical at both widths; layout is clean at both. No content clipping.

**Regression risk.** Low.
- Scope is `.panel--yellow` only (Vibe Coding). Red, black, blue panels untouched.
- Below 920px, a separate media query remaps the Mondrian into a single-column stack — these fixed sizes still apply but the panel width expands to match the viewport, so text doesn't look undersized.
- No semantic or structural changes.

**Style.** Matches sibling panels' fixed-size declarations and existing rem-based tokens.

**Test coverage.** No unit tests for typography; verified visually.

**Security/dependency hygiene.** Pure CSS diff. No new dependencies.

## Test plan

- [x] Vibe Coding panel opened at 1200×900 — text sizes consistent with pre-change narrow-viewport rendering, content fits with headroom.
- [x] Vibe Coding panel opened at 1900×1200 — text no longer grows relative to the grid; panel + stack ribbon fit comfortably.
- [x] Default/closed Mondrian unchanged at both widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)