### PR TITLE
content(matchline): expand description to the full one-liner

### DIFF
--- a/src/content/projects/matchline.md
+++ b/src/content/projects/matchline.md
@@ -1,7 +1,7 @@
 ---
 title: "Matchline"
 slug: "matchline"
-description: "From what you've done to what's next."
+description: "A career operating system for one person running a serious job search. Turns work history into structured, reusable evidence, maps it against specific job requirements, and generates tailored applications grounded in what the user has actually done."
 kicker: "AI × Product × Career Tools"
 order: 1
 status: "IN PROGRESS"


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Single frontmatter edit on \`src/content/projects/matchline.md\`:

- **Was:** \`description: \"From what you've done to what's next.\"\`
- **Now:** \`description: \"A career operating system for one person running a serious job search. Turns work history into structured, reusable evidence, maps it against specific job requirements, and generates tailored applications grounded in what the user has actually done.\"\`

The frontmatter \`description\` field drives both surfaces in scope:

- **\`/projects/\` index card** — \`<p class=\"post-desc\">\` rendered via the existing card template
- **\`/projects/matchline/\` detail page header** — \`.deck\` rendered in the project hero

One field, two surfaces, both verified rendering the new copy.

This brings the project surfaces into line with the homepage Vibe Coding card, which already uses the long version (since 76c2a45). Three surfaces now carry the same Matchline messaging.

## Verification

- \`npm run build\` clean (23 pages built).
- \`npm test\` 143/143 green.
- Browser preview at \`/projects/\` and \`/projects/matchline/\`: both render the new long description.

## Self-Review

- **Correctness.** Single frontmatter string change. Schema validates as a non-empty string; passes.
- **Regression risk.** None. No tests assert on the description string. No structural change. The OG card description in \`src/pages/og-templates/projects/matchline.astro\` is a separate hard-coded copy and stays as it was — out of scope per the user's ticket.
- **Style.** No apostrophes in the new copy, so no smartypants/curly-quote concerns.
- **Test coverage.** N/A — content-only.
- **Security.** N/A.