### PR TITLE
fix(home): pin text sizes across all Mondrian panels

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -160,7 +160,7 @@ html, body {
   align-items: flex-start;
   justify-content: flex-start;
   padding: min(8%, 2rem);
-  font-size: clamp(0.8rem, 1.1vw, 1.08rem);
+  font-size: 0.95rem;
   font-weight: 600;
   letter-spacing: 0.22em;
   text-transform: uppercase;
@@ -170,7 +170,7 @@ html, body {
 }
 
 .panel-label--name {
-  font-size: clamp(1.25rem, 2.7vw, 2.8rem);
+  font-size: 2.2rem;
   letter-spacing: 0.02em;
   text-transform: none;
   font-weight: 600;
@@ -209,26 +209,26 @@ html, body {
 }
 
 .content-inner {
-  padding: clamp(1rem, 2.1vw, 2rem);
+  padding: 1.5rem;
   height: 100%;
   overflow: auto;
 }
 
 .content-inner h1 {
   font-family: "Cormorant Garamond", Garamond, serif;
-  font-size: clamp(2rem, 4.6vw, 4.8rem);
+  font-size: 3.5rem;
   line-height: 0.95;
   margin-bottom: var(--su);
 }
 
 .panel--red .content-inner h1 {
   white-space: nowrap;
-  font-size: clamp(2.1rem, 5.6vw, 5.2rem);
+  font-size: 4rem;
 }
 
 .content-inner h2 {
   font-family: "Cormorant Garamond", Garamond, serif;
-  font-size: clamp(1.4rem, 2.2vw, 2.5rem);
+  font-size: 1.85rem;
   line-height: 1.05;
   margin-bottom: 0.45rem;
 }
@@ -236,7 +236,7 @@ html, body {
 .content-inner p,
 .content-inner li,
 .content-inner a {
-  font-size: clamp(0.86rem, 0.98vw, 1.02rem);
+  font-size: 0.94rem;
   line-height: 1.58;
 }
 
@@ -244,7 +244,7 @@ html, body {
 
 .lead {
   font-family: "Cormorant Garamond", Garamond, serif;
-  font-size: clamp(1.2rem, 1.02rem + 0.92vw, 1.62rem);
+  font-size: 1.4rem;
   line-height: 1.42;
   font-weight: 500;
   font-optical-sizing: auto;
@@ -273,7 +273,7 @@ html, body {
 
 .about-label {
   display: block;
-  font-size: clamp(0.52rem, 0.6vw, 0.58rem);
+  font-size: 0.56rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
   font-weight: 500;
@@ -292,7 +292,7 @@ html, body {
 }
 
 .about-meta-items {
-  font-size: clamp(0.64rem, 0.74vw, 0.72rem);
+  font-size: 0.68rem;
   line-height: 1.45;
   letter-spacing: 0.10em;
   word-spacing: 0.05em;
@@ -316,7 +316,7 @@ html, body {
   display: block;
   margin-top: var(--su);
   margin-bottom: var(--su);
-  font-size: clamp(0.52rem, 0.6vw, 0.58rem);
+  font-size: 0.56rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
   font-weight: 500;
@@ -325,7 +325,7 @@ html, body {
 
 .availability-signal {
   margin: 0 0 var(--su);
-  font-size: clamp(0.78rem, 0.95vw, 0.88rem);
+  font-size: 0.84rem;
   line-height: 1.45;
   color: rgba(25, 22, 17, 0.82);
 }
@@ -333,7 +333,7 @@ html, body {
 .availability-noscript {
   display: block;
   margin: 0 0 var(--su);
-  font-size: clamp(0.7rem, 0.85vw, 0.8rem);
+  font-size: 0.76rem;
   color: rgba(25, 22, 17, 0.62);
 }
 
@@ -350,7 +350,7 @@ html, body {
   padding: 0.22rem 0.42rem;
   color: inherit;
   text-decoration: none;
-  font-size: clamp(0.92rem, 1.02vw, 1.04rem);
+  font-size: 0.98rem;
   font-weight: 600;
   position: relative;
   transition: border-color var(--motion-hover) var(--ease-standard);
@@ -483,7 +483,7 @@ html, body {
 
 .p-name {
   font-family: "Cormorant Garamond", Garamond, serif;
-  font-size: clamp(1.02rem, 1.25vw, 1.28rem);
+  font-size: 1.15rem;
   font-weight: 700;
 }
 
@@ -491,7 +491,7 @@ html, body {
   color: inherit;
   text-decoration: none;
   font-family: "Cormorant Garamond", Garamond, serif;
-  font-size: clamp(1.02rem, 1.25vw, 1.28rem);
+  font-size: 1.15rem;
   font-weight: 700;
   line-height: 1.1;
 }
@@ -501,7 +501,7 @@ html, body {
 }
 
 .p-tag {
-  font-size: clamp(0.6rem, 0.75vw, 0.68rem);
+  font-size: 0.64rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   font-weight: 700;
@@ -584,7 +584,7 @@ html, body {
 
 .stack-label,
 .impact-label {
-  font-size: clamp(0.52rem, 0.6vw, 0.58rem);
+  font-size: 0.56rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
   font-weight: 500;
@@ -594,7 +594,7 @@ html, body {
 .stack-items,
 .impact-items,
 .blog-callout-link {
-  font-size: clamp(0.64rem, 0.74vw, 0.72rem);
+  font-size: 0.68rem;
   line-height: 1.45;
   letter-spacing: 0.10em;
   word-spacing: 0.05em;
@@ -611,7 +611,7 @@ html, body {
 }
 
 .blog-callout-label {
-  font-size: clamp(0.52rem, 0.6vw, 0.58rem);
+  font-size: 0.56rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
   font-weight: 500;
@@ -619,7 +619,7 @@ html, body {
 }
 
 .content-inner .blog-callout-link {
-  font-size: clamp(0.64rem, 0.74vw, 0.72rem);
+  font-size: 0.68rem;
   text-decoration: none;
   transition: color var(--motion-hover) var(--ease-standard);
 }
@@ -673,7 +673,7 @@ html, body {
 .effort-link {
   color: inherit;
   font-family: "Cormorant Garamond", Garamond, serif;
-  font-size: clamp(0.95rem, 1.08vw, 1.14rem);
+  font-size: 1.05rem;
   font-weight: 700;
   line-height: 1.16;
   text-decoration: underline;
@@ -687,7 +687,7 @@ html, body {
 
 .effort-amount {
   margin-top: 0.12rem;
-  font-size: clamp(0.78rem, 0.88vw, 0.9rem);
+  font-size: 0.84rem;
   font-weight: 500;
   letter-spacing: 0.01em;
   line-height: 1.2;
@@ -695,25 +695,25 @@ html, body {
 
 .effort-desc {
   margin-top: 0.10rem;
-  font-size: clamp(0.78rem, 0.88vw, 0.9rem);
+  font-size: 0.84rem;
   line-height: 1.38;
   opacity: 0.72;
 }
 
 .panel--black .content-inner {
-  padding-top: clamp(0.75rem, 1.6vw, 1.45rem);
-  padding-bottom: clamp(0.35rem, 1vw, 1rem);
+  padding-top: 1.1rem;
+  padding-bottom: 0.7rem;
 }
 
 .panel--black .content-inner h2 {
   margin-bottom: var(--su);
-  font-size: clamp(1.2rem, 1.9vw, 2.05rem);
+  font-size: 1.6rem;
   line-height: 1.05;
 }
 
 .panel--black .content-inner > p {
   margin-bottom: var(--su);
-  font-size: clamp(0.9rem, 1.02vw, 1.03rem);
+  font-size: 0.95rem;
   line-height: 1.42;
 }
 
@@ -812,12 +812,12 @@ html, body {
 }
 
 .panel--blue .content-inner {
-  padding-top: clamp(0.75rem, 1.6vw, 1.45rem);
-  padding-left: clamp(1.35rem, 2.8vw, 2.7rem);
+  padding-top: 1.1rem;
+  padding-left: 2rem;
 }
 
 .panel--blue .content-inner h2 {
-  font-size: clamp(1.2rem, 1.9vw, 2.05rem);
+  font-size: 1.6rem;
   margin-bottom: var(--su);
   line-height: 1.05;
 }


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Follow-up to #254 — applies the same fixed-size treatment to the red (About), black (Community), and blue (Connect) panels, plus shared `.content-inner` rules and panel labels.

Same rationale: the Mondrian grid is capped at `min(95vw, 95vh)` with `aspect-ratio: 1/1`, so on landscape monitors the grid stops growing past a point, but `clamp(min, Xvw, max)` font sizes keep scaling with viewport width. On wide screens this produced a slight mismatch where text felt bigger than the grid's breathing room wanted. Values chosen mid-clamp to sit close to the pre-change rendering at typical desktop widths.

## Self-Review

**Correctness.** Verified each panel open at 1900×1200 — all four fit content with headroom, text is visually consistent across panels, no clipping.

**Regression risk.** Low.
- Pure CSS value substitution (clamp → fixed rem). No selectors, no layout properties.
- Responsive behavior below 920px is handled by the separate media query, which remaps the Mondrian into a single-column stack. Fixed rem values still look right in that layout because the panel width itself expands to fit the viewport.
- Minimum values of the old clamps were floors, not where typical users saw the UI. Chosen fixed values sit mid-clamp, closer to the value rendered at ~1400–1600px viewports — the most common desktop sweet spot.

**Style.** Matches PR #254's yellow-panel pattern.

**Test coverage.** No unit tests for typography; verified visually at 1900×1200 across all four panels plus the default (closed) grid.

**Security/dependency hygiene.** Pure CSS diff.

## Test plan

- [x] Default (closed) Mondrian grid unchanged at 1900×1200.
- [x] Red panel (About) opens, fits all content + meta ribbon with breathing room.
- [x] Yellow panel (Vibe Coding) still fits after change (re-verified alongside others).
- [x] Black panel (Community) opens, three effort cards + scope ribbon fit.
- [x] Blue panel (Connect) opens, social stack + from-the-blog callout fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)