### PR TITLE
content(home): drop chips and match Giving link affordance in Vibe Coding

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -114,42 +114,36 @@ const homepageJsonLd = {
               <div class="project-item">
                 <div class="p-head">
                   <a class="p-name p-name-link" href="/projects/mergepath/" aria-label="Read the Mergepath project page">Mergepath</a>
-                  <span class="p-tag">Infrastructure × AI Tooling</span>
                 </div>
                 <p>A deterministic repository standard that keeps humans and AI coding agents aligned—the enforcement layer underneath every other project on this site.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">
                   <a class="p-name p-name-link" href="/projects/matchline/" aria-label="Read the Matchline project page">Matchline</a>
-                  <span class="p-tag">AI × Product × Career Tools</span>
                 </div>
                 <p>A career CRM for one person running a serious job search. Turns work history into structured, reusable evidence, maps that evidence against specific job requirements, and generates applications grounded in what the user has actually done. Not a resume builder—a discipline.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">
                   <a class="p-name p-name-link" href="/projects/override/" aria-label="Read the Override project page">Override</a>
-                  <span class="p-tag">Finance × Theater</span>
                 </div>
                 <p>The financial operating system for Broadway productions. Structure your capitalization, model investor returns, manage ownership, and share live deals with backers—without spreadsheets or PDF workflows.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">
                   <a class="p-name p-name-link" href="/projects/swipe-watch/" aria-label="Read the Swipe Watch project page">Swipe Watch</a>
-                  <span class="p-tag">Consumer × Streaming</span>
                 </div>
                 <p>A swipe-based discovery experiment for Disney+ and Hulu. Train your recommendations, earn coins, and build your next watchlist—built in vanilla JS over a weekend.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">
                   <a class="p-name p-name-link" href="/projects/friends-and-family-billing/" aria-label="Read the Friends and Family Billing project page">Friends &amp; Family Billing</a>
-                  <span class="p-tag">Utility × Finance</span>
                 </div>
                 <p>Cloud-synced shared-bill coordination for families and friend groups, turning monthly and annual costs into clear annual invoices, payment tracking, and shareable summaries.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">
                   <a class="p-name p-name-link" href="/projects/device-source-of-truth/" aria-label="Read the Device Source of Truth project page">Device Source of Truth</a>
-                  <span class="p-tag">Enterprise × Data</span>
                 </div>
                 <p>A single web application for understanding partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN.</p>
               </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -483,16 +483,6 @@ html, body {
   text-decoration: underline;
 }
 
-.p-tag {
-  font-size: 0.64rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  font-weight: 700;
-  padding: 0.13rem 0.36rem;
-  color: #f2d770;
-  background: #161512;
-}
-
 .p-link {
   color: var(--blue);
   text-decoration: none;
@@ -531,8 +521,30 @@ html, body {
   font-size: 1rem;
 }
 
-.panel--yellow .p-tag {
-  font-size: 0.6rem;
+/* Vibe Coding project-name links: same blue underline + arrow affordance
+   as the .p-link kicker links above the project list, so the click
+   target stops competing with the (now-removed) chip and reads as an
+   internal link in the same vocabulary as the surrounding "What agents
+   get wrong →" / "How the enforcement system works →" links. The arrow
+   is rendered via ::after so the existing inline link text stays clean. */
+.panel--yellow .p-name-link {
+  border-bottom: 1px solid rgba(34, 63, 137, 0.48);
+  transition: border-bottom-color var(--motion-hover) var(--ease-standard),
+    box-shadow var(--motion-hover) var(--ease-standard),
+    background-color var(--motion-hover) var(--ease-standard);
+}
+
+.panel--yellow .p-name-link::after {
+  content: " →";
+  color: var(--blue);
+  font-weight: 700;
+}
+
+.panel--yellow .p-name-link:hover {
+  border-bottom-color: var(--blue);
+  box-shadow: inset 0 -2px 0 var(--blue);
+  background-color: rgba(34, 63, 137, 0.08);
+  text-decoration: none;
 }
 
 .panel--yellow .project-list {


### PR DESCRIPTION
Closes #298, #299. Two paired tickets that only make sense together.

## Summary
- **#298 — Drop tag chips.** Remove the trailing `<span class="p-tag">…</span>` from each of the six Vibe Coding project entries (Mergepath, Matchline, Override, Swipe Watch, Friends & Family Billing, Device Source of Truth). Each entry now reads as: project name (link) → description. Two elements per project, clean reading order, no metadata between.
- **#299 — Match Giving link affordance.** Style `.panel--yellow .p-name-link` with a blue underline + trailing internal-navigation arrow (→), so the project name carries the same link vocabulary as the kicker links above ("What agents get wrong →" / "How the enforcement system works →"). Body text color preserved on the name; underline and arrow take `var(--blue)`. Hover deepens the underline to the existing `.p-link` box-shadow + bg-tint pattern.

The arrow is rendered via `::after` so the link text content stays clean and the inline markup matches the other `.p-name-link` instances on the site (no literal glyph in the anchor body).

## Convention captured
- Internal navigation arrow: `→` (Vibe Coding project names; existing kicker links)
- External destination arrow: `↗` (Giving campaign links unchanged)
- Connect section social rows are nav-style (icon + label + arrow) and intentionally out of scope per #299.

## CSS cleanup
- Remove the now-dead `.p-tag` and `.panel--yellow .p-tag` rules.
- `.p-head` wrapper kept (its `margin-bottom` still seats the description below the title).

Authoring-Agent: claude

## Self-Review
- Correctness: rendered homepage HTML shows zero `.p-tag` elements; each of the six `.p-name-link` anchors gets a blue border-bottom and a blue `::after` arrow (computed `rgb(34, 63, 137)`). Body text color on the name itself unchanged (`rgb(23, 18, 8)`). Giving section `.effort-link` anchors still render with the existing `↗︎` external arrow, untouched.
- Regression risk: changes are scoped to `.panel--yellow` descendants only; no other surface uses `.p-name-link` or `.p-tag`. Mobile (375px) verified — each of the six names still fits on a single line with the added arrow, and the longest label (`Friends & Family Billing →`) does not wrap.
- Style: keeping the arrow in `::after` instead of inline preserves the rest of the codebase pattern where `.p-name-link` text content is just the project name.
- Test coverage: none for these classes; verified visually at desktop and mobile breakpoints.
- Security / dependency hygiene: none.

## Test plan
- [ ] Open the Vibe Coding panel — each entry reads as: project name → description, no chip between them.
- [ ] Each project name is underlined in blue with a trailing → and routes to its `/projects/<slug>/` detail page on click.
- [ ] Hover on a project name shows the same deeper underline + bg-tint as the kicker links above.
- [ ] Giving section campaign links still use `↗︎` (untouched).
- [ ] Mobile (375px) — no name wraps to a second line because of the added arrow.