### PR TITLE
content(home): tighten Vibe Coding copy

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -109,7 +109,7 @@ const homepageJsonLd = {
         <div class="panel-content">
           <div class="content-inner">
             <h2>Vibe Coding</h2>
-            <p>Every project started as a real problem. Each one was built end-to-end with AI agents—Claude Code, Codex, and Cursor—under a multi-agent code review system I designed to catch the failure modes agents don’t catch themselves. <a href="/blog/six-prs-one-bug-agent-failure-modes/" class="p-link">What agents actually get wrong →</a> · <a href="/blog/agent-approval-workflow-genesis-of-mergepath/" class="p-link">How the enforcement system works →</a></p>
+            <p>Every project started as a real problem. Each one was built end-to-end with AI agents—Claude Code, Codex, and Cursor—within a multi-agent code review system I designed to catch failure modes that agents don’t catch on their own. <a href="/blog/six-prs-one-bug-agent-failure-modes/" class="p-link">What agents get wrong →</a> · <a href="/blog/agent-approval-workflow-genesis-of-mergepath/" class="p-link">How the enforcement system works →</a></p>
             <div class="project-list">
               <div class="project-item">
                 <div class="p-head">


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Three-word-level copy edits to the Vibe Coding panel paragraph (per user request):

- \`under a multi-agent code review system\` → \`within a multi-agent code review system\`
- \`to catch the failure modes agents don't catch themselves\` → \`to catch failure modes that agents don't catch on their own\`
- Link text: \`What agents actually get wrong →\` → \`What agents get wrong →\`

Hrefs unchanged on both \`p-link\` anchors. Apostrophe in \`don't\` stays curly (U+2019), preserving the homepage consistency landed in #279.

## Verification

- \`npm run build\` clean.
- \`npm test\` 143/143 green.
- Browser preview: text and link labels render exactly as specified.

## Self-Review

- **Correctness.** Single \`<p>\` element, exact replace.
- **Regression risk.** None. No tests assert this string; no styling/structure changed.
- **Style.** Curly apostrophe preserved. CMOS em-dashes intact.
- **Test coverage.** N/A — content-only.
- **Security.** N/A.