### PR TITLE
content(projects): hide STATUS kicker when status is LIVE (#277)

### DIFF
--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -58,7 +58,13 @@ const jsonLd = {
         {projects.map((project, i) => {
           const card = (
             <article class="post-card">
-              <p class="post-meta">{project.data.status}</p>
+              {/* Status kicker is exception-based: render only for non-LIVE
+                  projects so the status line carries meaning instead of
+                  noise. Defensively hide if status is missing too — fail
+                  closed to LIVE per #277. */}
+              {project.data.status && project.data.status !== 'LIVE' && (
+                <p class="post-meta">{project.data.status}</p>
+              )}
               <p class="post-meta">{project.data.tags.join(' · ')}</p>
               <h2 class="post-title"><a href={`/projects/${project.data.slug}/`}>{project.data.title}</a></h2>
               <p class="post-desc">{project.data.description}</p>


### PR DESCRIPTION
Authoring-Agent: claude

Closes #277.

## Summary

Make the project-card STATUS kicker exception-based: render only when status is not \`LIVE\`. The LIVE↗ CTA already signals shipped state, so the redundant kicker text just made the metadata zone louder without adding signal.

Result on \`/projects/\`:

| Card  | Status | Renders kicker? |
|-------|--------|-----------------|
| Mergepath | LIVE | no |
| Matchline | IN PROGRESS | yes |
| Override | LIVE | no |
| Swipe Watch | EXPERIMENT | yes |
| Friends & Family Billing | LIVE | no |
| Device Source of Truth | PAUSED | yes |

Detail-page metadata tables still surface STATUS for every project regardless of value — per the ticket's reasoning, detail pages are for invested readers and benefit from complete state, while index cards benefit from exception-based scanning.

## Implementation

One conditional in \`src/pages/projects/index.astro\`:

\`\`\`astro
{project.data.status && project.data.status !== 'LIVE' && (
  <p class="post-meta">{project.data.status}</p>
)}
\`\`\`

The defensive truthiness check (\`project.data.status &&\`) is belt-and-suspenders against a future schema loosening — today the zod schema makes status required, so the only path through which it could be missing is a deliberate change. With both checks the system fails closed to LIVE behavior (no kicker), matching the issue's edge-case spec.

## Spacing rebalance

The existing \`.post-meta:has(+ .post-meta)\` rule (\`global.css:1551\`) tightens the gap between stacked meta lines from 0.5rem to 0.15rem. When the LIVE kicker is removed, the remaining tag-line meta has no following sibling, so it falls back to the default 0.5rem margin — exactly the spacing LIVE cards had before #274 added the kicker. No CSS changes needed.

## Verification

- \`npm run build\` clean (23 pages built).
- \`npm test\` 143/143 green.
- Browser preview at \`/projects/\`: confirmed via DOM inspection that LIVE cards (Mergepath, Override, FFB) render only one \`.post-meta\` (the tag line); non-LIVE cards (Matchline, Swipe Watch, DSoT) render two with the kicker tightly grouped above the tag line.
- Visual check: tag-line-to-headline spacing on LIVE cards rebalances cleanly without any visible gap from the missing kicker.

## Acceptance criteria

- [x] Project index cards on \`/projects/\` render the status kicker only when status is not \`LIVE\`
- [x] LIVE cards show: tag line → headline → description → CTA (no kicker)
- [x] Non-LIVE cards show: status kicker → tag line → headline → description → CTA
- [x] Detail page metadata tables continue to show STATUS for all projects
- [x] No mobile regressions (no responsive overrides touched)
- [x] Spacing between tag line and headline on LIVE cards rebalances cleanly

## Self-Review

- **Correctness.** Verified rendering across all six project cards. The schema (\`src/content.config.ts\`) has \`status: z.enum([...])\` so missing status is impossible by build-time validation; the \`&&\` defensive guard is therefore vestigial today but cheap insurance against schema drift.
- **Regression risk.** Single-conditional change, scoped to one file, no CSS edits, no test edits. Detail pages, homepage Vibe Coding section, and OG generation are untouched.
- **Style.** Comment in the JSX explains the \"exception-based\" intent so a future reader doesn't \"helpfully\" remove the conditional. CMOS-aligned em-dashes in the comment.
- **Test coverage.** No existing tests assert the kicker's presence/absence on the projects index. Existing tests in \`tests/project-pages.test.js\` cover detail-page rendering and pass unchanged. Skipped writing a new index-page test — the rendering logic is a one-line conditional that visual + DOM verification covers without overhead.
- **Security / dependency hygiene.** No new deps; no client-side code; no protected paths touched.

## Test plan

- [ ] Pull branch, \`npm run dev\`, navigate to \`/projects/\`
- [ ] Confirm Mergepath / Override / FFB cards show only tag line as the meta zone (no STATUS kicker)
- [ ] Confirm Matchline / Swipe Watch / DSoT cards show STATUS kicker tightly grouped above the tag line
- [ ] Resize to mobile, confirm no layout regressions
- [ ] Visit each project detail page, confirm STATUS row in metadata table still renders for all projects