### PR TITLE
content(projects): add STATUS vocabulary, add Matchline, demote DSoT to PAUSED (#274 #275)

### DIFF
--- a/public/images/projects/matchline-wordmark.svg
+++ b/public/images/projects/matchline-wordmark.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 72" role="img">
+  <title>matchline wordmark</title>
+  <desc>The word "matchline" split by a pipe character between "match" and "line"; the pipe is rendered at weight 700 so it reads as the structural seam rather than as typographic punctuation.</desc>
+  <style>
+    text {
+      fill: #F5F5F5;
+      font-family: Inter, -apple-system, "Segoe UI", ui-sans-serif, system-ui, sans-serif;
+    }
+  </style>
+  <text x="160" y="50" text-anchor="middle" font-size="52" font-weight="500" letter-spacing="-1.8">match<tspan dx="3" font-weight="700">|</tspan><tspan dx="3">line</tspan></text>
+</svg>

--- a/specs/project-pages.md
+++ b/specs/project-pages.md
@@ -33,13 +33,13 @@ accentColor: "#3366cc"
 accentColorClass: "project-page--blue"
 gradientFrom: "#dce3f0"
 gradientTo: "#f5f0e4"
-liveUrl: "https://example.com"
+liveUrl: "https://example.com"     # optional — omit on pre-launch projects
 githubUrl: "https://github.com/you/repo"
 tags: ["Tag1", "Tag2", "Tag3"]
+status: "LIVE"                     # one of: LIVE | EXPERIMENT | IN PROGRESS | PAUSED | ARCHIVED
 metadata:
   format: "Product-type label (e.g., Financial operating system)"
   focus: "What it does in a few words"
-  status: "Live product"
 stack: "React · TypeScript · Vite · Firebase · Vitest"
 related:
   - label: "Blog: Related Post Title"
@@ -65,12 +65,12 @@ draft: false
 | `accentColorClass` | string | yes | CSS class for per-project theming |
 | `gradientFrom` | string | yes | Gradient start color (tinted toward accent) |
 | `gradientTo` | string | yes | Gradient end color (use `"#f5f0e4"` to blend into card) |
-| `liveUrl` | string | yes | URL for "View Live Product" CTA |
+| `liveUrl` | non-empty string | no | URL for "View Live Product" CTA. Omit on pre-launch projects (status `IN PROGRESS`) — the CTA, the index card "Live ↗" link, the homepage Vibe Coding "Live ↗" link, and the `SoftwareApplication` JSON-LD entity are all suppressed when this field is missing |
 | `githubUrl` | string | yes | URL for "View on GitHub" CTA |
 | `tags` | string[] | yes | Category/technology tags |
+| `status` | enum | yes | Project lifecycle status. One of `LIVE`, `EXPERIMENT`, `IN PROGRESS`, `PAUSED`, `ARCHIVED`. Drives both the project-card kicker on `/projects/` and the Status column in the detail-page metadata table — single source of truth, single short-form vocabulary across both surfaces. See #274 |
 | `metadata.format` | string | yes | Metadata strip: product-type label (e.g., "Internal platform tool"). The tech stack lives in the separate `stack` field — this field is for product category |
 | `metadata.focus` | string | yes | Metadata strip: focus area value |
-| `metadata.status` | string | yes | Metadata strip: project status |
 | `stack` | string | no | Tech stack values separated by ` · ` (e.g., `"React · TypeScript · Vite · Firebase · Vitest"`). Rendered as a figcaption below the screenshot. Optional — projects without a stack field render without the caption |
 | `related` | array | no | Related links with `label` and `href` |
 | `muxPlaybackId` | non-empty string | no | Mux public Playback ID. When set, the hero renders a `<mux-background-video>` video and `screenshotSrc` is used as the JS-disabled fallback. Schema rejects blank / whitespace-only values so a stray empty string fails build-time rather than producing a broken URL. See "Adding a Mux video" below |
@@ -233,7 +233,7 @@ The layout sets three custom properties from frontmatter:
 - **`src/layouts/ProjectLayout.astro`**: Sets CSS custom properties on the shell. Conditionally renders `HeroWide` or `HeroNarrow` based on `screenshotAspect`. Owns the `.metadata-surface` container that wraps `MetadataStrip` and the `<figure class="project-screenshot">`. The figure is rendered here (not in `MetadataStrip`) and contains the `<img>` plus a conditional `<figcaption class="project-stack">` when `stack` is present. The figcaption is a direct child of `<figure>` per HTML5 semantic rules.
 - **`src/components/HeroWide.astro`**: Hero header for wide-layout projects. No screenshot — the screenshot is rendered by `ProjectLayout` below the hero. The hero no longer renders the `kicker` tag row; that content moved into the `Topics` column of the metadata strip below.
 - **`src/components/HeroNarrow.astro`**: Hero header for narrow-layout projects. No screenshot — same as `HeroWide`, the screenshot is rendered by `ProjectLayout` below the hero. Also no longer renders the `kicker` tag row.
-- **`src/components/MetadataStrip.astro`**: Strip-only — four `<dt>`/`<dd>` pairs for topics, format, focus, and status (in that visual order). Does not own the screenshot; does not accept `screenshotSrc`/`screenshotAlt`/`screenshotAspect` props. The `topics` value is derived in `ProjectLayout` from the project's `kicker` frontmatter (split on `×` and re-joined with ` · ` to match the metadata table's separator convention). The strip is always rendered as a single 4-column horizontal row on desktop and collapses responsively (2×2 at ≤768px, 1-column at ≤480px) via `.metadata-strip--grid-4` media queries.
+- **`src/components/MetadataStrip.astro`**: Strip-only — four `<dt>`/`<dd>` pairs for topics, format, focus, and status (in that visual order). Does not own the screenshot; does not accept `screenshotSrc`/`screenshotAlt`/`screenshotAspect` props. The `topics` value is derived in `ProjectLayout` from the project's `kicker` frontmatter (split on `×` and re-joined with ` · ` to match the metadata table's separator convention). The `status` value is the project's top-level `status` enum, rendered identically on the index card kicker and in the metadata strip — single short-form vocabulary across both surfaces. The strip is always rendered as a single 4-column horizontal row on desktop and collapses responsively (2×2 at ≤768px, 1-column at ≤480px) via `.metadata-strip--grid-4` media queries.
 
 ### Content collection schema
 

--- a/src/components/HeroNarrow.astro
+++ b/src/components/HeroNarrow.astro
@@ -3,7 +3,7 @@ interface Props {
   title: string;
   deck: string;
   breadcrumbLabel: string;
-  liveUrl: string;
+  liveUrl?: string;
   githubUrl: string;
 }
 
@@ -23,7 +23,9 @@ const { title, deck, breadcrumbLabel, liveUrl, githubUrl } = Astro.props;
       <h1 class="project-title">{title}</h1>
       <p class="project-deck">{deck}</p>
       <div class="project-actions">
-        <a class="project-action" href={liveUrl} target="_blank" rel="noopener noreferrer">View Live Product</a>
+        {liveUrl && (
+          <a class="project-action" href={liveUrl} target="_blank" rel="noopener noreferrer">View Live Product</a>
+        )}
         <a class="project-action" href={githubUrl} target="_blank" rel="noopener noreferrer">View on GitHub</a>
       </div>
     </div>

--- a/src/components/HeroWide.astro
+++ b/src/components/HeroWide.astro
@@ -3,7 +3,7 @@ interface Props {
   title: string;
   deck: string;
   breadcrumbLabel: string;
-  liveUrl: string;
+  liveUrl?: string;
   githubUrl: string;
 }
 
@@ -23,7 +23,9 @@ const { title, deck, breadcrumbLabel, liveUrl, githubUrl } = Astro.props;
       <h1 class="project-title">{title}</h1>
       <p class="project-deck">{deck}</p>
       <div class="project-actions">
-        <a class="project-action" href={liveUrl} target="_blank" rel="noopener noreferrer">View Live Product</a>
+        {liveUrl && (
+          <a class="project-action" href={liveUrl} target="_blank" rel="noopener noreferrer">View Live Product</a>
+        )}
         <a class="project-action" href={githubUrl} target="_blank" rel="noopener noreferrer">View on GitHub</a>
       </div>
     </div>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -15,13 +15,20 @@ const projects = defineCollection({
     accentColorClass: z.string(),
     gradientFrom: z.string(),
     gradientTo: z.string(),
-    liveUrl: z.string(),
+    // Optional: in-progress projects (status "IN PROGRESS") may not have
+    // a deployed app yet. When omitted, the "View Live Product" CTA is
+    // suppressed on the detail page, the project card, and the homepage
+    // Vibe Coding section. When present, must be a non-empty string.
+    liveUrl: z.string().trim().min(1).optional(),
     githubUrl: z.string(),
     tags: z.array(z.string()),
+    // Status drives both the project-card kicker on /projects/ and the
+    // Status column in the detail-page metadata table — single source of
+    // truth, single short-form vocabulary across both surfaces. See #274.
+    status: z.enum(['LIVE', 'EXPERIMENT', 'IN PROGRESS', 'PAUSED', 'ARCHIVED']),
     metadata: z.object({
       format: z.string(),
       focus: z.string(),
-      status: z.string(),
     }),
     stack: z.string().optional(),
     related: z.array(z.object({

--- a/src/content/projects/device-source-of-truth.md
+++ b/src/content/projects/device-source-of-truth.md
@@ -3,7 +3,7 @@ title: "Device Source of Truth"
 slug: "device-source-of-truth"
 description: "A single web application for understanding partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN."
 kicker: "AI × Enterprise × Data"
-order: 2
+order: 5
 screenshotAspect: "wide"
 screenshotSrc: "/images/projects/device-source-of-truth-hero.png"
 accentColor: "#5b5f64"
@@ -13,10 +13,10 @@ gradientTo: "#f5f0e4"
 liveUrl: "https://device-source-of-truth.web.app"
 githubUrl: "https://github.com/nathanjohnpayne/device-source-of-truth"
 tags: ["Enterprise", "Data", "React", "Firebase"]
+status: "PAUSED"
 metadata:
   format: "Internal platform tool"
   focus: "Partner platforms and device support"
-  status: "Live product"
 stack: "React · TypeScript · Vite · Firebase · Vitest"
 related:
   - label: "Blog: Six PRs, One Bug—What AI Agents Actually Get Wrong"

--- a/src/content/projects/friends-and-family-billing.md
+++ b/src/content/projects/friends-and-family-billing.md
@@ -13,10 +13,10 @@ gradientTo: "#f5f0e4"
 liveUrl: "https://friends-and-family-billing.web.app"
 githubUrl: "https://github.com/nathanjohnpayne/friends-and-family-billing"
 tags: ["Utility", "Finance", "React", "Firebase"]
+status: "LIVE"
 metadata:
   format: "Household coordination tool"
   focus: "Shared subscriptions and recurring group expenses"
-  status: "Live product"
 stack: "React · TypeScript · Vite · Firebase · Vitest"
 related:
   - label: "Blog: Six PRs, One Bug—What AI Agents Actually Get Wrong"

--- a/src/content/projects/matchline.md
+++ b/src/content/projects/matchline.md
@@ -1,0 +1,50 @@
+---
+title: "Matchline"
+slug: "matchline"
+description: "From what you've done to what's next."
+kicker: "AI × Product × Career Tools"
+order: 1
+status: "IN PROGRESS"
+screenshotAspect: "wide"
+screenshotSrc: "/images/projects/matchline-wordmark.svg"
+accentColor: "#11100d"
+accentColorClass: "project-page--black"
+gradientFrom: "#dde1e5"
+gradientTo: "#f5f0e4"
+githubUrl: "https://github.com/nathanjohnpayne/matchline"
+tags: ["AI", "Product", "Career Tools"]
+metadata:
+  format: "Single-user web app"
+  focus: "Evidence-based application generation, capability mapping, pipeline management"
+stack: "TypeScript · Next.js · Vitest"
+related:
+  - label: "Project: Mergepath"
+    href: "/projects/mergepath/"
+---
+
+## Overview
+
+Matchline is a career operating system built for one person at a time, running a serious job search. It turns work history into structured, reusable evidence, maps that evidence against specific job requirements, and generates tailored applications grounded in what the user has actually done—not in what an AI can plausibly invent.
+
+This is not a resume builder. It's a discipline.
+
+## Why this exists
+
+Most "AI for job search" tools are generative writers: they take a job description, take a résumé, and produce a new document. The output reads well and means almost nothing—because the model doesn't know which projects mattered, which numbers are honest, which claims the user can defend in an interview. The artifact is glossy; the foundation is a guess.
+
+Matchline inverts the order. It treats the user's work history as a structured graph of capabilities, outcomes, and evidence—built up once, refined over time—and uses AI only to assemble that evidence against a specific opportunity. The model never invents; it selects, sequences, and frames what the user has already documented.
+
+The result is application material that the user can stand behind in an interview, because every claim traces back to a captured event in their own history.
+
+## What V1 does
+
+- **Captures work history as evidence.** Projects, roles, outcomes, decisions, scope changes—entered once, structured for reuse, owned by the user rather than scraped from a résumé.
+- **Maps capabilities against opportunities.** A target job description is decomposed into requirements; the user's evidence graph is searched for the strongest matches; gaps are surfaced explicitly.
+- **Generates application material grounded in evidence.** Cover letters, narrative bullets, and interview prep notes assembled from the evidence graph, with citations back to the source events.
+- **Tracks the pipeline.** Where each application is in the funnel, what was sent, what was said in the interview, what to follow up on—replacing the spreadsheet that every job seeker eventually builds.
+
+## Status
+
+In active build, V1 targeted for July 2026. Currently a single-user system—the author's own active job search is V1's only customer. Public release decisions come after V1 has earned its keep on real outcomes.
+
+No live URL until V1 ships. The repository is public; the running product is not.

--- a/src/content/projects/mergepath.md
+++ b/src/content/projects/mergepath.md
@@ -13,10 +13,10 @@ gradientTo: "#f5f0e4"
 liveUrl: "https://htmlpreview.github.io/?https://raw.githubusercontent.com/nathanjohnpayne/mergepath/main/mergepath/playground/index.html"
 githubUrl: "https://github.com/nathanjohnpayne/mergepath"
 tags: ["Infrastructure", "AI Tooling", "GitHub Actions", "Bash/Python"]
+status: "LIVE"
 metadata:
   format: "Repository standard"
   focus: "Agent governance, code review, and CI enforcement"
-  status: "Live template"
 stack: "Bash · Python · GitHub Actions · 1Password · Claude Code · Codex · Cursor"
 related:
   - label: "Blog: Agent Approval Workflow and the Genesis of Mergepath"

--- a/src/content/projects/override.md
+++ b/src/content/projects/override.md
@@ -3,7 +3,7 @@ title: "Override"
 slug: "override"
 description: "A Broadway-focused financial operating system for structuring capitalization, modeling investor returns, and replacing spreadsheet workflows with live, shareable deals."
 kicker: "AI × Finance × Theater"
-order: 1
+order: 2
 screenshotAspect: "wide"
 screenshotSrc: "/images/projects/override-hero.png"
 accentColor: "#d9b111"
@@ -13,10 +13,10 @@ gradientTo: "#f5f0e4"
 liveUrl: "https://overridebroadway.com"
 githubUrl: "https://github.com/nathanjohnpayne/overridebroadway"
 tags: ["Finance", "Theater", "React", "Firebase"]
+status: "LIVE"
 metadata:
   format: "Financial operating system"
   focus: "Capitalization, ownership, and investor workflows"
-  status: "Live product"
 stack: "Next.js · TypeScript · Firebase · Vitest"
 related:
   - label: "Blog: Agent Approval Workflow and the Genesis of Mergepath"

--- a/src/content/projects/swipe-watch.md
+++ b/src/content/projects/swipe-watch.md
@@ -14,10 +14,10 @@ gradientTo: "#f5f0e4"
 liveUrl: "https://swipewatch.web.app"
 githubUrl: "https://github.com/nathanjohnpayne/swipewatch"
 tags: ["Consumer", "Streaming", "Vanilla JS"]
+status: "EXPERIMENT"
 metadata:
   format: "Interaction prototype"
   focus: "Discovery, recommendations, and interaction design"
-  status: "Live experiment"
 stack: "Vanilla JavaScript · Firebase Hosting"
 related:
   - label: "Blog: Six PRs, One Bug—What AI Agents Actually Get Wrong"

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -26,12 +26,12 @@ interface Props {
   screenshotSrc: string;
   muxPlaybackId?: string;
   slug: string;
-  liveUrl: string;
+  liveUrl?: string;
   githubUrl: string;
+  status: string;
   metadata: {
     format: string;
     focus: string;
-    status: string;
   };
   stack?: string;
   related: RelatedLink[];
@@ -60,6 +60,7 @@ const {
   slug,
   liveUrl,
   githubUrl,
+  status,
   metadata,
   stack,
   related,
@@ -120,7 +121,7 @@ const topics = kicker.split(/\s*×\s*/).join(' · ');
           topics={topics}
           format={metadata.format}
           focus={metadata.focus}
-          status={metadata.status}
+          status={status}
         />
         <figure class={`project-screenshot project-screenshot--${screenshotAspect}`}>
           <div class="project-screenshot__inner">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -106,17 +106,17 @@ const homepageJsonLd = {
               </div>
               <div class="project-item">
                 <div class="p-head">
+                  <a class="p-name p-name-link" href="/projects/matchline/" aria-label="Read the Matchline project page">Matchline</a>
+                  <span class="p-tag">AI × Product × Career Tools</span>
+                </div>
+                <p>A career operating system for one person running a serious job search. Turns work history into structured, reusable evidence, maps it against specific job requirements, and generates tailored applications grounded in what the user has actually done—not in what an AI can plausibly invent. In progress; V1 ships when it earns its keep.</p>
+              </div>
+              <div class="project-item">
+                <div class="p-head">
                   <a class="p-name p-name-link" href="/projects/override/" aria-label="Read the Override project page">Override</a>
                   <span class="p-tag">Finance × Theater</span>
                 </div>
                 <p>The financial operating system for Broadway productions. Structure your capitalization, model investor returns, manage ownership, and share live deals with backers—without spreadsheets or PDF workflows. <a href="https://overridebroadway.com" target="_blank" rel="noopener" class="p-link" aria-label="View the live Override app">Live ↗</a></p>
-              </div>
-              <div class="project-item">
-                <div class="p-head">
-                  <a class="p-name p-name-link" href="/projects/device-source-of-truth/" aria-label="Read the Device Source of Truth project page">Device Source of Truth</a>
-                  <span class="p-tag">Enterprise × Data</span>
-                </div>
-                <p>A single web application for understanding partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN. <a href="https://device-source-of-truth.web.app" target="_blank" rel="noopener" class="p-link" aria-label="View the live Device Source of Truth app">Live ↗</a></p>
               </div>
               <div class="project-item">
                 <div class="p-head">
@@ -131,6 +131,13 @@ const homepageJsonLd = {
                   <span class="p-tag">Utility × Finance</span>
                 </div>
                 <p>Cloud-synced shared-bill coordination for families and friend groups, turning monthly and annual costs into clear annual invoices, payment tracking, and shareable summaries. <a href="https://friends-and-family-billing.web.app" target="_blank" rel="noopener" class="p-link" aria-label="View the live Friends and Family Billing app">Live ↗</a></p>
+              </div>
+              <div class="project-item">
+                <div class="p-head">
+                  <a class="p-name p-name-link" href="/projects/device-source-of-truth/" aria-label="Read the Device Source of Truth project page">Device Source of Truth</a>
+                  <span class="p-tag">Enterprise × Data</span>
+                </div>
+                <p>A single web application for understanding partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN. <a href="https://device-source-of-truth.web.app" target="_blank" rel="noopener" class="p-link" aria-label="View the live Device Source of Truth app">Live ↗</a></p>
               </div>
             </div>
             <div class="stack-ribbon">

--- a/src/pages/og-templates/projects/matchline.astro
+++ b/src/pages/og-templates/projects/matchline.astro
@@ -1,0 +1,10 @@
+---
+import OgCard from '../../../layouts/OgCard.astro';
+---
+
+<OgCard
+  label="nathanpayne.com / projects"
+  heading="Matchline"
+  description="A career operating system for one person running a serious job search. Turns work history into structured, reusable evidence and assembles tailored applications grounded in what the user has actually done."
+  meta="AI · Product · Career Tools"
+/>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -14,29 +14,12 @@ const { project } = Astro.props;
 const { Content } = await render(project);
 const { data } = project;
 
-const jsonLd = {
-  "@context": "https://schema.org",
-  "@graph": [
-    {
-      "@type": "WebPage",
-      "@id": `https://nathanpayne.com/projects/${data.slug}/#webpage`,
-      "url": `https://nathanpayne.com/projects/${data.slug}/`,
-      "name": `${data.title} | Nathan Payne`,
-      "description": data.description,
-      "isPartOf": { "@id": "https://nathanpayne.com/#website" },
-      "breadcrumb": { "@id": `https://nathanpayne.com/projects/${data.slug}/#breadcrumb` },
-      "mainEntity": { "@id": `https://nathanpayne.com/projects/${data.slug}/#app` },
-    },
-    {
-      "@type": "BreadcrumbList",
-      "@id": `https://nathanpayne.com/projects/${data.slug}/#breadcrumb`,
-      "itemListElement": [
-        { "@type": "ListItem", "position": 1, "name": "Nathan Payne", "item": "https://nathanpayne.com/" },
-        { "@type": "ListItem", "position": 2, "name": "Projects", "item": "https://nathanpayne.com/projects/" },
-        { "@type": "ListItem", "position": 3, "name": data.title, "item": `https://nathanpayne.com/projects/${data.slug}/` },
-      ],
-    },
-    {
+// SoftwareApplication node only when the project has a live URL.
+// Pre-launch projects (no liveUrl) drop the SoftwareApplication entry
+// rather than ship a SoftwareApplication with `url: undefined`, which
+// search engines treat as malformed structured data.
+const softwareApp = data.liveUrl
+  ? [{
       "@type": "SoftwareApplication",
       "@id": `https://nathanpayne.com/projects/${data.slug}/#app`,
       "name": data.title,
@@ -49,7 +32,36 @@ const jsonLd = {
         "url": "https://nathanpayne.com/",
       },
       "description": data.description,
+    }]
+  : [];
+
+const webPage: Record<string, unknown> = {
+  "@type": "WebPage",
+  "@id": `https://nathanpayne.com/projects/${data.slug}/#webpage`,
+  "url": `https://nathanpayne.com/projects/${data.slug}/`,
+  "name": `${data.title} | Nathan Payne`,
+  "description": data.description,
+  "isPartOf": { "@id": "https://nathanpayne.com/#website" },
+  "breadcrumb": { "@id": `https://nathanpayne.com/projects/${data.slug}/#breadcrumb` },
+};
+if (data.liveUrl) {
+  webPage.mainEntity = { "@id": `https://nathanpayne.com/projects/${data.slug}/#app` };
+}
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    webPage,
+    {
+      "@type": "BreadcrumbList",
+      "@id": `https://nathanpayne.com/projects/${data.slug}/#breadcrumb`,
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Nathan Payne", "item": "https://nathanpayne.com/" },
+        { "@type": "ListItem", "position": 2, "name": "Projects", "item": "https://nathanpayne.com/projects/" },
+        { "@type": "ListItem", "position": 3, "name": data.title, "item": `https://nathanpayne.com/projects/${data.slug}/` },
+      ],
     },
+    ...softwareApp,
   ],
 };
 ---
@@ -72,6 +84,7 @@ const jsonLd = {
   slug={data.slug}
   liveUrl={data.liveUrl}
   githubUrl={data.githubUrl}
+  status={data.status}
   metadata={data.metadata}
   stack={data.stack}
   related={data.related}

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -58,12 +58,15 @@ const jsonLd = {
         {projects.map((project, i) => {
           const card = (
             <article class="post-card">
+              <p class="post-meta">{project.data.status}</p>
               <p class="post-meta">{project.data.tags.join(' · ')}</p>
               <h2 class="post-title"><a href={`/projects/${project.data.slug}/`}>{project.data.title}</a></h2>
               <p class="post-desc">{project.data.description}</p>
-              <div class="tag-row">
-                <a href={project.data.liveUrl} target="_blank" rel="noopener noreferrer" class="tag">Live &nearr;</a>
-              </div>
+              {project.data.liveUrl && (
+                <div class="tag-row">
+                  <a href={project.data.liveUrl} target="_blank" rel="noopener noreferrer" class="tag">Live &nearr;</a>
+                </div>
+              )}
             </article>
           );
 
@@ -74,10 +77,15 @@ const jsonLd = {
               <div class="accent-blue" aria-hidden="true"></div>
             </div>
           );
+          // Row 2 hosts the in-progress anchor project. Black is the
+          // last unused Mondrian primary on the projects index and
+          // becomes Matchline's color block — unmarked composition,
+          // not a logo surface (the wordmark only renders on the
+          // detail page). See #275.
           if (i === 1) return (
             <div class="grid-row--2">
               {card}
-              <div class="accent-yellow" aria-hidden="true"></div>
+              <div class="accent-black" aria-hidden="true"></div>
             </div>
           );
           if (i === 2) return (
@@ -86,10 +94,13 @@ const jsonLd = {
               <div class="accent-white" aria-hidden="true"></div>
             </div>
           );
+          // Row 4 inherits the yellow that previously lived in row 2,
+          // so the Mondrian composition still has all four primaries
+          // visible on the index after the row 2 swap above.
           if (i === 3) return (
             <div class="grid-row--4">
               {card}
-              <div class="accent-black" aria-hidden="true"></div>
+              <div class="accent-yellow" aria-hidden="true"></div>
               <div class="accent-paper" aria-hidden="true"></div>
             </div>
           );

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1109,6 +1109,35 @@ body.blog-page {
   border: 1px solid var(--rule, rgba(17, 16, 13, 0.12));
 }
 
+/* Black-themed projects (currently Matchline) render a wordmark SVG in
+   the screenshot slot rather than a screenshot. Give the figure a black
+   surface so the white-fill wordmark sits on its intended background,
+   center the SVG inside its inner wrapper, and constrain its width so
+   the wordmark breathes rather than stretching to the full content
+   column. The border on the inner img is suppressed because there's no
+   raster screenshot edge to soften here. */
+.project-page--black .project-screenshot {
+  background: var(--ink);
+  border-top-color: var(--ink);
+}
+.project-page--black .project-screenshot__inner {
+  max-width: 28rem;
+  margin: 0 auto;
+  padding: clamp(2rem, 6vw, 4rem) clamp(1rem, 4vw, 2.5rem);
+}
+.project-page--black .project-screenshot--wide img {
+  border: none;
+}
+.project-page--black .project-stack {
+  color: rgba(245, 240, 228, 0.78);
+}
+.project-page--black .project-stack__label {
+  color: rgba(245, 240, 228, 0.62);
+}
+.project-page--black .project-stack__value {
+  color: rgba(245, 240, 228, 0.92);
+}
+
 /* Mux background-video rendered in the hero slot. The component picks
    its own aspect ratio from the asset's metadata — we deliberately
    don't hardcode one here, because different clips (e.g. 9:19.5 modern

--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -13,11 +13,18 @@ const CONTENT = resolve(__dirname, '../src/content/projects');
 
 const projectSlugs = [
   'mergepath',
+  'matchline',
   'override',
   'device-source-of-truth',
   'friends-and-family-billing',
   'swipe-watch',
 ];
+
+// Projects without a deployed live URL — the "View Live Product" CTA
+// is suppressed on the detail page, the project card, and the homepage
+// Vibe Coding section. The SoftwareApplication JSON-LD entity is also
+// dropped on these pages (no `url:` to populate).
+const noLiveUrlSlugs = ['matchline'];
 
 function readDistHtml(relativePath) {
   return readFileSync(resolve(DIST, relativePath), 'utf-8');
@@ -111,15 +118,22 @@ describe('Project Pages — render', () => {
         expect(headings).toContain('Overview');
       });
 
-      it('renders both CTA actions (View Live Product and View on GitHub)', () => {
+      it('renders the appropriate CTA actions for the project', () => {
         const actions = Array.from(document.querySelectorAll('.project-action')).map(
           (a) => a.textContent.trim(),
         );
-        expect(actions).toContain('View Live Product');
+        // The "Back to Projects" / "Back to Homepage" footer actions also
+        // share the .project-action class, so filter to the hero CTAs by
+        // checking for the canonical labels we render in HeroWide/Narrow.
+        if (noLiveUrlSlugs.includes(slug)) {
+          expect(actions).not.toContain('View Live Product');
+        } else {
+          expect(actions).toContain('View Live Product');
+        }
         expect(actions).toContain('View on GitHub');
       });
 
-      it('emits a JSON-LD graph containing a SoftwareApplication entity', () => {
+      it('emits a JSON-LD graph; SoftwareApplication present iff project has a live URL', () => {
         const scripts = document.querySelectorAll('script[type="application/ld+json"]');
         expect(scripts.length).toBeGreaterThan(0);
 
@@ -136,7 +150,11 @@ describe('Project Pages — render', () => {
             // malformed JSON-LD would fail another test; ignore here
           }
         }
-        expect(foundSoftwareApp, 'no SoftwareApplication entity in JSON-LD graph').toBe(true);
+        if (noLiveUrlSlugs.includes(slug)) {
+          expect(foundSoftwareApp, 'pre-launch project should NOT emit SoftwareApplication').toBe(false);
+        } else {
+          expect(foundSoftwareApp, 'no SoftwareApplication entity in JSON-LD graph').toBe(true);
+        }
       });
     });
   }
@@ -189,8 +207,14 @@ describe('Project Pages — screenshot aspect variants', () => {
     }
   });
 
-  it('Override, DST, and FFB use the wide screenshot variant', () => {
-    const wideSlugs = ['override', 'device-source-of-truth', 'friends-and-family-billing'];
+  it('Mergepath, Matchline, Override, DST, and FFB use the wide screenshot variant', () => {
+    const wideSlugs = [
+      'mergepath',
+      'matchline',
+      'override',
+      'device-source-of-truth',
+      'friends-and-family-billing',
+    ];
     for (const slug of wideSlugs) {
       setupDOM(readDistHtml(`projects/${slug}/index.html`));
       const figure = document.querySelector('figure.project-screenshot');


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Two coupled tickets, shipped together so the new project lands in the harmonized pattern rather than needing a follow-up restyle.

- **#274 — STATUS vocabulary.** New top-level `status` enum on the project schema (`LIVE` / `EXPERIMENT` / `IN PROGRESS` / `PAUSED` / `ARCHIVED`). Project-card kicker on `/projects/` now leads with status (small caps letterspaced, grouped tightly above the existing tag line via the `.post-meta:has(+ .post-meta)` rule shipped in #273). Detail-page metadata-strip Status column reads from the same top-level field — single source of truth, single short-form vocabulary across both surfaces. `metadata.status` is removed.
- **#275 — Matchline + reorder + DSoT pause.** New project at `/projects/matchline/` with status `IN PROGRESS`. Wide screenshot slot renders the Matchline wordmark on a black surface (white-fill SVG variant of the source asset; the only edits are removal of the `prefers-color-scheme` media query and a fill flip to `#F5F5F5` so the wordmark is visible on the black background — the source SVG would render black-on-black in light mode). Projects index black accent block moves from row 4 to row 2 so it pairs with Matchline; yellow swaps the other direction so all four Mondrian primaries still appear on the index. Wordmark renders only on the Matchline detail page — preserves the existing card system (color blocks as pure composition, no logo surfaces). Device Source of Truth status changes from `LIVE` to `PAUSED`; project order updated across the projects index and the homepage Vibe Coding section.

### Schema + plumbing

- `liveUrl` is now optional. When omitted, the "View Live Product" CTA, the index-card "Live ↗" link, the homepage Vibe Coding "Live ↗" link, and the `SoftwareApplication` JSON-LD entity are all suppressed (returning a `SoftwareApplication` with `url: undefined` would ship malformed structured data).
- `WebPage` JSON-LD drops `mainEntity` when there is no `SoftwareApplication` to point at.
- Tests updated: Matchline added to the project slug loop; CTA and `SoftwareApplication` assertions now branch on whether the project has a live URL. All 143 tests pass.
- Spec updated to document the new status field, optional `liveUrl`, and the single-vocabulary convention.

Authoring-Agent: claude

## Self-Review

- **Correctness:** build passes (23 pages, including new `/projects/matchline/` and its OG image). All 143 vitest tests pass (was 136 — +7 from Matchline being added to the project slug loop). Manual preview verification covered: `/projects/` index renders status kickers in the right order with conditional `Live ↗`, `/projects/matchline/` hero renders without "View Live Product" CTA, metadata strip shows `IN PROGRESS`, wordmark renders white on black with the expected geometry, and the stack caption reads white-on-black.
- **Regression risk:** medium. Schema changes (top-level `status`, optional `liveUrl`, removal of `metadata.status`) are enforced by Zod at build time, so any drift fails loudly. Five existing project frontmatter files updated in lockstep. Single-vocabulary reconciliation (`Live experiment` → `EXPERIMENT`, `Live product` → `LIVE`, `Live template` → `LIVE`, etc.) is content-only.
- **Style:** matches existing component conventions (props passed through `ProjectLayout`, named CSS modifier `.project-page--black .project-screenshot`, conditional renders in templates rather than ternary defaults). Wordmark CSS scoped under `.project-page--black` so it only affects the Matchline page; future black-themed projects would inherit the same pattern.
- **Test coverage:** the existing project-page test suite now branches on whether each project has a live URL (`noLiveUrlSlugs = ['matchline']`) so both shapes are exercised. The wide-aspect assertion was extended to include Mergepath and Matchline.
- **Security / dependency hygiene:** no new dependencies. New SVG asset is a static file in `public/images/projects/` — same risk profile as the other project hero images.

## Test plan

- [x] `npm run build` passes (23 pages, `/projects/matchline/` and `/og/projects/matchline.png` generated)
- [x] `npm test -- --run` passes (143/143)
- [x] `/projects/` verified — status kickers appear above tag lines, order is Mergepath, Matchline, Override, Swipe Watch, FFB, DSoT, Matchline pairs with the black accent block, no `Live ↗` button on Matchline
- [x] `/projects/matchline/` verified — hero renders without "View Live Product" CTA, metadata strip shows `IN PROGRESS`, wordmark renders white-on-black with stack caption legible
- [x] `/projects/swipe-watch/` verified — status reads `EXPERIMENT` (was `Live experiment`)
- [x] `/projects/device-source-of-truth/` verified — status reads `PAUSED`
- [x] Homepage `/` Vibe Coding section verified — Matchline appears in slot 2, DSoT moved to last
- [x] Mobile (375px) — projects index cards stack cleanly, status kicker wraps before tag line, no horizontal overflow

## Self-Review

(See body above for the full self-review checklist.)