### PR TITLE
[codex] Handle settled Mux embed loader state

### DIFF
--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -63,6 +63,13 @@ const posterSrc = playbackId
 
     const existingScript = document.querySelector('script[data-mux-embed]');
     if (existingScript) {
+      if (
+        existingScript.dataset.muxEmbedStatus === 'loaded' ||
+        existingScript.dataset.muxEmbedStatus === 'error'
+      ) {
+        return Promise.resolve();
+      }
+
       return new Promise((resolve) => {
         existingScript.addEventListener('load', resolve, { once: true });
         existingScript.addEventListener('error', resolve, { once: true });
@@ -73,9 +80,16 @@ const posterSrc = playbackId
       const script = document.createElement('script');
       script.defer = true;
       script.dataset.muxEmbed = 'true';
+      script.dataset.muxEmbedStatus = 'loading';
       script.src = 'https://cdn.jsdelivr.net/npm/mux-embed@5.18.0';
-      script.addEventListener('load', resolve, { once: true });
-      script.addEventListener('error', resolve, { once: true });
+      script.addEventListener('load', () => {
+        script.dataset.muxEmbedStatus = 'loaded';
+        resolve();
+      }, { once: true });
+      script.addEventListener('error', () => {
+        script.dataset.muxEmbedStatus = 'error';
+        resolve();
+      }, { once: true });
       document.head.append(script);
     });
   }


### PR DESCRIPTION
Authoring-Agent: codex

## Summary

- Track the injected `mux-embed` script's load/error state with `data-mux-embed-status`.
- Let later Mux hero initializers proceed if an existing script has already settled, avoiding a stuck Promise before `<mux-background-video>` registration.

## Root Cause

CodeRabbit caught a valid edge case after PR #264 merged: if more than one Mux hero component initializes and one finds an existing `script[data-mux-embed]` after its load/error event has already fired, the listener-only path can wait forever.

## Validation

- `npm run test`
- `npm run test:e2e`
