### PR TITLE
content(home): drop Live links from Vibe Coding section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -116,7 +116,7 @@ const homepageJsonLd = {
                   <a class="p-name p-name-link" href="/projects/mergepath/" aria-label="Read the Mergepath project page">Mergepath</a>
                   <span class="p-tag">Infrastructure × AI Tooling</span>
                 </div>
-                <p>A deterministic repository standard that keeps humans and AI coding agents aligned—the enforcement layer underneath every other project on this site. <a href="https://htmlpreview.github.io/?https://raw.githubusercontent.com/nathanjohnpayne/mergepath/main/mergepath/playground/index.html" target="_blank" rel="noopener" class="p-link" aria-label="View the live Mergepath Playground">Live ↗</a></p>
+                <p>A deterministic repository standard that keeps humans and AI coding agents aligned—the enforcement layer underneath every other project on this site.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">
@@ -130,28 +130,28 @@ const homepageJsonLd = {
                   <a class="p-name p-name-link" href="/projects/override/" aria-label="Read the Override project page">Override</a>
                   <span class="p-tag">Finance × Theater</span>
                 </div>
-                <p>The financial operating system for Broadway productions. Structure your capitalization, model investor returns, manage ownership, and share live deals with backers—without spreadsheets or PDF workflows. <a href="https://overridebroadway.com" target="_blank" rel="noopener" class="p-link" aria-label="View the live Override app">Live ↗</a></p>
+                <p>The financial operating system for Broadway productions. Structure your capitalization, model investor returns, manage ownership, and share live deals with backers—without spreadsheets or PDF workflows.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">
                   <a class="p-name p-name-link" href="/projects/swipe-watch/" aria-label="Read the Swipe Watch project page">Swipe Watch</a>
                   <span class="p-tag">Consumer × Streaming</span>
                 </div>
-                <p>A swipe-based discovery experiment for Disney+ and Hulu. Train your recommendations, earn coins, and build your next watchlist—built in vanilla JS over a weekend. <a href="https://swipewatch.web.app" target="_blank" rel="noopener" class="p-link" aria-label="View the live Swipe Watch app">Live ↗</a></p>
+                <p>A swipe-based discovery experiment for Disney+ and Hulu. Train your recommendations, earn coins, and build your next watchlist—built in vanilla JS over a weekend.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">
                   <a class="p-name p-name-link" href="/projects/friends-and-family-billing/" aria-label="Read the Friends and Family Billing project page">Friends &amp; Family Billing</a>
                   <span class="p-tag">Utility × Finance</span>
                 </div>
-                <p>Cloud-synced shared-bill coordination for families and friend groups, turning monthly and annual costs into clear annual invoices, payment tracking, and shareable summaries. <a href="https://friends-and-family-billing.web.app" target="_blank" rel="noopener" class="p-link" aria-label="View the live Friends and Family Billing app">Live ↗</a></p>
+                <p>Cloud-synced shared-bill coordination for families and friend groups, turning monthly and annual costs into clear annual invoices, payment tracking, and shareable summaries.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">
                   <a class="p-name p-name-link" href="/projects/device-source-of-truth/" aria-label="Read the Device Source of Truth project page">Device Source of Truth</a>
                   <span class="p-tag">Enterprise × Data</span>
                 </div>
-                <p>A single web application for understanding partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN. <a href="https://device-source-of-truth.web.app" target="_blank" rel="noopener" class="p-link" aria-label="View the live Device Source of Truth app">Live ↗</a></p>
+                <p>A single web application for understanding partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN.</p>
               </div>
             </div>
             <div class="stack-ribbon">


### PR DESCRIPTION
## Summary
- Remove the trailing inline "Live" anchor from the five Vibe Coding project descriptions on the homepage (Mergepath, Override, Swipe Watch, Friends & Family Billing, Device Source of Truth). Matchline already has no Live link, so no change there.
- Each project item still routes to its detail page via the title p-name-link, and every detail page renders its own outbound CTA. The intent is for visitors to read the project page first and click out from there, rather than getting an inline shortcut on the homepage.

Authoring-Agent: claude

## Self-Review
- Correctness: Only the trailing anchor (class p-link, aria-label "View the live ...") is removed from each project paragraph. Sentence content and terminal punctuation are preserved. Confirmed the rendered homepage HTML contains zero "Live" arrow strings and zero matching "View the live ..." anchors. Vibe Coding panel renders all six project items intact (title + tag + body) in the dev preview.
- Regression risk: Low. The p-name-link on each project title still routes to its detail page, so the homepage still funnels traffic to every project. Detail-page CTAs become the single sanctioned outbound path to the live apps.
- Style: No semantic markup changes -- only the trailing anchor and the single space preceding it are removed.
- Test coverage: No test asserts on these anchors. Verified via dev preview screenshot.
- Security/dependency hygiene: None.

## Test plan
- Visit / and open the Vibe Coding panel -- each of the six project items reads cleanly with no "Live" link in the description.
- Click each project title -- still routes to the corresponding /projects/SLUG/ detail page.
- Detail pages still expose their own live-app CTA in the hero where applicable.