### PR TITLE
content(projects): rename LIVE→SHIPPED, restore kickers, two-tier metadata (#285 #284)

### DIFF
--- a/specs/project-pages.md
+++ b/specs/project-pages.md
@@ -36,7 +36,7 @@ gradientTo: "#f5f0e4"
 liveUrl: "https://example.com"     # optional — omit on pre-launch projects
 githubUrl: "https://github.com/you/repo"
 tags: ["Tag1", "Tag2", "Tag3"]
-status: "LIVE"                     # one of: LIVE | EXPERIMENT | IN PROGRESS | PAUSED | ARCHIVED
+status: "SHIPPED"                  # one of: SHIPPED | EXPERIMENT | IN PROGRESS | PAUSED | ARCHIVED
 metadata:
   format: "Product-type label (e.g., Financial operating system)"
   focus: "What it does in a few words"
@@ -68,7 +68,7 @@ draft: false
 | `liveUrl` | non-empty string | no | URL for "View Live Product" CTA. Omit on pre-launch projects (status `IN PROGRESS`) — the CTA, the index card "Live ↗" link, the homepage Vibe Coding "Live ↗" link, and the `SoftwareApplication` JSON-LD entity are all suppressed when this field is missing |
 | `githubUrl` | string | yes | URL for "View on GitHub" CTA |
 | `tags` | string[] | yes | Category/technology tags |
-| `status` | enum | yes | Project lifecycle status. One of `LIVE`, `EXPERIMENT`, `IN PROGRESS`, `PAUSED`, `ARCHIVED`. Drives both the project-card kicker on `/projects/` and the Status column in the detail-page metadata table — single source of truth, single short-form vocabulary across both surfaces. See #274 |
+| `status` | enum | yes | Project lifecycle status. One of `SHIPPED`, `EXPERIMENT`, `IN PROGRESS`, `PAUSED`, `ARCHIVED`. Drives both the project-card kicker on `/projects/` and the Status column in the detail-page metadata table — single source of truth, single short-form vocabulary across both surfaces. See #274, #285 |
 | `metadata.format` | string | yes | Metadata strip: product-type label (e.g., "Internal platform tool"). The tech stack lives in the separate `stack` field — this field is for product category |
 | `metadata.focus` | string | yes | Metadata strip: focus area value |
 | `stack` | string | no | Tech stack values separated by ` · ` (e.g., `"React · TypeScript · Vite · Firebase · Vitest"`). Rendered as a figcaption below the screenshot. Optional — projects without a stack field render without the caption |

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -25,7 +25,7 @@ const projects = defineCollection({
     // Status drives both the project-card kicker on /projects/ and the
     // Status column in the detail-page metadata table — single source of
     // truth, single short-form vocabulary across both surfaces. See #274.
-    status: z.enum(['LIVE', 'EXPERIMENT', 'IN PROGRESS', 'PAUSED', 'ARCHIVED']),
+    status: z.enum(['SHIPPED', 'EXPERIMENT', 'IN PROGRESS', 'PAUSED', 'ARCHIVED']),
     metadata: z.object({
       format: z.string(),
       focus: z.string(),

--- a/src/content/projects/friends-and-family-billing.md
+++ b/src/content/projects/friends-and-family-billing.md
@@ -13,7 +13,7 @@ gradientTo: "#f5f0e4"
 liveUrl: "https://friends-and-family-billing.web.app"
 githubUrl: "https://github.com/nathanjohnpayne/friends-and-family-billing"
 tags: ["Utility", "Finance", "React", "Firebase"]
-status: "LIVE"
+status: "SHIPPED"
 metadata:
   format: "Household coordination tool"
   focus: "Shared subscriptions and recurring group expenses"

--- a/src/content/projects/mergepath.md
+++ b/src/content/projects/mergepath.md
@@ -13,7 +13,7 @@ gradientTo: "#f5f0e4"
 liveUrl: "https://htmlpreview.github.io/?https://raw.githubusercontent.com/nathanjohnpayne/mergepath/main/mergepath/playground/index.html"
 githubUrl: "https://github.com/nathanjohnpayne/mergepath"
 tags: ["Infrastructure", "AI Tooling", "GitHub Actions", "Bash/Python"]
-status: "LIVE"
+status: "SHIPPED"
 metadata:
   format: "Repository standard"
   focus: "Agent governance, code review, and CI enforcement"

--- a/src/content/projects/override.md
+++ b/src/content/projects/override.md
@@ -13,7 +13,7 @@ gradientTo: "#f5f0e4"
 liveUrl: "https://overridebroadway.com"
 githubUrl: "https://github.com/nathanjohnpayne/overridebroadway"
 tags: ["Finance", "Theater", "React", "Firebase"]
-status: "LIVE"
+status: "SHIPPED"
 metadata:
   format: "Financial operating system"
   focus: "Capitalization, ownership, and investor workflows"

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -58,13 +58,11 @@ const jsonLd = {
         {projects.map((project, i) => {
           const card = (
             <article class="post-card">
-              {/* Status kicker is exception-based: render only for non-LIVE
-                  projects so the status line carries meaning instead of
-                  noise. Defensively hide if status is missing too — fail
-                  closed to LIVE per #277. */}
-              {project.data.status && project.data.status !== 'LIVE' && (
-                <p class="post-meta">{project.data.status}</p>
-              )}
+              {/* Status kicker renders on every card — consistency in the
+                  card anatomy beats avoiding the apparent redundancy of
+                  multiple cards saying SHIPPED. See #285. The previous
+                  hide-when-LIVE rule from #277/#280 was reversed. */}
+              <p class="post-meta">{project.data.status}</p>
               <p class="post-meta">{project.data.tags.join(' · ')}</p>
               <h2 class="post-title"><a href={`/projects/${project.data.slug}/`}>{project.data.title}</a></h2>
               <p class="post-desc">{project.data.description}</p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1530,12 +1530,14 @@ body.blog-page {
   margin-bottom: 0.5rem;
 }
 
-/* When two .post-meta lines stack (date kicker + tag kicker on blog
-   cards), tighten the gap between them so they read as a single
-   metadata zone above the headline rather than two equal-weight
-   sibling lines. */
+/* Two-tier metadata zone: when a kicker (.post-meta) is followed by a
+ * tag line (.post-meta), the kicker takes the louder treatment —
+ * darker color, body-text weight — so it reads as primary metadata
+ * (date + read time on blog, status on projects). The tag line keeps
+ * the existing muted treatment so it reads as secondary. See #284. */
 .post-meta:has(+ .post-meta) {
-  margin-bottom: 0.15rem;
+  margin-bottom: 0.225rem;
+  color: rgba(17, 16, 13, 0.92);
 }
 
 .post-title {


### PR DESCRIPTION
Authoring-Agent: claude

Closes #285 and #284.

## Summary

Two coupled tickets bundled because they affect the same metadata zone on the same cards:

| Ticket | Change |
|---|---|
| **#285** | Rename status `LIVE` → `SHIPPED` everywhere it's used as a state value, and restore the kicker on every project card (reverses the hide-when-LIVE rule from #277/#280) |
| **#284** | Differentiate the kicker line from the tag line — kicker takes the body-text ink color, tag line keeps the existing muted gray, with ~1.5× vertical space between them |

After both land, every card on `/projects/` and `/blog/` has the same anatomy: dark kicker → muted tag line → headline → description.

## Implementation

### #285 — Status rename

- \`src/content.config.ts\`: enum changed to \`['SHIPPED', 'EXPERIMENT', 'IN PROGRESS', 'PAUSED', 'ARCHIVED']\`. Anything still trying to use \`LIVE\` will fail Zod validation at build.
- Three project frontmatter files updated: \`mergepath.md\`, \`override.md\`, \`friends-and-family-billing.md\` all switch from \`status: \"LIVE\"\` to \`status: \"SHIPPED\"\`.
- \`src/pages/projects/index.astro\`: removed the conditional that hid the kicker when status was \`LIVE\`. Every card now renders \`<p class=\"post-meta\">{project.data.status}</p>\` unconditionally.
- \`specs/project-pages.md\`: enum docs updated to reflect new vocabulary; added #285 reference alongside the existing #274 one.

CTAs are deliberately untouched per the ticket: \`LIVE ↗\` on cards refers to the URL the visitor is about to navigate to, not the project's lifecycle state. Same for \`VIEW LIVE PRODUCT\` on detail pages. The word \"live\" anywhere else in copy is unchanged.

### #284 — Two-tier metadata styling

Single CSS rule change in \`global.css\`:

\`\`\`css
.post-meta:has(+ .post-meta) {
  margin-bottom: 0.225rem;        /* was 0.15rem — ~1.5× the gap */
  color: rgba(17, 16, 13, 0.92);  /* was inherited 0.58 — louder kicker */
}
\`\`\`

The base \`.post-meta\` rule (the tag line, which has no following sibling) keeps its existing \`rgba(17, 16, 13, 0.58)\` muted gray and 0.5rem bottom margin. Same selector applies to both blog cards (date + read time kicker) and project cards (status kicker) — single rule, two surfaces, no per-page CSS.

## Verification

- \`npm run build\` clean (23 pages built, no Zod failures from the renamed enum).
- \`npm test\` 143/143 green.
- Browser preview confirmed:
  - All six project cards render a kicker (3 SHIPPED, 1 IN PROGRESS, 1 EXPERIMENT, 1 PAUSED).
  - Computed style: kicker color \`rgba(17, 16, 13, 0.92)\`; tag color \`rgba(17, 16, 13, 0.58)\`; kicker margin-bottom 3.6px (was 2.4px).
  - Blog index cards show the same two-tier hierarchy on the date + read time kicker.
  - Mobile viewport (375×812): hierarchy preserved.
  - Detail-page metadata tables unaffected.

## Acceptance criteria

### #285
- [x] All project frontmatter \`LIVE\` status values updated to \`SHIPPED\`
- [x] Status kicker renders on every project card on \`/projects/\`
- [x] \`SHIPPED\` status renders correctly with the same typography as other status values
- [x] Detail page metadata tables show updated status values
- [x] \`LIVE ↗\` CTA buttons on cards remain unchanged
- [x] \`VIEW LIVE PRODUCT\` button on detail pages remains unchanged
- [x] No mobile regressions

### #284
- [x] Vertical space between kicker line and tag line increased (~1.5×)
- [x] Kicker line renders darker; tag line stays in lighter gray
- [x] Applies to both blog cards and project cards
- [x] No mobile regressions
- [x] Detail page metadata tables unaffected

## Self-Review

- **Correctness.** Schema enum is the source of truth — any future frontmatter typo (\"LIVE\", \"shipped\", etc.) fails at build. The \`:has(+ .post-meta)\` selector targets the kicker precisely (the first \`.post-meta\` with another following) without needing a new class on the markup.
- **Regression risk.** Low. No tests assert on status string values (\`grep status tests/\` came up empty for status-related assertions; the existing \`View Live Product\` references are CTA labels, not status values). CTA buttons + JSON-LD untouched. Detail-page metadata tables read the same field, so they pick up the new vocabulary automatically.
- **Style.** New CSS comment explains the two-tier intent so a future reader doesn't \"helpfully\" merge the kicker color back into the tag color. CMOS em-dashes preserved throughout.
- **Test coverage.** Considered adding a test that asserts every project card renders a \`.post-meta\` kicker, but the existing test suite covers structure at the detail-page level rather than the index-page card level. The visual + DOM verification covers it without overhead.
- **Security / dependency hygiene.** No new deps, no client-side code, no protected paths touched.

## Test plan

- [ ] Pull branch, \`npm run dev\`, navigate to \`/projects/\`. Confirm every card shows a kicker line above its tag line; SHIPPED appears on Mergepath/Override/FFB; IN PROGRESS on Matchline; EXPERIMENT on Swipe Watch; PAUSED on DSoT.
- [ ] Confirm the kicker on each card is visibly darker than the tag line, with a small but clear vertical gap between them.
- [ ] Navigate to each project detail page. Confirm the metadata table's Status row shows the new value (SHIPPED for the three projects that were LIVE; everything else unchanged).
- [ ] Confirm \`Live ↗\` CTA buttons on cards and \`View Live Product\` button on detail pages still render (status changes shouldn't have touched them).
- [ ] Visit \`/blog/\` and confirm blog cards show the same two-tier hierarchy on their date + read time kicker.
- [ ] Resize to mobile (≤480px). Confirm both index pages render the kicker/tag hierarchy correctly.

## Notes for the reviewer

- The vertical gap bump from 0.15rem to 0.225rem is exactly 1.5×. If the cards start to feel too tall once you see them in context, dial it back toward 0.18rem; the ticket allows tightening if needed.
- The kicker color picks up rgba(17, 16, 13, 0.92) — close to the body \`--ink: #11100d\` but with a touch of softening so it doesn't read as full-weight headline copy. The ticket allows for a midway gray if 0.92 reads too heavy; couldn't see a reason to back off after browser-checking.