### PR TITLE
content(home): point Mergepath link to Playground, match "Live ↗" pattern

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -102,7 +102,7 @@ const homepageJsonLd = {
                   <a class="p-name p-name-link" href="/projects/mergepath/" aria-label="Read the Mergepath project page">Mergepath</a>
                   <span class="p-tag">Infrastructure × AI Tooling</span>
                 </div>
-                <p>A deterministic repository standard that keeps humans and AI coding agents aligned—the enforcement layer underneath every other project on this site. <a href="https://github.com/nathanjohnpayne/mergepath" target="_blank" rel="noopener" class="p-link" aria-label="View the Mergepath repository on GitHub">GitHub ↗</a></p>
+                <p>A deterministic repository standard that keeps humans and AI coding agents aligned—the enforcement layer underneath every other project on this site. <a href="https://htmlpreview.github.io/?https://raw.githubusercontent.com/nathanjohnpayne/mergepath/main/mergepath/playground/index.html" target="_blank" rel="noopener" class="p-link" aria-label="View the live Mergepath Playground">Live ↗</a></p>
               </div>
               <div class="project-item">
                 <div class="p-head">


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

The Mergepath project was the only homepage project item still using `GitHub ↗` as its external link. The other four (Override, Device Source of Truth, Swipe Watch, Friends & Family Billing) all link to a live/demo URL with `Live ↗` text.

Swap the Mergepath link target from the GitHub repo to the Mergepath Playground (`https://htmlpreview.github.io/?https://raw.githubusercontent.com/nathanjohnpayne/mergepath/main/mergepath/playground/index.html`, which already lives in `mergepath.md` as `liveUrl`), update the link text to `Live ↗`, and update the aria-label to match the `View the live [X]` convention used by the other project items.

The GitHub repo is still reachable from the `/projects/mergepath/` detail page via the project frontmatter's `githubUrl` — this PR just removes the homepage's direct GitHub link in favor of the Playground.

## Self-Review

- **Correctness** — Verified in dev server: the Mergepath card now renders `Live ↗` matching Override / DST / Swipe Watch / FFB exactly. The `href` resolves to the Playground URL that already powers the project detail page's `liveUrl`. Post-JS DOM check across all five project items confirms identical link-text pattern.
- **Regression risk** — Low. One `<a>` element changed on one page. No test asserted the previous GitHub URL or link text for this project, so no test updates needed.
- **Style** — `Live ↗` text, `View the live [X]` aria-label convention, `target="_blank" rel="noopener"` — all match the existing four project items.
- **Test coverage** — \`npm test\` → 135/135 green on this branch.
- **Security / dependency hygiene** — No new deps, no new client-side code. External link retains `rel="noopener"`.

## Test plan

- [ ] Load homepage in preview; confirm Mergepath card reads \`Live ↗\`.
- [ ] Click through → Mergepath Playground loads (external htmlpreview.github.io).
- [ ] Visit \`/projects/mergepath/\` and confirm the GitHub repo is still linked there (via \`githubUrl\` frontmatter).
- [ ] \`npm test\` green.