### PR TITLE
polish: harmonize tag rendering across index + detail pages (#266 #267 #268 #269 #270)

### DIFF
--- a/specs/project-pages.md
+++ b/specs/project-pages.md
@@ -37,7 +37,6 @@ liveUrl: "https://example.com"
 githubUrl: "https://github.com/you/repo"
 tags: ["Tag1", "Tag2", "Tag3"]
 metadata:
-  domain: "Domain × Subdomain"
   format: "Product-type label (e.g., Financial operating system)"
   focus: "What it does in a few words"
   status: "Live product"
@@ -58,7 +57,7 @@ draft: false
 | `title` | string | yes | Page title, hero heading, JSON-LD name |
 | `slug` | string | yes | URL path segment; must match filename |
 | `description` | string | yes | Hero deck text, meta description, JSON-LD |
-| `kicker` | string | yes | Tag line above title (e.g., "AI × Finance × Theater") |
+| `kicker` | string | yes | Source for the metadata table's `Topics` column (e.g., "AI × Finance × Theater" → renders as `AI · Finance · Theater`). Field name kept for frontmatter back-compat |
 | `order` | number | yes | Position on the `/projects/` index grid (lower = first) |
 | `screenshotAspect` | `"wide"` \| `"narrow"` | yes | Layout variant — see below |
 | `screenshotSrc` | string | yes | Path to hero image in `public/` |
@@ -69,7 +68,6 @@ draft: false
 | `liveUrl` | string | yes | URL for "View Live Product" CTA |
 | `githubUrl` | string | yes | URL for "View on GitHub" CTA |
 | `tags` | string[] | yes | Category/technology tags |
-| `metadata.domain` | string | yes | Metadata strip: domain value |
 | `metadata.format` | string | yes | Metadata strip: product-type label (e.g., "Internal platform tool"). The tech stack lives in the separate `stack` field — this field is for product category |
 | `metadata.focus` | string | yes | Metadata strip: focus area value |
 | `metadata.status` | string | yes | Metadata strip: project status |
@@ -233,9 +231,9 @@ The layout sets three custom properties from frontmatter:
 
 - **`src/pages/projects/[slug].astro`**: Dynamic route. Calls `getStaticPaths()` from the projects collection, generates JSON-LD, passes all frontmatter to `ProjectLayout`. Forwards the optional `stack` field through `stack={data.stack}`.
 - **`src/layouts/ProjectLayout.astro`**: Sets CSS custom properties on the shell. Conditionally renders `HeroWide` or `HeroNarrow` based on `screenshotAspect`. Owns the `.metadata-surface` container that wraps `MetadataStrip` and the `<figure class="project-screenshot">`. The figure is rendered here (not in `MetadataStrip`) and contains the `<img>` plus a conditional `<figcaption class="project-stack">` when `stack` is present. The figcaption is a direct child of `<figure>` per HTML5 semantic rules.
-- **`src/components/HeroWide.astro`**: Hero header for wide-layout projects. No screenshot — the screenshot is rendered by `ProjectLayout` below the hero.
-- **`src/components/HeroNarrow.astro`**: Hero header for narrow-layout projects. No screenshot — same as `HeroWide`, the screenshot is rendered by `ProjectLayout` below the hero.
-- **`src/components/MetadataStrip.astro`**: Strip-only — four `<dt>`/`<dd>` pairs for domain, format, focus, and status. Does not own the screenshot; does not accept `screenshotSrc`/`screenshotAlt`/`screenshotAspect` props. The strip is always rendered as a single 4-column horizontal row on desktop and collapses responsively (2-column at ≤768px, 1-column at ≤480px) via `.metadata-strip--grid-4` media queries.
+- **`src/components/HeroWide.astro`**: Hero header for wide-layout projects. No screenshot — the screenshot is rendered by `ProjectLayout` below the hero. The hero no longer renders the `kicker` tag row; that content moved into the `Topics` column of the metadata strip below.
+- **`src/components/HeroNarrow.astro`**: Hero header for narrow-layout projects. No screenshot — same as `HeroWide`, the screenshot is rendered by `ProjectLayout` below the hero. Also no longer renders the `kicker` tag row.
+- **`src/components/MetadataStrip.astro`**: Strip-only — four `<dt>`/`<dd>` pairs for topics, format, focus, and status (in that visual order). Does not own the screenshot; does not accept `screenshotSrc`/`screenshotAlt`/`screenshotAspect` props. The `topics` value is derived in `ProjectLayout` from the project's `kicker` frontmatter (split on `×` and re-joined with ` · ` to match the metadata table's separator convention). The strip is always rendered as a single 4-column horizontal row on desktop and collapses responsively (2×2 at ≤768px, 1-column at ≤480px) via `.metadata-strip--grid-4` media queries.
 
 ### Content collection schema
 
@@ -257,7 +255,6 @@ const { Content } = await render(project);
 | Element | Size | Style | Color |
 |---------|------|-------|-------|
 | Breadcrumb | 12–13px | Uppercase, tracked | Tertiary (0.38 opacity) |
-| Kicker (AI × Domain) | 12–13px | Uppercase, tracked | Tertiary (0.38 opacity) |
 | Project title | Large serif (clamp 2.4–5.1rem) | Roman | Primary |
 | Description | 16–17px serif | Roman | Primary |
 | CTA buttons | ~14px | Uppercase, 0.14em tracking | Primary, accent fill on hover |
@@ -290,7 +287,7 @@ src/pages/projects/index.astro     Project index grid
 src/layouts/ProjectLayout.astro    Layout wrapper (CSS props, hero, metadata, footer)
 src/components/HeroWide.astro      Wide hero header (no screenshot)
 src/components/HeroNarrow.astro    Narrow hero header (no screenshot)
-src/components/MetadataStrip.astro 4-column metadata strip (domain/format/focus/status)
+src/components/MetadataStrip.astro 4-column metadata strip (topics/format/focus/status)
 src/styles/global.css              All project page styles (.metadata-strip, .project-screenshot, .project-stack)
 public/images/projects/            Hero screenshots
 ```

--- a/src/components/HeroNarrow.astro
+++ b/src/components/HeroNarrow.astro
@@ -1,14 +1,13 @@
 ---
 interface Props {
   title: string;
-  kicker: string;
   deck: string;
   breadcrumbLabel: string;
   liveUrl: string;
   githubUrl: string;
 }
 
-const { title, kicker, deck, breadcrumbLabel, liveUrl, githubUrl } = Astro.props;
+const { title, deck, breadcrumbLabel, liveUrl, githubUrl } = Astro.props;
 ---
 
 <header class="project-hero project-hero--narrow">
@@ -21,7 +20,6 @@ const { title, kicker, deck, breadcrumbLabel, liveUrl, githubUrl } = Astro.props
         <span class="breadcrumb-sep">/</span>
         <span class="breadcrumb-current" aria-current="page">{breadcrumbLabel}</span>
       </nav>
-      <p class="project-kicker">{kicker}</p>
       <h1 class="project-title">{title}</h1>
       <p class="project-deck">{deck}</p>
       <div class="project-actions">

--- a/src/components/HeroWide.astro
+++ b/src/components/HeroWide.astro
@@ -1,14 +1,13 @@
 ---
 interface Props {
   title: string;
-  kicker: string;
   deck: string;
   breadcrumbLabel: string;
   liveUrl: string;
   githubUrl: string;
 }
 
-const { title, kicker, deck, breadcrumbLabel, liveUrl, githubUrl } = Astro.props;
+const { title, deck, breadcrumbLabel, liveUrl, githubUrl } = Astro.props;
 ---
 
 <header class="project-hero project-hero--wide">
@@ -21,7 +20,6 @@ const { title, kicker, deck, breadcrumbLabel, liveUrl, githubUrl } = Astro.props
         <span class="breadcrumb-sep">/</span>
         <span class="breadcrumb-current" aria-current="page">{breadcrumbLabel}</span>
       </nav>
-      <p class="project-kicker">{kicker}</p>
       <h1 class="project-title">{title}</h1>
       <p class="project-deck">{deck}</p>
       <div class="project-actions">

--- a/src/components/MetadataStrip.astro
+++ b/src/components/MetadataStrip.astro
@@ -1,18 +1,18 @@
 ---
 interface Props {
-  domain: string;
+  topics: string;
   format: string;
   focus: string;
   status: string;
 }
 
-const { domain, format, focus, status } = Astro.props;
+const { topics, format, focus, status } = Astro.props;
 ---
 
 <dl class="metadata-strip metadata-strip--grid-4">
   <div class="metadata-strip__item">
-    <dt>Domain</dt>
-    <dd>{domain}</dd>
+    <dt>Topics</dt>
+    <dd>{topics}</dd>
   </div>
   <div class="metadata-strip__item">
     <dt>Format</dt>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -19,7 +19,6 @@ const projects = defineCollection({
     githubUrl: z.string(),
     tags: z.array(z.string()),
     metadata: z.object({
-      domain: z.string(),
       format: z.string(),
       focus: z.string(),
       status: z.string(),

--- a/src/content/projects/device-source-of-truth.md
+++ b/src/content/projects/device-source-of-truth.md
@@ -14,7 +14,6 @@ liveUrl: "https://device-source-of-truth.web.app"
 githubUrl: "https://github.com/nathanjohnpayne/device-source-of-truth"
 tags: ["Enterprise", "Data", "React", "Firebase"]
 metadata:
-  domain: "Enterprise × Data"
   format: "Internal platform tool"
   focus: "Partner platforms and device support"
   status: "Live product"

--- a/src/content/projects/friends-and-family-billing.md
+++ b/src/content/projects/friends-and-family-billing.md
@@ -14,7 +14,6 @@ liveUrl: "https://friends-and-family-billing.web.app"
 githubUrl: "https://github.com/nathanjohnpayne/friends-and-family-billing"
 tags: ["Utility", "Finance", "React", "Firebase"]
 metadata:
-  domain: "Utility × Finance"
   format: "Household coordination tool"
   focus: "Shared subscriptions and recurring group expenses"
   status: "Live product"

--- a/src/content/projects/mergepath.md
+++ b/src/content/projects/mergepath.md
@@ -14,7 +14,6 @@ liveUrl: "https://htmlpreview.github.io/?https://raw.githubusercontent.com/natha
 githubUrl: "https://github.com/nathanjohnpayne/mergepath"
 tags: ["Infrastructure", "AI Tooling", "GitHub Actions", "Bash/Python"]
 metadata:
-  domain: "Infrastructure × AI Tooling"
   format: "Repository standard"
   focus: "Agent governance, code review, and CI enforcement"
   status: "Live template"

--- a/src/content/projects/override.md
+++ b/src/content/projects/override.md
@@ -14,7 +14,6 @@ liveUrl: "https://overridebroadway.com"
 githubUrl: "https://github.com/nathanjohnpayne/overridebroadway"
 tags: ["Finance", "Theater", "React", "Firebase"]
 metadata:
-  domain: "Finance × Theater"
   format: "Financial operating system"
   focus: "Capitalization, ownership, and investor workflows"
   status: "Live product"

--- a/src/content/projects/swipe-watch.md
+++ b/src/content/projects/swipe-watch.md
@@ -15,7 +15,6 @@ liveUrl: "https://swipewatch.web.app"
 githubUrl: "https://github.com/nathanjohnpayne/swipewatch"
 tags: ["Consumer", "Streaming", "Vanilla JS"]
 metadata:
-  domain: "Consumer × Streaming"
   format: "Interaction prototype"
   focus: "Discovery, recommendations, and interaction design"
   status: "Live experiment"

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -71,9 +71,13 @@ const {
 } = Astro.props;
 
 // Derive the metadata-table "Topics" value from the same `kicker`
-// frontmatter the hero used to render. Re-join with " · " to match the
-// project-card metadata convention used elsewhere in the metadata table.
-const topics = kicker.split(/\s*[×x]\s*/).join(' · ');
+// frontmatter the hero used to render. Split on the multiplication
+// sign (U+00D7) — the kicker's documented separator — and re-join
+// with " · " to match the project-card metadata convention used
+// elsewhere in the metadata table. Intentionally NOT splitting on
+// lowercase `x`: that would silently slice mid-word on a future
+// kicker like "AI × Mux × Streaming".
+const topics = kicker.split(/\s*×\s*/).join(' · ');
 ---
 
 <BaseLayout

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -29,7 +29,6 @@ interface Props {
   liveUrl: string;
   githubUrl: string;
   metadata: {
-    domain: string;
     format: string;
     focus: string;
     status: string;
@@ -70,6 +69,11 @@ const {
   ogImageHeight,
   ogImageAlt,
 } = Astro.props;
+
+// Derive the metadata-table "Topics" value from the same `kicker`
+// frontmatter the hero used to render. Re-join with " · " to match the
+// project-card metadata convention used elsewhere in the metadata table.
+const topics = kicker.split(/\s*[×x]\s*/).join(' · ');
 ---
 
 <BaseLayout
@@ -92,7 +96,6 @@ const {
       {screenshotAspect === 'narrow' ? (
         <HeroNarrow
           title={headline}
-          kicker={kicker}
           deck={deck}
           breadcrumbLabel={breadcrumbLabel}
           liveUrl={liveUrl}
@@ -101,7 +104,6 @@ const {
       ) : (
         <HeroWide
           title={headline}
-          kicker={kicker}
           deck={deck}
           breadcrumbLabel={breadcrumbLabel}
           liveUrl={liveUrl}
@@ -111,7 +113,7 @@ const {
 
       <div class="metadata-surface">
         <MetadataStrip
-          domain={metadata.domain}
+          topics={topics}
           format={metadata.format}
           focus={metadata.focus}
           status={metadata.status}

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -65,7 +65,6 @@ function readingTime(body: string | undefined): string {
           <span class="breadcrumb-sep">/</span>
           <span>Blog</span>
         </nav>
-        <p class="kicker">AI &times; Product &times; Reality</p>
         <h1>The AI-Augmented PM</h1>
         <p class="deck">Writing about what happens when product managers actually use AI to ship&mdash;the leverage, the loops, and the limits.</p>
       </header>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -77,13 +77,9 @@ function readingTime(body: string | undefined): string {
           <div class="grid-row--1">
             <article class="post-card">
               <p class="post-meta">{formatDate(posts[0].data.date)} &middot; {readingTime(posts[0].body)}</p>
+              <p class="post-meta">{posts[0].data.tags.join(' · ')}</p>
               <h2 class="post-title"><a href={`/blog/${posts[0].id}/`}>{posts[0].data.title}</a></h2>
               <p class="post-desc">{posts[0].data.description}</p>
-              <div class="tag-row">
-                {posts[0].data.tags.map((tag) => (
-                  <span class="tag">{tag}</span>
-                ))}
-              </div>
             </article>
             <div class="accent-red" aria-hidden="true"></div>
             <div class="accent-blue" aria-hidden="true">
@@ -97,13 +93,9 @@ function readingTime(body: string | undefined): string {
           {posts[1] ? (
             <article class="post-card">
               <p class="post-meta">{formatDate(posts[1].data.date)} &middot; {readingTime(posts[1].body)}</p>
+              <p class="post-meta">{posts[1].data.tags.join(' · ')}</p>
               <h2 class="post-title"><a href={`/blog/${posts[1].id}/`}>{posts[1].data.title}</a></h2>
               <p class="post-desc">{posts[1].data.description}</p>
-              <div class="tag-row">
-                {posts[1].data.tags.map((tag) => (
-                  <span class="tag">{tag}</span>
-                ))}
-              </div>
             </article>
           ) : (
             <div class="post-card--placeholder">
@@ -118,13 +110,9 @@ function readingTime(body: string | undefined): string {
           {posts[2] ? (
             <article class="post-card">
               <p class="post-meta">{formatDate(posts[2].data.date)} &middot; {readingTime(posts[2].body)}</p>
+              <p class="post-meta">{posts[2].data.tags.join(' · ')}</p>
               <h2 class="post-title"><a href={`/blog/${posts[2].id}/`}>{posts[2].data.title}</a></h2>
               <p class="post-desc">{posts[2].data.description}</p>
-              <div class="tag-row">
-                {posts[2].data.tags.map((tag) => (
-                  <span class="tag">{tag}</span>
-                ))}
-              </div>
             </article>
           ) : (
             <div class="post-card--placeholder">
@@ -141,13 +129,9 @@ function readingTime(body: string | undefined): string {
           <div class="grid-row--4">
             <article class="post-card">
               <p class="post-meta">{formatDate(posts[3].data.date)} &middot; {readingTime(posts[3].body)}</p>
+              <p class="post-meta">{posts[3].data.tags.join(' · ')}</p>
               <h2 class="post-title"><a href={`/blog/${posts[3].id}/`}>{posts[3].data.title}</a></h2>
               <p class="post-desc">{posts[3].data.description}</p>
-              <div class="tag-row">
-                {posts[3].data.tags.map((tag) => (
-                  <span class="tag">{tag}</span>
-                ))}
-              </div>
             </article>
             <div class="accent-black" aria-hidden="true"></div>
             <div class="accent-paper" aria-hidden="true"></div>
@@ -159,13 +143,9 @@ function readingTime(body: string | undefined): string {
           <div class={i % 2 === 0 ? 'grid-row--overflow-a' : 'grid-row--overflow-b'}>
             <article class="post-card">
               <p class="post-meta">{formatDate(post.data.date)} &middot; {readingTime(post.body)}</p>
+              <p class="post-meta">{post.data.tags.join(' · ')}</p>
               <h2 class="post-title"><a href={`/blog/${post.id}/`}>{post.data.title}</a></h2>
               <p class="post-desc">{post.data.description}</p>
-              <div class="tag-row">
-                {post.data.tags.map((tag) => (
-                  <span class="tag">{tag}</span>
-                ))}
-              </div>
             </article>
             <div class={i % 2 === 0 ? 'accent-overflow accent-overflow--cream' : 'accent-overflow accent-overflow--yellow'} aria-hidden="true"></div>
           </div>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -46,7 +46,6 @@ const jsonLd = {
           <span class="breadcrumb-sep">/</span>
           <span>Projects</span>
         </nav>
-        <p class="kicker">AI &times; Product &times; Engineering</p>
         <h1>Projects</h1>
         <p class="deck">Every project started as a real problem. Each one became a systems design exercise&mdash;built with AI agents from first commit to deploy, on top of an enforcement system I designed to make agent output reliable. The infrastructure behind these projects is documented in <a href="/blog/agent-approval-workflow-genesis-of-mergepath/" class="p-link">Agent Approval Workflow and the Genesis of Mergepath</a>.</p>
       </header>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1515,6 +1515,14 @@ body.blog-page {
   margin-bottom: 0.5rem;
 }
 
+/* When two .post-meta lines stack (date kicker + tag kicker on blog
+   cards), tighten the gap between them so they read as a single
+   metadata zone above the headline rather than two equal-weight
+   sibling lines. */
+.post-meta:has(+ .post-meta) {
+  margin-bottom: 0.15rem;
+}
+
 .post-title {
   font-family: "Cormorant Garamond", Garamond, serif;
   font-size: clamp(1.6rem, 2.2vw, 2.4rem);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -934,15 +934,6 @@ body.blog-page {
   user-select: none;
 }
 
-.project-kicker {
-  margin-bottom: calc(var(--su) * 0.9);
-  padding-left: clamp(1rem, 2.2vw, 1.6rem);
-  font-size: clamp(0.7rem, 0.88vw, 0.82rem);
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(17, 16, 13, 0.38);
-}
-
 .project-hero h1 {
   padding-left: clamp(1rem, 2.2vw, 1.6rem);
   font-family: "Cormorant Garamond", Garamond, serif;
@@ -1047,7 +1038,7 @@ body.blog-page {
 }
 
 /* Metadata strip — always a 4-column horizontal row on desktop, regardless
-   of screenshot aspect. Collapses to 2-col on tablet, 1-col on phone. */
+   of screenshot aspect. Collapses to 2×2 on tablet, 1-col on phone. */
 .metadata-strip {
   display: grid;
   gap: 0;
@@ -1429,15 +1420,6 @@ body.blog-page {
 
 .breadcrumbs .breadcrumb-sep {
   user-select: none;
-}
-
-.kicker {
-  margin-bottom: 0.4rem;
-  font-size: clamp(0.7rem, 0.88vw, 0.82rem);
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: #223f89;
-  font-weight: 600;
 }
 
 .hero h1 {
@@ -2672,10 +2654,6 @@ a:focus-visible {
   .project-breadcrumbs {
     padding-left: 0.5rem;
     font-size: 0.68rem;
-  }
-
-  .project-kicker {
-    padding-left: 0.5rem;
   }
 
   .project-hero h1 {

--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -86,11 +86,11 @@ describe('Project Pages — render', () => {
         expect(items.length).toBe(4);
       });
 
-      it('renders all four metadata labels (Domain, Format, Focus, Status)', () => {
+      it('renders all four metadata labels (Topics, Format, Focus, Status)', () => {
         const labels = Array.from(document.querySelectorAll('.metadata-strip dt')).map(
           (dt) => dt.textContent.trim(),
         );
-        expect(labels).toEqual(['Domain', 'Format', 'Focus', 'Status']);
+        expect(labels).toEqual(['Topics', 'Format', 'Focus', 'Status']);
       });
 
       it('has a <figure class="project-screenshot"> containing an <img> with src and alt', () => {


### PR DESCRIPTION
## Summary

Five `polish`-labeled issues filed in the last hour all touched the same surface area: the redundant tag rows that bracketed the blog index, projects index, and project detail pages. Resolved in one PR since the markup overlaps and shipping them separately would have churned the same templates three times.

- **#266 — Blog index hero kicker removed.** "AI × Product × Reality" tag row removed from `/blog/`. Headline + deck already establish what the blog is about.
- **#267 — Projects index hero kicker removed.** "AI × Product × Engineering" tag row removed from `/projects/`. Headline + deck do the work.
- **#268 — Detail page kicker → metadata table Topics column.** The per-project kicker (which collided visually with the breadcrumb above) moves out of the hero and into the metadata table as a new "Topics" column, derived from the existing `kicker` frontmatter and re-joined with ` · ` to match the metadata table's separator convention. While in here, also removed the redundant Domain column (Topics fully covered it across all five projects, e.g. Domain "Consumer × Streaming" vs. Topics "AI · Consumer · Streaming"). Topics now leads the strip; the strip stays at four columns. `metadata.domain` is dropped from the schema and from each project's frontmatter rather than left as orphan data.
- **#269 — Index card chips → inline meta line.** Blog index post cards rendered tags as bordered gray chips while project cards rendered the same kind of information as an inline "·"-separated meta line. Standardized on the inline pattern. The `.tag-row` / `a.tag` CSS stays — the projects index still uses those for the "Live ↗" anchor.
- **#270 — Blog tags move from bottom to top kicker position.** Tags now render between the date/reading-time line and the headline, matching the projects index card anatomy. Added `.post-meta:has(+ .post-meta) { margin-bottom: 0.15rem }` so the two stacked meta lines hug as one zone (≈2.4px) and the gap to the headline (≈8px) reads as the real visual break.

After this PR, all topic/tag rendering uses one consistent pattern: small-caps letterspaced text with `·` separators, whether on index cards or in the detail page metadata table.

Authoring-Agent: claude

## Self-Review

- **Correctness:** build passes, all 136 vitest tests pass, manual preview verification confirmed the Topics column renders the expected `AI · Consumer · Streaming` string on Swipe Watch and matches across all five project pages. Blog cards verified at desktop, tablet (2×2 metadata strip), and mobile (single column); project cards verified unchanged in their card structure.
- **Regression risk:** low. Hero markup only loses the kicker `<p>`; CTAs, breadcrumb, headline, and deck untouched. The metadata strip retains its 4-column shape and responsive rules; the only schema change (removing `metadata.domain`) is enforced by Zod, so any lingering reference would fail the build at startup, and `grep` confirmed none remain. The blog index card markup change is purely structural — same data, different element + position. `:has()` is already in use in the stylesheet (`.grid-row--2:has(> .post-card--placeholder)`), so the new grouping rule introduces no new browser-support assumption.
- **Style:** follows existing component conventions (single-purpose Astro components, props passed through `ProjectLayout`, named CSS modifier). Removed dead `.kicker` and `.project-kicker` CSS rules and unused frontmatter to avoid orphan data per repo guidance.
- **Test coverage:** `tests/project-pages.test.js` updated to assert both the item count (4) and the exact label order (`Topics, Format, Focus, Status`) on every project page, so any future regression in either the Topics derivation or the column order will fail loudly.
- **Security / dependency hygiene:** no new dependencies, no runtime code paths added, no user input. Pure markup + content change.

## Test plan

- [x] `npm run build` passes
- [x] `npm test -- --run` passes (136/136)
- [x] `/blog/` hero verified — no kicker tag row, breadcrumb → headline → deck flows cleanly
- [x] `/projects/` hero verified — no kicker tag row
- [x] `/projects/swipe-watch/` and `/projects/mergepath/` verified — no hero kicker, 4-column metadata strip with Topics in column 1, Domain absent
- [x] Blog cards verified — date and tag meta lines stack tightly above the headline; tags wrap gracefully on the longer lists; no chips remain
- [x] Mobile (375px) verified — metadata strip collapses to single column, blog card meta lines preserve grouping, no horizontal overflow