### PR TITLE
gh-projects(matchline): resolve parent issue numbers dynamically

### DIFF
--- a/scripts/gh-projects/examples/matchline/additions/add-plan-refinements.sh
+++ b/scripts/gh-projects/examples/matchline/additions/add-plan-refinements.sh
@@ -27,9 +27,27 @@ export PROJECT=6
 # shellcheck source=../../../lib.sh
 source "$SCRIPT_DIR/../../../lib.sh"
 
-# Existing parents
-P0_NUM=5
-P1_NUM=15
+# Resolve existing parent issue numbers by exact title. Issue numbers are
+# repo-global, so they cannot be hardcoded — re-running create-issues.sh in a
+# repo with prior issues will not place parents at #5/#15.
+find_parent_num() {
+  local title="$1"
+  local num
+  num=$(gh issue list --repo "$REPO" --state all --limit 200 \
+    --search "in:title \"$title\"" \
+    --json number,title \
+    --jq ".[] | select(.title == \"$title\") | .number" \
+    | head -1)
+  if [ -z "$num" ]; then
+    echo "ERROR: could not find parent issue with title: $title" >&2
+    return 1
+  fi
+  echo "$num"
+}
+
+P0_NUM=$(find_parent_num "Phase 0: Foundations & access")
+P1_NUM=$(find_parent_num "Phase 1: Core loop (Career → Experience Units → Matching → Application)")
+echo "Resolved parents: P0=#$P0_NUM, P1=#$P1_NUM"
 
 # -----------------------------------------------------------------------------
 # Phase 0 additions


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Follow-up to [#263](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/263). Addresses the Codex P2 finding that was deferred at merge time: `add-plan-refinements.sh` had hardcoded `P0_NUM=5` / `P1_NUM=15`, which only hold against a fresh `nathanjohnpayne/matchline` repo. If `create-issues.sh` runs after the repo already contains other issues, parents land at different numbers and the additions silently miswire to the wrong parent.

This replaces the hardcoded constants with a title-based lookup via `gh issue list --search`. The lookup fails loudly (non-zero exit, error to stderr) when no exact-title match is found, so a misconfigured run aborts before creating mismatched children.

## Self-Review

- **Correctness**: `find_parent_num` queries by title, then filters with `select(.title == "...")` to require an exact match (the `--search` query alone is fuzzy). Returns the lowest issue number on collision via `head -1`, which matches the original create-issues.sh ordering. Fails non-zero when nothing matches; `set -euo pipefail` propagates the failure.
- **Regression risk**: Low. The script is one-shot and not idempotent (per its own header) — already run successfully against the matchline repo. This change only affects future re-runs against fresh repos.
- **Style**: Inlined the helper in the script rather than adding to `lib.sh`, since it's specific to the additions driver and doesn't generalize cleanly. Echo line on resolution mirrors the existing logging style.
- **Test coverage**: No automated tests for these example scripts; verification is manual run against the matchline repo. Bash syntax check passes.
- **Security/dependency hygiene**: No new deps. Title interpolation into the `--search` query is bounded to repo titles we control. The `--jq` filter uses string equality, not eval.

## Test plan

- [ ] `bash -n scripts/gh-projects/examples/matchline/additions/add-plan-refinements.sh` passes
- [ ] CI lint passes
- [ ] Spot-check: `gh issue list --repo nathanjohnpayne/matchline --search 'in:title "Phase 0: Foundations & access"' --json number,title` returns the expected parent