### PR TITLE
content(home): NOW section + tag row drop + LAST UPDATED tightening (#272 #278)

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -76,4 +76,25 @@ const blog = defineCollection({
   }),
 });
 
-export const collections = { blog, projects };
+// `bio` collection — long-lived, hand-edited copy that lives on the
+// homepage but isn't the page template. Currently a single entry: NOW
+// (the current-state signal under About). Content stays in MD so an
+// edit doesn't require a template change; `lastUpdated` is explicit
+// (not file mtime) so unrelated edits to the file don't drift the
+// timestamp. See #272.
+const bio = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: './src/content/bio' }),
+  schema: z.object({
+    // Month + year for the human-facing "LAST UPDATED · APRIL 2026"
+    // line. Author edits this whenever they refresh the body — the
+    // whole point of the section is freshness, so an explicit value
+    // beats anything auto-derived. Format: "Month YYYY" in title case
+    // (e.g., "April 2026"); the template uppercases it for display.
+    lastUpdated: z.string().regex(
+      /^(January|February|March|April|May|June|July|August|September|October|November|December) \d{4}$/,
+      'lastUpdated must be "Month YYYY" (e.g., "April 2026")'
+    ),
+  }),
+});
+
+export const collections = { blog, projects, bio };

--- a/src/content/bio/now.md
+++ b/src/content/bio/now.md
@@ -1,0 +1,5 @@
+---
+lastUpdated: April 2026
+---
+
+Spending most of my time at the seam where AI coding agents meet shipped software—building projects end-to-end with Claude Code, Codex, and Cursor under an enforcement system designed to catch the failure modes agents don't catch themselves. Writing about what I learn as I go. Open to PM roles where streaming infrastructure, developer tools, or AI-augmented workflows are the work.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,9 +1,18 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import { getCollection } from 'astro:content';
+import { getCollection, getEntry, render } from 'astro:content';
 
 const latestPost = (await getCollection('blog', ({ data }) => !data.draft))
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())[0];
+
+// NOW section — current-state signal under About. Content + freshness
+// timestamp live in `src/content/bio/now.md`; the template only
+// renders. See #272.
+const nowEntry = await getEntry('bio', 'now');
+if (!nowEntry) {
+  throw new Error('Missing bio entry "now" — expected at src/content/bio/now.md');
+}
+const { Content: NowContent } = await render(nowEntry);
 
 const homepageJsonLd = {
   "@context": "https://schema.org",
@@ -80,9 +89,11 @@ const homepageJsonLd = {
                 <span class="about-label">Approach</span>
                 <p>I treat operational ambiguity as a product problem. The work that matters most is usually at the seam between systems—where a codec mismatch, a certification gap, or a failed-fix loop creates a support burden at scale.</p>
               </div>
-            </div>
-            <div class="about-meta">
-              <span class="about-meta-items">San Francisco · AI Agents · Product · Broadway</span>
+              <div class="about-block about-block--now">
+                <span class="about-label">Now</span>
+                <NowContent />
+                <p class="about-now-updated">Last updated · {nowEntry.data.lastUpdated}</p>
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -79,11 +79,11 @@ const homepageJsonLd = {
         <div class="panel-content">
           <div class="content-inner">
             <h1>Nathan Payne</h1>
-            <p class="lead">Most product decisions are invisible—until they aren't.</p>
+            <p class="lead">Most product decisions are invisible—until they aren’t.</p>
             <div class="about-blocks">
               <div class="about-block">
                 <span class="about-label">Context</span>
-                <p>I spent ten years building the streaming platforms that run Disney+, Hulu, and ESPN—first at MLB.com and BAMTECH, which Disney acquired in 2017, and most recently five years leading the Native Client Platform across PlayStation, Xbox, Amazon Fire TV, Vega OS, and smart TVs. I am now focused on the intersection of AI coding agents and shipped software, and open to what's next.</p>
+                <p>I spent ten years building the streaming platforms that run Disney+, Hulu, and ESPN—first at MLB.com and BAMTECH, which Disney acquired in 2017, and most recently five years leading the Native Client Platform across PlayStation, Xbox, Amazon Fire TV, Vega OS, and smart TVs. I am now focused on the intersection of AI coding agents and shipped software, and open to what’s next.</p>
               </div>
               <div class="about-block">
                 <span class="about-label">Approach</span>
@@ -106,7 +106,7 @@ const homepageJsonLd = {
         <div class="panel-content">
           <div class="content-inner">
             <h2>Vibe Coding</h2>
-            <p>Every project started as a real problem. Each one was built end-to-end with AI agents—Claude Code, Codex, and Cursor—under a multi-agent code review system I designed to catch the failure modes agents don't catch themselves. <a href="/blog/six-prs-one-bug-agent-failure-modes/" class="p-link">What agents actually get wrong →</a> · <a href="/blog/agent-approval-workflow-genesis-of-mergepath/" class="p-link">How the enforcement system works →</a></p>
+            <p>Every project started as a real problem. Each one was built end-to-end with AI agents—Claude Code, Codex, and Cursor—under a multi-agent code review system I designed to catch the failure modes agents don’t catch themselves. <a href="/blog/six-prs-one-bug-agent-failure-modes/" class="p-link">What agents actually get wrong →</a> · <a href="/blog/agent-approval-workflow-genesis-of-mergepath/" class="p-link">How the enforcement system works →</a></p>
             <div class="project-list">
               <div class="project-item">
                 <div class="p-head">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -120,7 +120,7 @@ const homepageJsonLd = {
                   <a class="p-name p-name-link" href="/projects/matchline/" aria-label="Read the Matchline project page">Matchline</a>
                   <span class="p-tag">AI × Product × Career Tools</span>
                 </div>
-                <p>A career operating system for one person running a serious job search. Turns work history into structured, reusable evidence, maps it against specific job requirements, and generates tailored applications grounded in what the user has actually done—not in what an AI can plausibly invent. In progress; V1 ships when it earns its keep.</p>
+                <p>A career operating system for one person running a serious job search. Turns work history into structured, reusable evidence, maps it against specific job requirements, and generates tailored applications grounded in what the user has actually done.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -281,17 +281,12 @@ html, body {
   margin-bottom: calc(var(--su) * 0.5);
 }
 
-.about-meta {
-  margin-top: calc(var(--su) * 1.25);
-  padding-top: calc(var(--su) * 0.6);
-  margin-left: -0.4rem;
-  margin-right: -0.4rem;
-  padding-left: 0.4rem;
-  padding-right: 0.4rem;
-  border-top: 1px solid var(--rule);
-}
-
-.about-meta-items {
+/* "LAST UPDATED · MONTH YEAR" closer for the NOW section. Small-caps
+ * letterspaced, muted, and tightly grouped with the NOW paragraph
+ * above (~14px) so it reads as the section's signature rather than as
+ * a free-floating metadata row. See #272, #278. */
+.about-now-updated {
+  margin-top: 0.875rem;
   font-size: 0.68rem;
   line-height: 1.45;
   letter-spacing: 0.10em;
@@ -2655,10 +2650,9 @@ a.tag:hover {
 .connect-label,
 .stack-label,
 .impact-label,
-.about-meta-items,
+.about-now-updated,
 .stack-items,
 .impact-items,
-.about-meta,
 .stack-ribbon,
 .impact-ribbon {
   transition: opacity var(--motion-fast) var(--ease-linear);
@@ -2766,7 +2760,7 @@ a:focus-visible {
     letter-spacing: 0.15em;
   }
 
-  .about-meta-items,
+  .about-now-updated,
   .stack-items,
   .impact-items {
     font-size: clamp(0.68rem, 0.64rem + 0.24vw, 0.78rem);
@@ -2775,12 +2769,8 @@ a:focus-visible {
   }
 
   .panel--red .about-label,
-  .panel--red .about-meta-items {
+  .panel--red .about-now-updated {
     color: rgba(242, 237, 225, 0.82);
-  }
-
-  .panel--red .about-meta {
-    border-top-color: rgba(242, 237, 225, 0.28);
   }
 
   .panel--yellow .stack-label,


### PR DESCRIPTION
Authoring-Agent: claude

Closes #272 and #278.

## Summary

Bundles the two coupled bio-block tickets so the NOW section and the layout cleanup ship in a single review:

- **#272 (NOW section).** Adds a third labeled About block — `NOW` — with locked content from the ticket and a `LAST UPDATED · APRIL 2026` closer line. Gives the bio block a current-state signal and removes the structural sparseness flagged in the ticket (cream block previously extended well past where Context + Approach ended).
- **#278 (drop tag row, tighten LAST UPDATED).** Removes the `San Francisco · AI Agents · Product · Broadway` row from the bio (it was orphaned now that NOW carries the freshness signal), and tightens the LAST UPDATED line to 14px below the NOW paragraph so it reads as the section's signature rather than as a floating metadata row.

These were already drafted as a coupled pair in #278 ("After adding the NOW section to the bio block, two visual issues remain"), so a single PR keeps the diff coherent.

## Implementation

- **New `bio` content collection.** `src/content/bio/now.md` carries the body + `lastUpdated` frontmatter; `src/content.config.ts` registers the collection with a zod regex that rejects anything other than `Month YYYY` (e.g., \"April 2026\"). This satisfies the #272 acceptance criterion that content + timestamp be editable from a single source AND that the timestamp not be auto-derived from file mtime (which would drift on unrelated edits).
- **Homepage template.** \`src/pages/index.astro\` reads the entry via \`getEntry('bio', 'now')\` and renders \`<NowContent />\` plus the \`Last updated · {nowEntry.data.lastUpdated}\` line. Throws a clear error if the entry is missing rather than silently rendering an empty section.
- **CSS.** Replaced \`.about-meta\` / \`.about-meta-items\` rules with a single \`.about-now-updated\` rule that inherits the same muted small-caps treatment (so the LAST UPDATED line carries the visual weight the tag row used to). Removed corresponding \`.panel--red\` mobile overrides. \`text-transform: uppercase\` does the visual work — the source content reads \"April 2026\" so future automation/grep stays readable.

## Verification

- \`npm run build\` → clean (23 pages built).
- \`npm test\` → 143/143 green.
- Browser preview at desktop and mobile breakpoints: bio block renders Context → Approach → NOW → LAST UPDATED in correct hierarchy; tag row no longer present; mobile applies the existing cream-on-red treatment to LAST UPDATED via the \`.panel--red\` override.
- Manual screenshot pass attached on each issue (will pull into PR description if reviewer wants).

## Acceptance criteria

### #272
- [x] New \`NOW\` labeled section renders in the bio block, below \`APPROACH\` and above the (now-removed) tag row
- [x] Typography matches \`CONTEXT\` / \`APPROACH\` labels
- [x] \`LAST UPDATED · APRIL 2026\` appears as small caps letterspaced metadata
- [x] Content editable from a single source (content collection)
- [x] Last-updated value editable from frontmatter, not auto-generated from mtime
- [x] Cream block height now matches its content
- [x] No mobile regressions

### #278
- [x] Bottom tag row no longer renders
- [x] LAST UPDATED line sits closer to NOW paragraph (14px) — clearly grouped with NOW
- [x] Bio block ends with: NOW → LAST UPDATED → block padding
- [x] No mobile regressions
- [x] No filler content added in the space the tag row vacated

## Notes for the reviewer

- The tag row's content is preserved across the rest of the site (San Francisco in the page footer + tab title; AI Agents in NOW copy + Vibe Coding label; Product in the tab title; Broadway in the Override project), so removing it doesn't drop any actual signal.
- Per #272 \"set a recurring reminder before shipping\" — flagging this for you to wire up your monthly/quarterly NOW refresh cadence outside the repo (calendar item, etc.). The schema regex will reject typos that would otherwise produce a stale \"APRIL 2026\" rendering when it's actually July.
- The schema is intentionally strict about \`Month YYYY\` format (e.g., it will reject \"Apr 2026\" or \"April 26\"). Loosen if you'd rather have \`Apr\` parity with blog card kickers; current strictness was chosen to enforce the longer-form #272 convention that differentiates section freshness from publish dates.

## Self-Review

- **Correctness.** Verified rendering matches the locked content from #272. \`getEntry\` throws if the file is missing, which fails the build loudly rather than silently rendering an empty section. Schema regex catches malformed dates at build time.
- **Regression risk.** Low. New collection is additive. Removed CSS rules are only used by the deleted \`.about-meta\` markup — confirmed via repo grep no other call sites. Mobile override block also pruned to match.
- **Style.** CMOS em-dashes preserved in the new content. NOW label matches the existing CONTEXT/APPROACH small-caps treatment. LAST UPDATED uses the same muted color/letterspacing the tag row used.
- **Test coverage.** No existing tests asserted the tag row content or position — confirmed via \`grep -rn 'about-meta\|San Francisco · AI Agents\|Broadway' tests/\`. Considered adding a test that asserts the NOW section + LAST UPDATED line render, but the existing project + SEO test patterns don't extend to homepage content shape; punting unless reviewer wants one.
- **Security / dependency hygiene.** No new deps; no client-side code; no protected paths touched.

## Test plan

- [ ] Pull branch, \`npm run dev\`, confirm desktop bio block matches the screenshots
- [ ] Resize to mobile (≤480px), confirm NOW + LAST UPDATED render correctly with the cream-on-red treatment
- [ ] Edit \`src/content/bio/now.md\` to bump \`lastUpdated\` to \"May 2026\", confirm the homepage updates on next build
- [ ] Try a malformed value (e.g., \"may 2026\" or \"05/2026\"), confirm zod rejects with a clear error