### PR TITLE
content(projects): paint DSoT's overflow accent red

### DIFF
--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -109,10 +109,14 @@ const jsonLd = {
             </div>
           );
           // Projects 5+ use alternating overflow rows. FFB gets the
-          // light-blue accent to match its detail-page variant.
-          const accentClass = project.data.slug === 'friends-and-family-billing'
-            ? 'accent-lightblue'
-            : 'accent-paper';
+          // light-blue accent to match its detail-page variant; DSoT
+          // gets red so the bottom of the grid keeps a Mondrian
+          // primary in rotation rather than fading to paper.
+          const accentBySlug = {
+            'friends-and-family-billing': 'accent-lightblue',
+            'device-source-of-truth': 'accent-red',
+          };
+          const accentClass = accentBySlug[project.data.slug] ?? 'accent-paper';
           return (
             <div class={i % 2 === 0 ? 'grid-row--overflow-a' : 'grid-row--overflow-b'}>
               {card}


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

The Device Source of Truth row's overflow accent was \`accent-paper\` (near-cream). Promote it to \`accent-red\` so the bottom of the projects index keeps a Mondrian primary in rotation rather than fading to paper.

Refactored the FFB-vs-paper ternary into a small slug→class lookup so adding the next per-project accent stays a one-line change:

\`\`\`astro
const accentBySlug = {
  'friends-and-family-billing': 'accent-lightblue',
  'device-source-of-truth': 'accent-red',
};
const accentClass = accentBySlug[project.data.slug] ?? 'accent-paper';
\`\`\`

## Verification

- \`npm run build\` clean.
- \`npm test\` 143/143 green.
- DOM check on \`/projects/\`: DSoT row's accent has class \`accent-red\` and computed background \`rgb(193, 29, 25)\` (the existing \`--red: #c11d19\`).

## Self-Review

- **Correctness.** The lookup falls through to \`accent-paper\` for any slug not in the map, preserving the existing default.
- **Regression risk.** None. Other overflow projects (currently just FFB plus future additions) keep their existing behavior.
- **Style.** Comment explains the why (keep a Mondrian primary visible at the bottom of the grid).
- **Test coverage.** No tests assert specific accent classes per slug; the visual check is sufficient for a color-only change.
- **Security.** N/A.