### PR TITLE
[codex] Fix Mux Data background video tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,1 @@
-# Mux Data environment key. Exposed to client code via Vite's PUBLIC_ prefix.
-# Safe to publish — Mux Data env keys are designed to be client-visible.
-# Find yours at https://dashboard.mux.com/ under Settings -> Data -> Env Keys.
-# Omit or leave blank to disable analytics; the player keeps working.
-PUBLIC_MUX_ENV_KEY=
+# No client-side PUBLIC_* env vars are currently required.

--- a/.env.tpl
+++ b/.env.tpl
@@ -1,7 +1,3 @@
 # Template resolved by scripts/bootstrap.sh via `op inject`.
 # Never edit the generated .env.local directly — change this file and
 # re-run ./scripts/bootstrap.sh --force.
-
-# Mux Data environment key. Client-visible, safe to publish post-build.
-# Dashboard: https://dashboard.mux.com/ (Settings, Data, Environments)
-PUBLIC_MUX_ENV_KEY=op://Private/owk6d74z2ofmrcivmgju25pifm/env-key

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -399,13 +399,10 @@ Any `PUBLIC_*` env var read via `import.meta.env` during the build is baked into
 3. Anyone on the team runs `./scripts/bootstrap.sh --force` to refresh their `.env.local`.
 4. `npm run build` picks up the new value automatically.
 
-**Current `PUBLIC_*` vars:**
-
-| Var | 1Password reference | Purpose |
-|---|---|---|
-| `PUBLIC_MUX_ENV_KEY` | `op://Private/owk6d74z2ofmrcivmgju25pifm/env-key` | Mux Data analytics env key (safe to publish; Mux env keys are client-visible by design). Unset = analytics off, player still works. |
-
-Mux env key is provisioned per Mux workspace, not per deploy target — the same key works for dev and prod. Rotate via the [Mux dashboard](https://dashboard.mux.com/) (Settings → Data → Environments) and update the 1Password item; the next bootstrap + build picks up the new value.
+There are no current `PUBLIC_*` vars. Mux Data for project hero videos does
+not use a build-time env var in this site: pages with a Mux hero load
+`mux-embed`, and `@mux/mux-background-video` infers the Mux Data env key from
+the public `stream.mux.com` URL at runtime.
 
 ## Deployment Steps
 

--- a/specs/project-pages.md
+++ b/specs/project-pages.md
@@ -75,7 +75,7 @@ draft: false
 | `metadata.status` | string | yes | Metadata strip: project status |
 | `stack` | string | no | Tech stack values separated by ` · ` (e.g., `"React · TypeScript · Vite · Firebase · Vitest"`). Rendered as a figcaption below the screenshot. Optional — projects without a stack field render without the caption |
 | `related` | array | no | Related links with `label` and `href` |
-| `muxPlaybackId` | non-empty string | no | Mux public Playback ID. When set, the hero renders a themed `<mux-player>` video and `screenshotSrc` is used as the poster + JS-disabled fallback. Schema rejects blank / whitespace-only values so a stray empty string fails build-time rather than producing a broken URL. See "Adding a Mux video" below |
+| `muxPlaybackId` | non-empty string | no | Mux public Playback ID. When set, the hero renders a `<mux-background-video>` video and `screenshotSrc` is used as the JS-disabled fallback. Schema rejects blank / whitespace-only values so a stray empty string fails build-time rather than producing a broken URL. See "Adding a Mux video" below |
 | `draft` | boolean | no | `true` to exclude from builds (default: `false`) |
 
 ### Body content structure
@@ -148,11 +148,10 @@ Any project can render a vertical Mux video in the hero instead of a static scre
 
 ### What happens automatically
 
-- **Theming**: the player's progress bar, scrubber, and accent ornaments pick up the page's `--project-accent` CSS var. Any `project-page--*` class (red, yellow, blue, etc.) themes the player with no extra config.
-- **Autoplay + loop**: `autoplay="muted" muted loop playsinline` match the feel of the animated GIFs that the static hero slot previously used.
-- **Analytics**: if `PUBLIC_MUX_ENV_KEY` is provisioned (see [DEPLOYMENT.md](../DEPLOYMENT.md#client-side-env-vars)), the player reports views to Mux Data tagged with `video_title` = project title and `video_id` = project slug. Without the env key, the player runs identically but emits no analytics.
-- **Fallback**: the existing `screenshotSrc` image renders as the `<img slot="poster">` inside `<mux-player>`. Browsers with JS disabled render the poster directly (unknown custom elements render their light-DOM children inline).
-- **Bundle cost**: `@mux/mux-player` only downloads on pages that actually contain a `<mux-player>` element — projects without `muxPlaybackId` pay zero cost.
+- **Autoplay + loop**: `<mux-background-video>` creates a muted, looped, plays-inline video to match the feel of the animated GIFs that the static hero slot previously used.
+- **Analytics**: pages with a Mux hero load `mux-embed` before registering `<mux-background-video>`. Mux Data monitoring is automatic for the background video and infers the env key from the `stream.mux.com` URL; no `PUBLIC_MUX_ENV_KEY` is read by this site.
+- **Fallback**: the existing `screenshotSrc` image renders in `<noscript>`, while the Mux thumbnail renders inside `<mux-background-video>` as the pre-upgrade poster.
+- **Bundle cost**: the Mux custom element is registered only when a page contains a `<mux-background-video>` element. Projects without `muxPlaybackId` do not load `mux-embed` or the background-video package at runtime.
 
 ### Aspect ratio
 

--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -56,8 +56,36 @@ const posterSrc = playbackId
 )}
 
 <script>
-  // Register <mux-background-video> only on pages that actually contain one.
-  if (document.querySelector('mux-background-video')) {
-    import('@mux/mux-background-video/html');
+  const muxHero = document.querySelector('mux-background-video');
+
+  function loadMuxEmbed() {
+    if (globalThis.mux) return Promise.resolve();
+
+    const existingScript = document.querySelector('script[data-mux-embed]');
+    if (existingScript) {
+      return new Promise((resolve) => {
+        existingScript.addEventListener('load', resolve, { once: true });
+        existingScript.addEventListener('error', resolve, { once: true });
+      });
+    }
+
+    return new Promise((resolve) => {
+      const script = document.createElement('script');
+      script.defer = true;
+      script.dataset.muxEmbed = 'true';
+      script.src = 'https://cdn.jsdelivr.net/npm/mux-embed';
+      script.addEventListener('load', resolve, { once: true });
+      script.addEventListener('error', resolve, { once: true });
+      document.head.append(script);
+    });
+  }
+
+  // Register and monitor <mux-background-video> only on pages that contain one.
+  // The component's Mux Data hook reads globalThis.mux during registration and
+  // infers the env key from the stream.mux.com URL.
+  if (muxHero) {
+    loadMuxEmbed().finally(() => {
+      import('@mux/mux-background-video/html');
+    });
   }
 </script>

--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -73,7 +73,7 @@ const posterSrc = playbackId
       const script = document.createElement('script');
       script.defer = true;
       script.dataset.muxEmbed = 'true';
-      script.src = 'https://cdn.jsdelivr.net/npm/mux-embed';
+      script.src = 'https://cdn.jsdelivr.net/npm/mux-embed@5.18.0';
       script.addEventListener('load', resolve, { once: true });
       script.addEventListener('error', resolve, { once: true });
       document.head.append(script);

--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -151,7 +151,8 @@ describe('Project Pages — screenshot aspect variants', () => {
   });
 
   it('Swipe Watch renders mux-background-video with the Safari-safe hero config', () => {
-    setupDOM(readDistHtml('projects/swipe-watch/index.html'));
+    const html = readDistHtml('projects/swipe-watch/index.html');
+    setupDOM(html);
 
     const player = document.querySelector('mux-background-video.project-screenshot__mux');
     expect(player, 'Swipe Watch mux-background-video not found').not.toBeNull();
@@ -163,6 +164,24 @@ describe('Project Pages — screenshot aspect variants', () => {
     const poster = player.querySelector('img');
     expect(poster, 'Swipe Watch poster img not found').not.toBeNull();
     expect(poster.getAttribute('src')).toBe('https://image.mux.com/wNCRY97981o2uDAJrJ3ExPeK379yldRRFJgUIgSYz00k/thumbnail.jpg?width=1280&time=0');
+
+    const muxScriptSrc = html.match(/<script type="module" src="([^"]*ProjectMuxPlayer[^"]*)"/)?.[1];
+    expect(muxScriptSrc, 'ProjectMuxPlayer module script not found').toBeTruthy();
+    const muxScript = readFileSync(resolve(DIST, muxScriptSrc.replace(/^\//, '')), 'utf-8');
+    expect(muxScript).toContain('https://cdn.jsdelivr.net/npm/mux-embed');
+    expect(muxScript).toContain('document.querySelector("mux-background-video")');
+    expect(html).not.toContain('PUBLIC_MUX_ENV_KEY');
+  });
+
+  it('only Swipe Watch opts into the Mux hero today', () => {
+    for (const slug of projectSlugs.filter((projectSlug) => projectSlug !== 'swipe-watch')) {
+      setupDOM(readDistHtml(`projects/${slug}/index.html`));
+      expect(
+        document.querySelector('mux-background-video'),
+        `${slug} should not render a Mux background video`,
+      ).toBeNull();
+      expect(document.querySelector('mux-player'), `${slug} should not render mux-player`).toBeNull();
+    }
   });
 
   it('Override, DST, and FFB use the wide screenshot variant', () => {

--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -165,11 +165,16 @@ describe('Project Pages — screenshot aspect variants', () => {
     expect(poster, 'Swipe Watch poster img not found').not.toBeNull();
     expect(poster.getAttribute('src')).toBe('https://image.mux.com/wNCRY97981o2uDAJrJ3ExPeK379yldRRFJgUIgSYz00k/thumbnail.jpg?width=1280&time=0');
 
-    const muxScriptSrc = html.match(/<script type="module" src="([^"]*ProjectMuxPlayer[^"]*)"/)?.[1];
-    expect(muxScriptSrc, 'ProjectMuxPlayer module script not found').toBeTruthy();
-    const muxScript = readFileSync(resolve(DIST, muxScriptSrc.replace(/^\//, '')), 'utf-8');
-    expect(muxScript).toContain('https://cdn.jsdelivr.net/npm/mux-embed');
-    expect(muxScript).toContain('document.querySelector("mux-background-video")');
+    const moduleSrcs = Array.from(
+      html.matchAll(/<script type="module" src="([^"]+)"/g),
+      (match) => match[1],
+    );
+    expect(moduleSrcs.length, 'No module scripts found').toBeGreaterThan(0);
+    const muxScript = moduleSrcs
+      .map((src) => readFileSync(resolve(DIST, src.replace(/^\//, '')), 'utf-8'))
+      .find((code) => code.includes('https://cdn.jsdelivr.net/npm/mux-embed@5.18.0'));
+    expect(muxScript, 'Mux runtime module not found').toBeTruthy();
+    expect(muxScript).toMatch(/querySelector\((['"])mux-background-video\1\)/);
     expect(html).not.toContain('PUBLIC_MUX_ENV_KEY');
   });
 


### PR DESCRIPTION
Authoring-Agent: codex

## Summary

- Load `mux-embed` before registering `<mux-background-video>` so Mux Data monitoring actually initializes on Mux-backed project pages.
- Keep Mux runtime loading scoped to pages that render a Mux hero; non-Mux project pages do not load `mux-embed` or the Mux custom element.
- Remove stale `PUBLIC_MUX_ENV_KEY` env/config documentation and update project-page docs to match the current background-video integration.

## Root Cause

The recent integration documented a `PUBLIC_MUX_ENV_KEY` flow, but `@mux/mux-background-video` does not consume that attr/env path. Its monitoring hook checks `globalThis.mux` during load and infers the env key from the `stream.mux.com` URL, but the site never loaded `mux-embed`, so tracking could not initialize.

## Validation

- `npm run test`
- `npm run test:e2e`
- Browser preview check: `/projects/swipe-watch/` has `mux-background-video` plus `script[data-mux-embed]`; `/projects/mergepath/` has neither.
