### PR TITLE
content(home): match LAST UPDATED to Stack/Scope ribbon format

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -92,7 +92,10 @@ const homepageJsonLd = {
               <div class="about-block about-block--now">
                 <span class="about-label">Now</span>
                 <NowContent />
-                <p class="about-now-updated">Last updated · {nowEntry.data.lastUpdated}</p>
+                <div class="now-ribbon">
+                  <span class="now-ribbon-label">Last updated</span>
+                  <span class="now-ribbon-date">{nowEntry.data.lastUpdated}</span>
+                </div>
               </div>
             </div>
           </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -283,20 +283,6 @@ html, body {
   margin-bottom: calc(var(--su) * 0.5);
 }
 
-/* "LAST UPDATED · MONTH YEAR" closer for the NOW section. Small-caps
- * letterspaced, muted, and tightly grouped with the NOW paragraph
- * above (~14px) so it reads as the section's signature rather than as
- * a free-floating metadata row. See #272, #278. */
-.about-now-updated {
-  margin-top: 0.875rem;
-  font-size: 0.68rem;
-  line-height: 1.45;
-  letter-spacing: 0.10em;
-  word-spacing: 0.05em;
-  color: rgba(17, 16, 13, 0.50);
-  text-transform: uppercase;
-}
-
 .social-stack,
 .project-list,
 .effort-list {
@@ -567,7 +553,8 @@ html, body {
 }
 
 .stack-ribbon,
-.impact-ribbon {
+.impact-ribbon,
+.now-ribbon {
   display: flex;
   flex-direction: column;
   gap: 0.08rem;
@@ -585,7 +572,8 @@ html, body {
 }
 
 .stack-label,
-.impact-label {
+.impact-label,
+.now-ribbon-label {
   font-size: 0.56rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -595,6 +583,7 @@ html, body {
 
 .stack-items,
 .impact-items,
+.now-ribbon-date,
 .blog-callout-link {
   font-size: 0.68rem;
   line-height: 1.45;
@@ -2652,11 +2641,13 @@ a.tag:hover {
 .connect-label,
 .stack-label,
 .impact-label,
-.about-now-updated,
+.now-ribbon-label,
 .stack-items,
 .impact-items,
+.now-ribbon-date,
 .stack-ribbon,
-.impact-ribbon {
+.impact-ribbon,
+.now-ribbon {
   transition: opacity var(--motion-fast) var(--ease-linear);
 }
 
@@ -2812,22 +2803,28 @@ a:focus-visible {
   .about-label,
   .connect-label,
   .stack-label,
-  .impact-label {
+  .impact-label,
+  .now-ribbon-label {
     font-size: clamp(0.56rem, 0.52rem + 0.2vw, 0.64rem);
     letter-spacing: 0.15em;
   }
 
-  .about-now-updated,
   .stack-items,
-  .impact-items {
+  .impact-items,
+  .now-ribbon-date {
     font-size: clamp(0.68rem, 0.64rem + 0.24vw, 0.78rem);
     line-height: 1.48;
     letter-spacing: 0.06em;
   }
 
   .panel--red .about-label,
-  .panel--red .about-now-updated {
+  .panel--red .now-ribbon-label,
+  .panel--red .now-ribbon-date {
     color: rgba(242, 237, 225, 0.82);
+  }
+
+  .panel--red .now-ribbon {
+    border-top-color: rgba(242, 237, 225, 0.28);
   }
 
   .panel--yellow .stack-label,


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Refactor the About > NOW \"Last updated\" closer to use the same two-line ribbon pattern as the Vibe Coding (Stack), Community (Scope), and other panel footers:

\`\`\`
───────────
LAST UPDATED
April 2026
\`\`\`

(Was: a single inline \`Last updated · April 2026\` line.)

The horizontal rule is the existing \`border-top: 1px solid var(--rule)\` from the shared ribbon class. Label and date stack via \`flex-direction: column\`.

## Implementation

- **Markup** — Replace \`<p class="about-now-updated">\` with \`<div class="now-ribbon"><span class="now-ribbon-label">Last updated</span><span class="now-ribbon-date">{date}</span></div>\`.
- **CSS** — Drop the standalone \`.about-now-updated\` rule (which was a one-off duplicate of the ribbon styling) and add \`.now-ribbon\` / \`.now-ribbon-label\` / \`.now-ribbon-date\` to the existing joint selectors that already power Stack and Scope:
  - \`.stack-ribbon, .impact-ribbon, .now-ribbon\` for the layout (column flex + border-top + spacing)
  - \`.stack-label, .impact-label, .now-ribbon-label\` for the label typography (small caps, letterspaced, uppercase via \`text-transform\`)
  - \`.stack-items, .impact-items, .now-ribbon-date, .blog-callout-link\` for the body typography (slightly larger, muted)
  - Same opacity-transition group, same mobile font-size group, same \`.panel--red\` cream-on-color override (extended to cover the new label/date plus a matching \`border-top-color\` rule for the ribbon itself in the mobile context)
- **Casing**: \`text-transform: uppercase\` on the label so \`Last updated\` renders \`LAST UPDATED\`. Date kept in source title case (\`April 2026\`), matching the human-edited \`lastUpdated: "April 2026"\` field in \`src/content/bio/now.md\`.

## Verification

- \`npm run build\` clean (23 pages built).
- \`npm test\` 143/143 green; no test edits.
- Browser preview confirmed:
  - Desktop About > NOW block ends with the rule, \"LAST UPDATED\" line, then \"April 2026\". Computed styles match the Vibe Coding stack-ribbon (\`flex-direction: column\`, \`border-top: 1px solid rgba(17,16,13,0.18)\`, label \`text-transform: uppercase\`).
  - Mobile (\`375x812\`): cream-on-red treatment applies cleanly to label, date, and the ribbon's top border, matching how Vibe Coding's stack-ribbon flips on mobile.

## Self-Review

- **Correctness.** Verified that the .stack-ribbon / .impact-ribbon parent selectors didn't carry layout assumptions specific to Stack/Scope (e.g., bottom-of-flex positioning) — they're position-agnostic and work in any flex column. The Now-ribbon sits as the last child of \`.about-block--now\` and renders correctly.
- **Regression risk.** Low. The deleted \`.about-now-updated\` class had three call sites (one main rule, two mobile-block rules); all three were updated to the new class names. No other selectors reference \`.about-now-updated\` after this change (verified via grep).
- **Style.** Class names follow the \`X-ribbon\`/\`X-label\`/\`X-items\` convention but use \`X-date\` for the items slot since this ribbon's body is semantically a date, not a list of items. CMOS em-dashes preserved in comments.
- **Test coverage.** No tests asserted the prior \`Last updated · {date}\` format. Existing tests (135 pre-existing + 8 from the prior bio-section PR) all pass.
- **Security / dependency hygiene.** No new deps; no client-side code; no protected paths.

## Test plan

- [ ] Pull branch, \`npm run dev\`, open About panel — confirm rule + LAST UPDATED + April 2026 stack matches the Stack ribbon visually
- [ ] Resize to mobile, confirm cream-on-red treatment applies to label, date, and rule color
- [ ] Compare rendered ribbon against Vibe Coding's Stack ribbon — typography, spacing, and rule color should be identical (modulo the panel-color overrides)
- [ ] Edit \`src/content/bio/now.md\` to bump \`lastUpdated\` to \"May 2026\", confirm the homepage updates on next build