### PR TITLE
fix(home): keep Nathan Payne headline inside About panel on phones

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2865,6 +2865,16 @@ a:focus-visible {
     letter-spacing: 0.06em;
   }
 
+  /* Base rule sets the About headline at a flat 4rem with white-space: nowrap,
+     which overflows the panel on phone-sized viewports (the desktop panel is
+     wide enough but the stacked-mobile layout is not). Scale the headline
+     fluidly with viewport width while keeping the nowrap so "Nathan Payne"
+     stays a single line; clamp upper bound restores the desktop value at the
+     920px breakpoint. */
+  .panel--red .content-inner h1 {
+    font-size: clamp(2.4rem, 9vw, 4rem);
+  }
+
   .panel--red .about-label,
   .panel--red .now-ribbon-label,
   .panel--red .now-ribbon-date {


### PR DESCRIPTION
User caught the bug on a 393x852 (iPhone 14 Pro) viewport: the open About panel rendered "Nathan Payne" with white-space: nowrap at a flat 4rem (64px), pushing the headline past the right edge of the panel. The trailing "e" of "Payne" was clipped.

## Summary
- The base `.panel--red .content-inner h1` rule sets `font-size: 4rem; white-space: nowrap`. Desktop has room; the stacked single-column mobile layout does not.
- Add an override inside the existing `@media (max-width: 920px)` block that clamps the headline between `2.4rem` and `4rem`, scaling with viewport via `9vw` in the middle. The clamp upper bound matches the current desktop value at the 920px boundary; the lower bound keeps "Nathan Payne" on one line down to 320px-viewport phones.

## Verified
| Viewport | Headline font-size | Headline right edge | Panel right edge | Overflow? |
|----------|--------------------|---------------------|------------------|-----------|
| 320px | 38.4px | 279 | 303 | no (24px gap) |
| 393px | 38.4px | 351 | 375 | no (24px gap) |
| 919px | 64px (clamp ceiling) | 839 | 863 | no (24px gap) |
| >= 920px | 64px (base rule, unchanged) | desktop unchanged | - | - |

`white-space: nowrap` preserved at all sizes; the headline never wraps to a second line.

Authoring-Agent: claude

## Self-Review
- Correctness: change is scoped to `.panel--red .content-inner h1` inside the existing 920px media block. The base rule (and the desktop behavior at >= 920px) is untouched.
- Regression risk: low. Other `.panel--<color>` headlines (yellow, black, blue) inherit the base `3.5rem .content-inner h1` and arent affected; the override is panel--red-specific.
- Style: `clamp()` is consistent with the existing fluid sizing in the same media block (`.about-label`, `.stack-items`, `.now-ribbon-date`).
- Test coverage: none for typography; verified via dev preview at three viewport widths.
- Security / dependency hygiene: none.

## Test plan
- [ ] Open the homepage on a phone-sized viewport (e.g. 393x852). The "Nathan Payne" headline fits inside the red About panel with breathing room and does not wrap.
- [ ] Open the homepage at 1280x800 (desktop). The headline still renders at 4rem inside its mondrian panel — unchanged.
- [ ] Resize the browser between ~320px and ~920px. The headline scales smoothly without ever overflowing the panel.