### PR TITLE
content(matchline): inline SVG fallback so the wordmark stays crisp

### DIFF
--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -16,6 +16,9 @@
 // When `playbackId` is unset, falls back to the `fallbackSrc` image so the
 // hero never goes blank.
 
+import fs from 'node:fs';
+import path from 'node:path';
+
 interface Props {
   playbackId?: string;
   fallbackSrc: string;
@@ -36,6 +39,32 @@ const streamSrc = playbackId
 const posterSrc = playbackId
   ? `https://image.mux.com/${playbackId}/thumbnail.jpg?width=1280&time=0`
   : undefined;
+
+// Inline SVG fallbacks so the page's loaded webfonts (Inter) are
+// available to the SVG's text rendering. `<img src=*.svg>` sandboxes
+// the SVG and forces system-font fallback, which renders fuzzily once
+// the wordmark scales past its small intrinsic size — visible after
+// the Matchline hero was doubled in #291. Inline SVG renders crisply
+// because it's part of the document tree and inherits its font stack.
+const isSvgFallback = !playbackId && fallbackSrc.toLowerCase().endsWith('.svg');
+let inlineSvg: string | null = null;
+if (isSvgFallback) {
+  try {
+    const svgPath = path.join(process.cwd(), 'public', fallbackSrc.replace(/^\/+/, ''));
+    const raw = fs.readFileSync(svgPath, 'utf-8');
+    // Inject role + aria-label on the root <svg> so the inline element
+    // remains an accessible image with the same alt-equivalent text the
+    // <img> path would have provided.
+    inlineSvg = raw.replace(
+      /<svg\b/,
+      `<svg role="img" aria-label="${altText.replace(/"/g, '&quot;')}"`
+    );
+  } catch (err) {
+    // If the file isn't readable for any reason, fall back to the <img>
+    // path so the hero still renders something.
+    inlineSvg = null;
+  }
+}
 ---
 
 {playbackId ? (
@@ -51,6 +80,8 @@ const posterSrc = playbackId
       <img src={fallbackSrc} alt={altText} loading="eager" />
     </noscript>
   </>
+) : inlineSvg ? (
+  <Fragment set:html={inlineSvg} />
 ) : (
   <img src={fallbackSrc} alt={altText} loading="eager" />
 )}

--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -46,18 +46,48 @@ const posterSrc = playbackId
 // the wordmark scales past its small intrinsic size — visible after
 // the Matchline hero was doubled in #291. Inline SVG renders crisply
 // because it's part of the document tree and inherits its font stack.
+//
+// Sanitization caveat: `set:html` injects raw HTML into the document.
+// Even though `public/` files are author-controlled, scrub the
+// dangerous-in-page-context constructs (<script>, event handlers,
+// javascript: URLs, <foreignObject>) before injection so a future
+// SVG asset can't accidentally bring active content along. Also
+// escape the aria-label full-HTML-style before concatenation.
+const escapeAttr = (s: string) =>
+  s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const sanitizeSvg = (raw: string) =>
+  raw
+    // Strip <script>...</script> blocks (handles attributes + multiline).
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, '')
+    // Strip self-closing or unterminated <script> tags too.
+    .replace(/<script\b[^>]*\/?>/gi, '')
+    // Strip <foreignObject> (allows arbitrary HTML, including scripts).
+    .replace(/<foreignObject\b[^>]*>[\s\S]*?<\/foreignObject\s*>/gi, '')
+    .replace(/<foreignObject\b[^>]*\/?>/gi, '')
+    // Strip on* event attributes (onclick, onload, onmouseover, etc.).
+    .replace(/\s+on[a-z]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, '')
+    // Strip javascript: URLs (href, xlink:href, src attributes).
+    .replace(/(href|src)\s*=\s*("javascript:[^"]*"|'javascript:[^']*'|javascript:[^\s>]+)/gi, '$1=""');
+
 const isSvgFallback = !playbackId && fallbackSrc.toLowerCase().endsWith('.svg');
 let inlineSvg: string | null = null;
 if (isSvgFallback) {
   try {
     const svgPath = path.join(process.cwd(), 'public', fallbackSrc.replace(/^\/+/, ''));
     const raw = fs.readFileSync(svgPath, 'utf-8');
+    const safe = sanitizeSvg(raw);
     // Inject role + aria-label on the root <svg> so the inline element
     // remains an accessible image with the same alt-equivalent text the
     // <img> path would have provided.
-    inlineSvg = raw.replace(
+    inlineSvg = safe.replace(
       /<svg\b/,
-      `<svg role="img" aria-label="${altText.replace(/"/g, '&quot;')}"`
+      `<svg role="img" aria-label="${escapeAttr(altText)}"`
     );
   } catch (err) {
     // If the file isn't readable for any reason, fall back to the <img>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1084,14 +1084,18 @@ body.blog-page {
   width: 100%;
 }
 
-.project-screenshot img {
+.project-screenshot img,
+.project-screenshot > svg,
+.project-screenshot__inner > svg {
   display: block;
   width: 100%;
   height: auto;
   border-radius: 12px;
 }
 
-.project-screenshot--wide img {
+.project-screenshot--wide img,
+.project-screenshot--wide > svg,
+.project-screenshot--wide .project-screenshot__inner > svg {
   border: 1px solid var(--rule, rgba(17, 16, 13, 0.12));
 }
 
@@ -1111,7 +1115,8 @@ body.blog-page {
   margin: 0 auto;
   padding: clamp(2rem, 6vw, 4rem) clamp(1rem, 4vw, 2.5rem);
 }
-.project-page--black .project-screenshot--wide img {
+.project-page--black .project-screenshot--wide img,
+.project-page--black .project-screenshot--wide .project-screenshot__inner > svg {
   border: none;
 }
 .project-page--black .project-stack {

--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -114,6 +114,12 @@ describe('Project Pages — render', () => {
           expect(img.getAttribute('src')).toBeTruthy();
           expect(img.getAttribute('alt')).toBeTruthy();
         } else {
+          // Inline SVG must carry image semantics so screen readers
+          // announce it the way an <img alt="..."> would.
+          expect(
+            svg.getAttribute('role'),
+            'inline <svg> in .project-screenshot must have role="img"',
+          ).toBe('img');
           const ariaLabel = svg.getAttribute('aria-label');
           const titleEl = svg.querySelector('title');
           expect(

--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -100,13 +100,27 @@ describe('Project Pages — render', () => {
         expect(labels).toEqual(['Topics', 'Format', 'Focus', 'Status']);
       });
 
-      it('has a <figure class="project-screenshot"> containing an <img> with src and alt', () => {
+      it('has a <figure class="project-screenshot"> containing an accessible image', () => {
         const figure = document.querySelector('figure.project-screenshot');
         expect(figure, 'figure.project-screenshot not found').not.toBeNull();
+        // The screenshot slot accepts either <img> (raster screenshots) or
+        // <svg> (inline wordmarks; see ProjectMuxPlayer for why SVG fallbacks
+        // are inlined rather than referenced via <img src=...>). Either path
+        // must carry an accessible name.
         const img = figure.querySelector('img');
-        expect(img, '<img> inside .project-screenshot not found').not.toBeNull();
-        expect(img.getAttribute('src')).toBeTruthy();
-        expect(img.getAttribute('alt')).toBeTruthy();
+        const svg = figure.querySelector('svg');
+        expect(img || svg, 'no <img> or <svg> inside .project-screenshot').not.toBeNull();
+        if (img) {
+          expect(img.getAttribute('src')).toBeTruthy();
+          expect(img.getAttribute('alt')).toBeTruthy();
+        } else {
+          const ariaLabel = svg.getAttribute('aria-label');
+          const titleEl = svg.querySelector('title');
+          expect(
+            ariaLabel || (titleEl && titleEl.textContent.trim()),
+            'inline <svg> in .project-screenshot lacks an accessible name (aria-label or <title>)',
+          ).toBeTruthy();
+        }
       });
 
       it('has a .project-copy container with an <h2>Overview</h2> heading', () => {


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

The matchline wordmark started rendering fuzzy after #291 doubled it from 28rem to 56rem (you flagged this). Cause: \`<img src=*.svg>\` sandboxes the SVG so it can't access the page's loaded webfonts, and the SVG falls back to system fonts (-apple-system / Segoe UI / etc.) that look softer than Inter once the wordmark scales up.

Fix: when \`ProjectMuxPlayer\` renders an SVG fallback (no Mux \`playbackId\` + \`.svg\` extension), read the file at build time and emit it inline via \`<Fragment set:html>\` instead of \`<img>\`. Inline SVG is part of the document tree and inherits the page's font stack — Inter (already loaded via Google Fonts on every page) takes over and the text renders crisply at any size.

## Changes

**\`src/components/ProjectMuxPlayer.astro\`** — new \`isSvgFallback\` branch reads \`public/<path>\` at build time, injects \`role=\"img\"\` + \`aria-label\` on the root \`<svg>\` to match the accessibility of the \`<img>\` path, and emits via \`set:html\`. Falls back to the original \`<img>\` path if the file read fails for any reason, so the hero never goes blank.

**\`src/styles/global.css\`** — extended \`.project-screenshot img\` rules to also match \`> svg\`, including the \`.project-page--black\` border-suppression override, so the inline SVG sizes and themes identically to the prior \`<img>\`.

**\`tests/project-pages.test.js\`** — the \"figure contains \\<img\\>\" test was strict to \`<img>\` only. Updated to accept either \`<img>\` or \`<svg>\` in \`.project-screenshot\`, with an accessible-name check on either path (\`alt\` for img; \`aria-label\` or \`<title>\` for svg).

## Verification

- \`npm run build\` clean (23 pages built; \`grep -c '<svg.*role=\"img\".*aria-label.*Matchline' dist/projects/matchline/index.html\` → 1).
- \`npm test\` 143/143 green (the previously-failing project-pages test now passes both the matchline svg path and the other projects' img paths).
- DOM inspection on \`/projects/matchline/\`:
  - \`.project-screenshot__inner > svg\` exists; no \`<img>\` in the figure.
  - \`role=\"img\"\` and \`aria-label=\"Matchline product screenshot\"\` present.
  - \`<text>\` computed font-family includes Inter.
  - \`document.fonts.check('500 52px Inter')\` returns \`true\` — Inter is loaded and the SVG can use it.
- Visual: wordmark glyphs are visibly crisp at the doubled size.

## Self-Review

- **Correctness.** Build-time file read scoped to \`!playbackId && fallbackSrc.endsWith('.svg')\`, so projects with playback IDs or raster fallbacks are unaffected. Path resolution uses \`process.cwd() + 'public/'\` matching how Astro resolves \`public/\` URLs at runtime.
- **Regression risk.** Low. Only Matchline currently uses an SVG fallback (per repo grep); other projects keep the \`<img>\` path. The CSS additions are additive selectors that only match SVG children of \`.project-screenshot\` — no existing img rendering touched.
- **Accessibility.** Inline SVG carries \`role=\"img\"\` + \`aria-label\` so screen readers announce it the same way an \`<img alt=\"...\">\` would. The original SVG also carries a \`<title>\` for SVG-native AT support.
- **Style.** Comment in the component explains the why (the sandbox / webfont issue) so a future reader doesn't unwind the inline path thinking it's an unnecessary special case. CMOS em-dashes preserved.
- **Test coverage.** Updated test now covers both code paths; verified locally that the matchline assertion runs the svg branch and the other projects run the img branch.
- **Security / dependency hygiene.** No new deps. Build-time file read is bounded to \`public/\` paths derived from the validated \`screenshotSrc\` field.

## Test plan

- [ ] Pull branch, \`npm run dev\`, navigate to \`/projects/matchline/\`. Confirm the wordmark renders crisply at the doubled size — text edges should look as sharp as the body type.
- [ ] View \`source\` on the page — \`<svg role=\"img\" aria-label=\"Matchline product screenshot\">…</svg>\` appears inline (no \`<img src=\".../matchline-wordmark.svg\">\`).
- [ ] Visit any other project detail page. Confirm the screenshot still renders via \`<img>\` (the inline SVG path only fires for SVG fallbacks).
- [ ] Resize to mobile (≤480px). Confirm the wordmark adapts cleanly.
- [ ] Use a screen reader on the matchline detail page; confirm the wordmark announces as \"Matchline product screenshot\".