### PR TITLE
content(matchline): reframe as "career CRM" not "operating system" (#288)

### DIFF
--- a/src/content/projects/matchline.md
+++ b/src/content/projects/matchline.md
@@ -1,7 +1,7 @@
 ---
 title: "Matchline"
 slug: "matchline"
-description: "A career operating system for one person running a serious job search. Turns work history into structured, reusable evidence, maps it against specific job requirements, and generates tailored applications grounded in what the user has actually done."
+description: "A career CRM for one person running a serious job search. Turns work history into structured, reusable evidence, maps that evidence against specific job requirements, and generates applications grounded in what the user has actually done. Not a resume builder—a discipline."
 kicker: "AI × Product × Career Tools"
 order: 1
 status: "IN PROGRESS"
@@ -24,7 +24,7 @@ related:
 
 ## Overview
 
-Matchline is a career operating system built for one person at a time, running a serious job search. It turns work history into structured, reusable evidence, maps that evidence against specific job requirements, and generates tailored applications grounded in what the user has actually done—not in what an AI can plausibly invent.
+Matchline is a career CRM built for one person at a time, running a serious job search. It functions as an evidence-based application engine: it turns work history into structured, reusable evidence, maps that evidence against specific job requirements, and generates applications grounded in what the user has actually done—not in what an AI can plausibly invent.
 
 This is not a resume builder. It's a discipline.
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -123,7 +123,7 @@ const homepageJsonLd = {
                   <a class="p-name p-name-link" href="/projects/matchline/" aria-label="Read the Matchline project page">Matchline</a>
                   <span class="p-tag">AI × Product × Career Tools</span>
                 </div>
-                <p>A career operating system for one person running a serious job search. Turns work history into structured, reusable evidence, maps it against specific job requirements, and generates tailored applications grounded in what the user has actually done.</p>
+                <p>A career CRM for one person running a serious job search. Turns work history into structured, reusable evidence, maps that evidence against specific job requirements, and generates applications grounded in what the user has actually done. Not a resume builder—a discipline.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">

--- a/src/pages/og-templates/projects/matchline.astro
+++ b/src/pages/og-templates/projects/matchline.astro
@@ -5,6 +5,6 @@ import OgCard from '../../../layouts/OgCard.astro';
 <OgCard
   label="nathanpayne.com / projects"
   heading="Matchline"
-  description="A career operating system for one person running a serious job search. Turns work history into structured, reusable evidence and assembles tailored applications grounded in what the user has actually done."
+  description="A career CRM for one person running a serious job search. Turns work history into structured, reusable evidence and assembles applications grounded in what the user has actually done."
   meta="AI · Product · Career Tools"
 />


### PR DESCRIPTION
Authoring-Agent: claude

Closes #288.

## Summary

Matchline currently leans on \"career operating system\" framing while Override leans on \"financial operating system\" — two of six projects sharing the same big-claim phrase flattens it into a signature tic. Matchline has stronger native descriptors (\"career CRM,\" \"evidence-based application engine\") that don't need to borrow OS to carry weight. Override has earned the OS framing; this PR reserves it for Override.

## Changes

Four surfaces, all switched to lead with **career CRM**:

| Surface | File | Change |
|---|---|---|
| Project index card | \`src/content/projects/matchline.md\` (frontmatter \`description\`) | Card-canonical text from the ticket |
| Detail page deck | same file (same field) | One field, two surfaces |
| Detail page body | same file (Overview body) | Lead paragraph reframed; weaves in \"evidence-based application engine\" as the supporting descriptor per ticket guidance |
| OG card | \`src/pages/og-templates/projects/matchline.astro\` | Punchier variant — drops \"tailored,\" leads with career CRM |
| Homepage Vibe Coding | \`src/pages/index.astro\` | Same card-canonical text |

Per the ticket's card spec, every card-shaped surface also drops \"tailored\" before \"applications\" (the rest of the sentence already establishes tailoring) and adds \"Not a resume builder—a discipline.\" as the closer.

The body's existing \"This is not a resume builder. It's a discipline.\" line stays as-is — the body has room for the two-sentence rhythm; the card needs the punchier em-dash form.

## Verification

- \`npm run build\` clean (23 pages built).
- \`npm test\` 143/143 green.
- Browser preview: confirmed all four surfaces render \"career CRM\" lead and the new card-canonical paragraph (where applicable).
- \`grep -rn \"operating system\" src/ specs/\` shows only Override references remain (expected: 4 — frontmatter description, metadata.format, homepage card, OG card).

## Acceptance criteria

- [x] Matchline project card on the projects index uses \"career CRM\" framing
- [x] Homepage Vibe Coding section Matchline card uses \"career CRM\" framing
- [x] Matchline detail page reframed; \"career CRM\" appears as the primary descriptor; \"evidence-based application engine\" supports it later in the body
- [x] Override copy unchanged
- [x] No other project copy uses \"operating system\" framing (verified via grep)
- [x] No mobile regressions

## Self-Review

- **Correctness.** Verified via DOM inspection on \`/projects/\`, \`/projects/matchline/\`, and \`/\` (homepage Vibe Coding). All three card-shaped surfaces carry the same card-canonical text; the detail-page body uses the longer reframe with the supporting descriptor.
- **Regression risk.** None. Frontmatter \`description\` field is the same shape (string), tests don't assert on description content, and the OG card only changes its hardcoded text. JSON-LD on the detail page that pulls from \`description\` automatically picks up the new copy.
- **Style.** CMOS em-dash (no spaces) preserved. Apostrophes left as-is in the body's existing prose.
- **Test coverage.** N/A — content-only.
- **Security.** N/A.