### PR TITLE
content(matchline): fix list-marker bug, double wordmark, add tech tags

### DIFF
--- a/src/content/projects/matchline.md
+++ b/src/content/projects/matchline.md
@@ -12,11 +12,11 @@ accentColorClass: "project-page--black"
 gradientFrom: "#dde1e5"
 gradientTo: "#f5f0e4"
 githubUrl: "https://github.com/nathanjohnpayne/matchline"
-tags: ["AI", "Product", "Career Tools"]
+tags: ["AI", "Product", "Career Tools", "React", "Firebase"]
 metadata:
   format: "Single-user web app"
   focus: "Evidence-based application generation, capability mapping, pipeline management"
-stack: "React · TypeScript · Vite · Firebase · Vitest"
+stack: "React · TypeScript · Vite · Tailwind · Firebase · Anthropic · OpenAI · Vitest"
 related:
   - label: "Project: Mergepath"
     href: "/projects/mergepath/"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1107,7 +1107,7 @@ body.blog-page {
   border-top-color: var(--ink);
 }
 .project-page--black .project-screenshot__inner {
-  max-width: 28rem;
+  max-width: 56rem;
   margin: 0 auto;
   padding: clamp(2rem, 6vw, 4rem) clamp(1rem, 4vw, 2.5rem);
 }
@@ -1210,22 +1210,42 @@ body.blog-page {
   margin-top: 0.8rem;
 }
 
-.project-copy ul {
-  list-style: none;
+.project-copy ul,
+.project-copy ol {
   display: grid;
   gap: 0.7rem;
-  padding: 0;
   margin: 0.5rem 0 0;
 }
 
+/* Unordered lists get a custom accent square via ::before, so suppress
+ * the default disc and let ::before sit at left: 0. Ordered lists keep
+ * the default decimal counter — without this split, ol items rendered
+ * both the decimal AND the accent square (the "1. ▪ Career…" bug). */
+.project-copy ul {
+  list-style: none;
+  padding: 0;
+}
+
+.project-copy ol {
+  list-style: decimal;
+  padding-left: 1.4rem;
+}
+
 .project-copy li {
-  position: relative;
-  padding-left: 1rem;
   font-size: clamp(0.95rem, 0.92rem + 0.14vw, 1.02rem);
   line-height: 1.65;
 }
 
-.project-copy li::before {
+.project-copy ul li {
+  position: relative;
+  padding-left: 1rem;
+}
+
+.project-copy ol li {
+  padding-left: 0.4rem;
+}
+
+.project-copy ul li::before {
   content: "";
   position: absolute;
   top: 0.5em;
@@ -1233,6 +1253,11 @@ body.blog-page {
   width: 0.42rem;
   height: 0.42rem;
   background: var(--project-accent);
+}
+
+.project-copy ol li::marker {
+  color: var(--project-accent);
+  font-variant-numeric: tabular-nums;
 }
 
 /* In-content links — clearly marked, accent-colored, with a hover that

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1255,8 +1255,12 @@ body.blog-page {
   background: var(--project-accent);
 }
 
+/* Use the same contrast-corrected color the in-content links use.
+ * Themes whose accent fails body-text contrast on cream (e.g. the
+ * yellow Override theme) override --project-link-color with a darker
+ * variant; piggyback on that here so the ol decimals stay legible. */
 .project-copy ol li::marker {
-  color: var(--project-accent);
+  color: var(--project-link-color, var(--project-accent));
   font-variant-numeric: tabular-nums;
 }
 


### PR DESCRIPTION
Authoring-Agent: claude

Three polish items spotted on \`/projects/matchline/\` after the body rebuild:

## 1. List-marker bug — \"1. ▪ Career → Experience Units\"

The new \"The core loop\" section uses an ordered list, but \`.project-copy li::before\` was applying the unordered-list accent square to *every* \`li\` regardless of parent. Result: ordered list items were rendering the decimal counter \`1.\` *and* the square bullet \`▪\` side by side.

Fix: split the \`.project-copy\` list styles so \`ul\` keeps its custom \`::before\` square (with the existing accent fill) and \`ol\` gets the default decimal counter — plus a \`::marker { color: var(--project-accent) }\` so the numbers adopt the per-project accent color. Per-list padding is tuned to each marker shape.

## 2. Double the matchline wordmark in the hero

\`.project-page--black .project-screenshot__inner { max-width: 28rem }\` → \`56rem\`. Rendered width on desktop goes from ~448px to ~816px (figure padding eats some of the cap, so it lands at ~1.8× rather than a true 2×). \`clamp()\` padding stays the same so mobile still adapts.

If 56rem reads too big once you see it in context, dial back toward 44rem — the wordmark's intrinsic ratio (320×72) means width changes propagate directly to height.

## 3. Stack on the projects index card

The matchline frontmatter \`tags\` were domain-only (\`AI · Product · Career Tools\`) — the only project on the index whose card didn't surface any tech. Other Firebase apps (Friends & Family Billing, Device Source of Truth) and Override all mix domain + tech in their tags. Added \`React\` and \`Firebase\` to bring matchline into line.

Also expanded the project-detail \`stack\` field to include Tailwind, Anthropic, and OpenAI per the PRD's full stack declaration. Renders in the metadata-strip Stack value: \`React · TypeScript · Vite · Tailwind · Firebase · Anthropic · OpenAI · Vitest\`.

## Verification

- \`npm run build\` clean (23 pages built — schema validates the expanded tags + stack).
- \`npm test\` 143/143 green.
- DOM verification on \`/projects/matchline/\`:
  - \`ol li\`: \`listStyleType: decimal\`, \`::before\` content \`none\`, \`::marker\` color matches \`--project-accent\` — no double markers.
  - Wordmark img: 816 × 184px (was ~448 × ~91).
  - Stack value: full 8-item list rendered in metadata strip.
- DOM verification on \`/projects/\`:
  - Matchline card tag line: \`AI · Product · Career Tools · React · Firebase\`.

## Self-Review

- **Correctness.** Three independent fixes verified in the DOM. The list fix preserves the existing accent-square treatment for \`ul\` (so other project pages with bullet lists are unaffected) while correcting the \`ol\` rendering only.
- **Regression risk.** Low. The list CSS split is additive — the existing \`ul\` behavior is preserved verbatim; new \`ol\` rules only fire on ordered lists, which only matchline currently uses. The wordmark cap change is scoped to \`.project-page--black\` (matchline only). Tag/stack changes are content edits.
- **Style.** CMOS conventions preserved. New CSS comments explain the why for both the list split and the bug it prevents.
- **Test coverage.** No tests assert on list rendering or wordmark dimensions.
- **Security.** N/A.