### PR TITLE
content(matchline): use charcoal accent (#333333) to match community tile

### DIFF
--- a/src/content/projects/matchline.md
+++ b/src/content/projects/matchline.md
@@ -7,7 +7,7 @@ order: 1
 status: "IN PROGRESS"
 screenshotAspect: "wide"
 screenshotSrc: "/images/projects/matchline-wordmark.svg"
-accentColor: "#11100d"
+accentColor: "#333333"
 accentColorClass: "project-page--black"
 gradientFrom: "#dde1e5"
 gradientTo: "#f5f0e4"


### PR DESCRIPTION
## Summary
- The matchline detail page accent was set to `#11100d` (true black/`--ink`), so the left rule, screenshot backplate, and metadata dividers read as pure black instead of the charcoal used elsewhere in the "black" project styling and on the homepage community tile.
- The page already carries `accentColorClass: "project-page--black"`, which maps `--project-accent` to `var(--accent-black)` (`#333333`) — but the inline `accentColor` on `.project-shell` was overriding it. This brings the inline value into agreement with the class so the accent matches the homepage community tile (`panel--black`, also `--accent-black`).

Authoring-Agent: claude

## Self-Review
- **Correctness:** Only matchline frontmatter is touched; `accentColorClass` unchanged. Verified locally that `.project-shell` resolves `--project-accent: #333333` and that the homepage `.panel--black` computes to `rgb(51, 51, 51)` — same value, same source token.
- **Regression risk:** Grep of `src/content/projects/*.md` confirms matchline is the only project using the black accent class. No other page uses this color path; the rest still pass through their own `accentColor` values (red/yellow/blue/lightblue/paper).
- **Style:** Single-line frontmatter swap; no formatting drift.
- **Test coverage:** No test coverage exists on frontmatter color values. Verified by visual preview at `/projects/matchline/`.
- **Security/dependency hygiene:** None.

## Test plan
- [ ] Visit `/projects/matchline/` — left rule, wordmark backplate, and metadata dividers render in charcoal (`#333333`), matching the community tile on `/`.
- [ ] No other project pages change.