### PR TITLE
content(matchline): rebuild detail body from PRD; fix deck/body repeat

### DIFF
--- a/src/content/projects/matchline.md
+++ b/src/content/projects/matchline.md
@@ -16,7 +16,7 @@ tags: ["AI", "Product", "Career Tools"]
 metadata:
   format: "Single-user web app"
   focus: "Evidence-based application generation, capability mapping, pipeline management"
-stack: "TypeScript · Next.js · Vitest"
+stack: "React · TypeScript · Vite · Firebase · Vitest"
 related:
   - label: "Project: Mergepath"
     href: "/projects/mergepath/"
@@ -24,24 +24,26 @@ related:
 
 ## Overview
 
-Matchline is a career CRM built for one person at a time, running a serious job search. It functions as an evidence-based application engine: it turns work history into structured, reusable evidence, maps that evidence against specific job requirements, and generates applications grounded in what the user has actually done—not in what an AI can plausibly invent.
+Two things changed in the 2026 job market that weren't true three years ago. Anyone can generate a tailored résumé and cover letter in seconds with ChatGPT, so the floor of "looks reasonable" has collapsed—every application is polished, and polish is no longer a signal. At the same time, recruiters and hiring managers are drowning in AI-generated applications that are technically on-target but substantively empty. Credibility and specificity are the new signal.
 
-This is not a resume builder. It's a discipline.
+Most "AI for job search" tools are generative writers: take a job description, take a résumé, produce a new document. The output reads well and means almost nothing—because the model doesn't know which projects mattered, which numbers are honest, which claims the user can defend in an interview. The artifact is glossy; the foundation is a guess.
 
-## Why this exists
+Matchline inverts the order. It treats the user's work history as a structured graph of capabilities, outcomes, and evidence—built up once, refined over time—and uses AI only to assemble that evidence against a specific opportunity. The model never invents; it selects, sequences, and frames what the user has already documented. The result is application material the user can stand behind in an interview, because every claim traces back to a captured event in their own history.
 
-Most "AI for job search" tools are generative writers: they take a job description, take a résumé, and produce a new document. The output reads well and means almost nothing—because the model doesn't know which projects mattered, which numbers are honest, which claims the user can defend in an interview. The artifact is glossy; the foundation is a guess.
+## The core loop
 
-Matchline inverts the order. It treats the user's work history as a structured graph of capabilities, outcomes, and evidence—built up once, refined over time—and uses AI only to assemble that evidence against a specific opportunity. The model never invents; it selects, sequences, and frames what the user has already documented.
+Four steps. Each one has a clear input, output, and quality bar. If any step breaks, the product doesn't work; if all four work, Matchline is useful even before any of the V2 layers ship on top.
 
-The result is application material that the user can stand behind in an interview, because every claim traces back to a captured event in their own history.
+1. **Career → Experience Units.** Pasted résumé, LinkedIn HTML, long-form prose, or uploaded artifacts (PRDs, decks, retros) feed an extraction pipeline that produces atomic, verifiable claims. Each Unit carries skills, tools, domains, metrics, and a confidence score, and is owned by the user rather than scraped from a résumé. The user reviews and approves before anything enters the graph.
+2. **Job → Requirement Units.** A pasted JD parses into structured requirements with priority, must-have flags, and signals (seniority, scope, domain). Mostly deterministic parsing plus light LLM classification—cheaper than extraction, but the matches downstream are only as right as the requirements upstream.
+3. **Match Units to Requirements.** The matching engine scores each Experience Unit against each Requirement using semantic similarity, skill/tool/domain overlap, seniority and scope alignment, and recency. Output is a side-by-side view with explainable scores and rationales. Gaps are surfaced honestly, not hidden. The user approves or rejects each match.
+4. **Generate.** Using only matches the user has approved, the engine produces a tailored résumé and optional cover letter. Every claim traces back to an approved Unit.
 
-## What V1 does
+## Zero fabrication
 
-- **Captures work history as evidence.** Projects, roles, outcomes, decisions, scope changes—entered once, structured for reuse, owned by the user rather than scraped from a résumé.
-- **Maps capabilities against opportunities.** A target job description is decomposed into requirements; the user's evidence graph is searched for the strongest matches; gaps are surfaced explicitly.
-- **Generates application material grounded in evidence.** Cover letters, narrative bullets, and interview prep notes assembled from the evidence graph, with citations back to the source events.
-- **Tracks the pipeline.** Where each application is in the funnel, what was sent, what was said in the interview, what to follow up on—replacing the spreadsheet that every job seeker eventually builds.
+The hard constraint that makes the rest of the product trustworthy: no generated output contains a claim that isn't grounded in approved evidence. A validation layer sits between generation and the user—every claim is parsed, traced back to its Experience Unit, flagged inline if the trace breaks, and held off the editor until the user resolves it (by editing, removing, or supplying a supporting Unit). The model can never quietly invent; if it tries, validation catches it before the user does.
+
+This is a hard constraint, not a target. The full-flow latency budget is under twenty seconds at p95 and the per-application cost budget is under one dollar—both designed so the constraint stays cheap enough to enforce on every generation.
 
 ## Status
 


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

The Matchline detail page was restating the deck verbatim in its Overview paragraph (you flagged this). Other project pages — Override's investing anecdote, Mergepath's origin story — use Overview to add fresh narrative, not to paraphrase the deck. This PR brings Matchline into line by drawing fresh body content from the actual PRD at \`~/GitHub/docs/projects/matchline/matchline-prd.md\`.

## Changes

**Overview** — leads with the 2026 market thesis (the floor of \"looks reasonable\" has collapsed; credibility and specificity are the new signal), then the inversion narrative (most AI-for-job-search tools are generative writers; Matchline treats the work history as evidence and uses AI only to assemble it). Three paragraphs of substantive setup that the deck doesn't carry.

**The core loop** — new section. Four numbered steps (Career → Experience Units → Job → Requirement Units → Match → Generate) with each step's responsibilities spelled out per the PRD's Product Structure section. Replaces the prior generic \"What V1 does\" bullet list, which was lower-resolution than the PRD content and read as a feature checklist rather than an architecture.

**Zero fabrication** — new section. Explains the validation layer as the hard constraint that makes the rest of the product trustworthy, with the PRD's published latency budget (<20s p95) and cost budget (<$1 per application) so it reads as engineering rather than aspiration.

**Status** — unchanged.

**Frontmatter \`stack\`** — corrected from the misleading \`TypeScript · Next.js · Vitest\` to \`React · TypeScript · Vite · Firebase · Vitest\` to match the PRD's declared stack and the sister Firebase apps (Friends & Family Billing, Device Source of Truth).

## Verification

- \`npm run build\` clean (23 pages built — schema validates the new stack string).
- \`npm test\` 143/143 green.
- Browser preview: deck text no longer appears in body (\`deckRepeatedInBody: 0\` via DOM check). Sections render in order: Overview → The core loop → Zero fabrication → Status → Related.

## Acceptance criteria

- [x] Header (deck) and Overview body no longer repeat
- [x] Body draws from the PRD as source
- [x] Frontmatter stack accurately describes the implementation per the PRD
- [x] No mobile regressions

## Self-Review

- **Correctness.** Verified rendering on \`/projects/matchline/\`. Deck still carries the elevator-pitch sentence; body now adds market context, the four-step architecture, and the zero-fabrication constraint — all distinct from the deck.
- **Regression risk.** None. Body content lives in the markdown body (unconstrained shape); the only frontmatter change is \`stack\` (a string field, schema unchanged).
- **Style.** CMOS em-dashes preserved throughout. Apostrophes in the new prose are straight in source; remark/smartypants converts them to U+2019 in render, matching site convention. Lists use ordered numerals where the order matters (the four-step loop).
- **Test coverage.** N/A — content-only.
- **Security.** N/A.

## Test plan

- [ ] Visit \`/projects/matchline/\`. Confirm the deck text no longer appears verbatim in the Overview paragraphs.
- [ ] Read the page top-to-bottom. Confirm the Overview adds context that the deck doesn't, the core loop reads as architecture (not just features), and the zero-fabrication section explains the validation constraint with concrete latency/cost numbers.
- [ ] Confirm the metadata strip's Stack value reads \`React · TypeScript · Vite · Firebase · Vitest\`.
- [ ] Resize to mobile (≤480px). Confirm body sections stack and read cleanly.