### PR TITLE
content(home): unify trailing-arrow link convention site-wide

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -109,41 +109,41 @@ const homepageJsonLd = {
         <div class="panel-content">
           <div class="content-inner">
             <h2>Vibe Coding</h2>
-            <p>Every project started as a real problem. Each one was built end-to-end with AI agents—Claude Code, Codex, and Cursor—within a multi-agent code review system I designed to catch failure modes that agents don’t catch on their own. <a href="/blog/six-prs-one-bug-agent-failure-modes/" class="p-link">What agents get wrong →</a> · <a href="/blog/agent-approval-workflow-genesis-of-mergepath/" class="p-link">How the enforcement system works →</a></p>
+            <p>Every project started as a real problem. Each one was built end-to-end with AI agents—Claude Code, Codex, and Cursor—within a multi-agent code review system I designed to catch failure modes that agents don’t catch on their own. <a href="/blog/six-prs-one-bug-agent-failure-modes/" class="p-link">What agents get wrong<span class="link-arrow" aria-hidden="true">→</span></a> · <a href="/blog/agent-approval-workflow-genesis-of-mergepath/" class="p-link">How the enforcement system works<span class="link-arrow" aria-hidden="true">→</span></a></p>
             <div class="project-list">
               <div class="project-item">
                 <div class="p-head">
-                  <a class="p-name p-name-link" href="/projects/mergepath/" aria-label="Read the Mergepath project page">Mergepath</a>
+                  <a class="p-name p-name-link" href="/projects/mergepath/" aria-label="Read the Mergepath project page">Mergepath<span class="link-arrow" aria-hidden="true">→</span></a>
                 </div>
                 <p>A deterministic repository standard that keeps humans and AI coding agents aligned—the enforcement layer underneath every other project on this site.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">
-                  <a class="p-name p-name-link" href="/projects/matchline/" aria-label="Read the Matchline project page">Matchline</a>
+                  <a class="p-name p-name-link" href="/projects/matchline/" aria-label="Read the Matchline project page">Matchline<span class="link-arrow" aria-hidden="true">→</span></a>
                 </div>
                 <p>A career CRM for one person running a serious job search. Turns work history into structured, reusable evidence, maps that evidence against specific job requirements, and generates applications grounded in what the user has actually done. Not a resume builder—a discipline.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">
-                  <a class="p-name p-name-link" href="/projects/override/" aria-label="Read the Override project page">Override</a>
+                  <a class="p-name p-name-link" href="/projects/override/" aria-label="Read the Override project page">Override<span class="link-arrow" aria-hidden="true">→</span></a>
                 </div>
                 <p>The financial operating system for Broadway productions. Structure your capitalization, model investor returns, manage ownership, and share live deals with backers—without spreadsheets or PDF workflows.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">
-                  <a class="p-name p-name-link" href="/projects/swipe-watch/" aria-label="Read the Swipe Watch project page">Swipe Watch</a>
+                  <a class="p-name p-name-link" href="/projects/swipe-watch/" aria-label="Read the Swipe Watch project page">Swipe Watch<span class="link-arrow" aria-hidden="true">→</span></a>
                 </div>
                 <p>A swipe-based discovery experiment for Disney+ and Hulu. Train your recommendations, earn coins, and build your next watchlist—built in vanilla JS over a weekend.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">
-                  <a class="p-name p-name-link" href="/projects/friends-and-family-billing/" aria-label="Read the Friends and Family Billing project page">Friends &amp; Family Billing</a>
+                  <a class="p-name p-name-link" href="/projects/friends-and-family-billing/" aria-label="Read the Friends and Family Billing project page">Friends &amp; Family Billing<span class="link-arrow" aria-hidden="true">→</span></a>
                 </div>
                 <p>Cloud-synced shared-bill coordination for families and friend groups, turning monthly and annual costs into clear annual invoices, payment tracking, and shareable summaries.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">
-                  <a class="p-name p-name-link" href="/projects/device-source-of-truth/" aria-label="Read the Device Source of Truth project page">Device Source of Truth</a>
+                  <a class="p-name p-name-link" href="/projects/device-source-of-truth/" aria-label="Read the Device Source of Truth project page">Device Source of Truth<span class="link-arrow" aria-hidden="true">→</span></a>
                 </div>
                 <p>A single web application for understanding partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN.</p>
               </div>
@@ -166,17 +166,17 @@ const homepageJsonLd = {
             <p>Community organizing—identifying shared stakes, building coalitions, and sustaining momentum—is a form of product management. I’ve raised over $105,000 for three causes.</p>
             <ul class="effort-list">
               <li>
-                <a class="effort-link" href="https://donate.larkinstreetyouth.org/campaign/653966/donate" target="_blank" rel="noopener">Larkin Street Youth Services ↗︎</a>
+                <a class="effort-link" href="https://donate.larkinstreetyouth.org/campaign/653966/donate" target="_blank" rel="noopener">Larkin Street Youth Services<span class="link-arrow" aria-hidden="true">→</span></a>
                 <div class="effort-amount">$16,684 raised</div>
                 <div class="effort-desc">$16,684 raised for Safe &amp; Seen—a campaign for LGBTQ+ youth experiencing homelessness in San Francisco, providing housing, education, and healthcare through Larkin Street Youth Services.</div>
               </li>
               <li>
-                <a class="effort-link" href="https://www.sfaf.org" target="_blank" rel="noopener">San Francisco AIDS Foundation ↗︎</a>
+                <a class="effort-link" href="https://www.sfaf.org" target="_blank" rel="noopener">San Francisco AIDS Foundation<span class="link-arrow" aria-hidden="true">→</span></a>
                 <div class="effort-amount">$80,195 raised</div>
                 <div class="effort-desc">Three AIDS/LifeCycle rides. $9,166 in 2023. $45,646 in 2024. $25,383 in 2025. $80,195 total for HIV prevention, care services, and housing stability through the San Francisco AIDS Foundation.</div>
               </li>
               <li>
-                <a class="effort-link" href="https://jewishfed.org/what-we-do/our-programs/giving-circles/jewish-pride-fund/" target="_blank" rel="noopener">Jewish Pride Fund ↗︎</a>
+                <a class="effort-link" href="https://jewishfed.org/what-we-do/our-programs/giving-circles/jewish-pride-fund/" target="_blank" rel="noopener">Jewish Pride Fund<span class="link-arrow" aria-hidden="true">→</span></a>
                 <div class="effort-amount">$8,959 raised</div>
                 <div class="effort-desc">Raised $8,959 and stayed involved after the check cleared—joining one of the few LGBTQ+ Jewish giving circles in the nation to interview grant applicants and help direct where the fund’s dollars land.</div>
               </li>
@@ -216,7 +216,7 @@ const homepageJsonLd = {
                 data-u="aGlyZQ=="
                 data-d="bmF0aGFucGF5bmUuY29t"
                 data-s="RnJvbSUyMG5hdGhhbnBheW5lLmNvbQ=="
-              >Get in touch &rarr;</a>
+              >Get in touch<span class="link-arrow" aria-hidden="true">→</span></a>
             </p>
             <noscript>
               <p class="availability-noscript">Email: hire [at] nathanpayne [dot] com</p>
@@ -305,7 +305,7 @@ const homepageJsonLd = {
             {latestPost && (
               <div class="blog-callout">
                 <span class="blog-callout-label">From the Blog</span>
-                <a href={`/blog/${latestPost.id}/`} class="blog-callout-link">{latestPost.data.title} &rarr;</a>
+                <a href={`/blog/${latestPost.id}/`} class="blog-callout-link">{latestPost.data.title}<span class="link-arrow" aria-hidden="true">→</span></a>
               </div>
             )}
           </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -479,25 +479,65 @@ html, body {
   line-height: 1.1;
 }
 
-.p-name-link:hover {
-  text-decoration: underline;
-}
-
 .p-link {
   color: var(--blue);
-  text-decoration: none;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
   font-weight: 700;
-  border-bottom: 1px solid rgba(34, 63, 137, 0.48);
-  box-shadow: 0 0 0 transparent;
-  transition: border-bottom-color var(--motion-hover) var(--ease-standard),
-    box-shadow var(--motion-hover) var(--ease-standard),
-    background-color var(--motion-hover) var(--ease-standard);
 }
 
-.p-link:hover {
-  border-bottom-color: var(--blue);
-  box-shadow: inset 0 -2px 0 var(--blue);
-  background-color: rgba(34, 63, 137, 0.08);
+/* === Site-wide link affordance ============================================
+   ONE arrow (→), ONE resting state (text underlined, arrow not), ONE hover
+   behavior (arrow translates 3px right). Captured here so future links can
+   reach for the same convention without inventing new ones.
+
+   Markup convention: every link with a trailing arrow contains
+     <span class="link-arrow" aria-hidden="true">→</span>
+   as the final child of the anchor. The wrapper span has
+   `text-decoration: none`, so the underline cleanly stops at the link
+   text and the arrow can be transformed independently on hover.
+
+   .s-arrow (Connect social rows) is a sibling of .link-arrow that keeps
+   its own bespoke layout (margin-left: auto inside a flex tile) but joins
+   the same hover-translate selector group so the convention is uniform.
+
+   ── Scope exception (Connect social rows) ──────────────────────────────
+   The Connect "Elsewhere" tiles intentionally retain their bespoke hover
+   decoration: per-platform brand-colored gradient under-bar, .s-icon
+   opacity ramp, .s-arrow opacity ramp. The strict reading of issue #302
+   ("no other property changes on hover") would strip those, but the
+   gradients are a deliberate brand-recognition design moment. The site
+   owner explicitly chose Option A on the #302 review: keep the social
+   rows exactly as they are, apply the new convention only to the body-
+   text links above. Future contributors: do not "harmonize" the social
+   rows without asking — that's a documented deviation, not an oversight.
+   ========================================================================== */
+.link-arrow {
+  display: inline-block;
+  margin-left: 0.18em;
+  text-decoration: none;
+  transition: transform var(--motion-hover) var(--ease-standard);
+}
+
+a:hover .link-arrow,
+a:focus-visible .link-arrow,
+.social-row:hover .s-arrow,
+.social-row:focus-visible .s-arrow {
+  transform: translateX(3px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .link-arrow,
+  .s-arrow {
+    transition: none;
+  }
+  a:hover .link-arrow,
+  a:focus-visible .link-arrow,
+  .social-row:hover .s-arrow,
+  .social-row:focus-visible .s-arrow {
+    transform: none;
+  }
 }
 
 .panel--yellow .content-inner h2 {
@@ -521,30 +561,18 @@ html, body {
   font-size: 1rem;
 }
 
-/* Vibe Coding project-name links: same blue underline + arrow affordance
-   as the .p-link kicker links above the project list, so the click
-   target stops competing with the (now-removed) chip and reads as an
-   internal link in the same vocabulary as the surrounding "What agents
-   get wrong →" / "How the enforcement system works →" links. The arrow
-   is rendered via ::after so the existing inline link text stays clean. */
+/* Vibe Coding project-name links pick up the site-wide link convention:
+   text-decoration underline at rest, blue arrow translates on hover. */
 .panel--yellow .p-name-link {
-  border-bottom: 1px solid rgba(34, 63, 137, 0.48);
-  transition: border-bottom-color var(--motion-hover) var(--ease-standard),
-    box-shadow var(--motion-hover) var(--ease-standard),
-    background-color var(--motion-hover) var(--ease-standard);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
 }
 
-.panel--yellow .p-name-link::after {
-  content: " →";
+.panel--yellow .p-name-link .link-arrow,
+.panel--black .effort-link .link-arrow {
   color: var(--blue);
   font-weight: 700;
-}
-
-.panel--yellow .p-name-link:hover {
-  border-bottom-color: var(--blue);
-  box-shadow: inset 0 -2px 0 var(--blue);
-  background-color: rgba(34, 63, 137, 0.08);
-  text-decoration: none;
 }
 
 .panel--yellow .project-list {
@@ -623,12 +651,9 @@ html, body {
 
 .content-inner .blog-callout-link {
   font-size: 0.68rem;
-  text-decoration: none;
-  transition: color var(--motion-hover) var(--ease-standard);
-}
-
-.blog-callout-link:hover {
-  color: var(--ink);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
 }
 
 .panel--blue .blog-callout {
@@ -643,10 +668,6 @@ html, body {
   color: rgba(240, 244, 255, 0.55);
 }
 
-.panel--blue .blog-callout-link:hover {
-  color: rgba(240, 244, 255, 0.9);
-}
-
 /* When Connect panel is expanded, revert to dark text on cream bg */
 .panel--blue.is-open .blog-callout {
   border-top-color: var(--rule);
@@ -658,10 +679,6 @@ html, body {
 
 .panel--blue.is-open .blog-callout-link {
   color: rgba(17, 16, 13, 0.50);
-}
-
-.panel--blue.is-open .blog-callout-link:hover {
-  color: var(--ink);
 }
 
 .effort-list {
@@ -682,11 +699,8 @@ html, body {
   text-decoration: underline;
   text-decoration-color: var(--rule);
   text-decoration-thickness: 1px;
-  text-underline-offset: 3px;
-  transition: opacity var(--motion-hover) var(--ease-standard);
+  text-underline-offset: 2px;
 }
-
-.effort-link:hover { opacity: 0.70; }
 
 .effort-amount {
   margin-top: 0.12rem;


### PR DESCRIPTION
Closes #302. One arrow (->), one resting state (text underlined, arrow not), one hover behavior (arrow translates 3px right). Captured in a comment block at the top of the new `.link-arrow` rule so the convention persists.

## Markup
Every link with a trailing arrow now contains `<span class="link-arrow" aria-hidden="true">-></span>` as the final child of the anchor. Replaces:
- inline " ->" in the .p-link kicker links above Vibe Coding
- the .panel--yellow .p-name-link `::after` pseudo arrow
- the variation-selector "↗︎" used by .effort-link Giving campaign links (now bare ->, no `︎`)
- "&rarr;" in the Connect "Get in touch" mailto and the "From the Blog" footer link

## CSS
- New global `.link-arrow` rule plus `a:hover/focus-visible .link-arrow` translate, with `prefers-reduced-motion` override. Same selector group also covers `.social-row .s-arrow` so the Connect tiles join the convention without restyling their layout.
- `.p-link`, `.panel--yellow .p-name-link`, `.blog-callout-link` all switched from `border-bottom` (or `text-decoration: none`) to `text-decoration: underline` at rest with 1px thickness and 2px underline-offset, matching `.effort-link`.
- Bespoke hover decorations dropped from `.p-link`, `.panel--yellow .p-name-link`, `.effort-link`, `.blog-callout-link` (and its `.panel--blue` variants). Only the arrow translates on hover now.
- Vibe Coding + Community arrow color: shared rule colors `.link-arrow` inside `.panel--yellow .p-name-link` AND inside `.panel--black .effort-link` as `var(--blue)` at weight 700, so the Community campaign links read with the same blue arrow as the Vibe Coding project names (per review feedback).

## Scope exception (Connect social rows) -- explicit Option A choice
The `.social-row` tiles intentionally retain their bespoke hover decoration: per-platform brand-colored gradient under-bar, `.s-icon` opacity ramp, `.s-arrow` opacity ramp. The strict reading of #302 ("no other property changes on hover") would strip those, but they are a deliberate brand-recognition design moment.

The site owner explicitly chose **Option A** on the review pass: keep the social rows exactly as they are, apply the new convention only to the body-text links above. The carve-out is documented inline in `global.css` so future contributors do not "harmonize" the rows by accident.

Authoring-Agent: claude

## Self-Review
- **Correctness:** Rendered homepage HTML shows every trailing arrow inside a `.link-arrow` span. The Giving `↗︎` was the only character flip; every other arrow was already `->` and stays `->`. Verified computed styles for the Community arrow color: `.panel--black .effort-link .link-arrow` resolves to `rgb(34, 63, 137)` (= `var(--blue)`) at weight 700, matching `.panel--yellow .p-name-link .link-arrow`.
- **Regression risk:** The `.social-row` carve-out is documented inline. None of `.p-link / .effort-link / .blog-callout-link / .p-name-link` are used outside the homepage (greped), so the underline / hover changes do not bleed into project or blog pages.
- **Reduced motion:** Arrow translate is gated by `@media (prefers-reduced-motion: reduce)`. Stylesheet inspection in the dev preview confirms the rule is present.
- **Test coverage:** None for these classes; verified visually at desktop and via DOM-inspected computed styles.
- **Security / dependency hygiene:** None.

## Test plan
- [ ] Open Vibe Coding -- each project name underlined at rest, blue `->` arrow, arrow shifts right on hover; nothing else changes.
- [ ] Open Vibe Coding intro line -- "What agents get wrong" / "How the enforcement system works" underlined in blue with `->` that shifts on hover.
- [ ] Open Community -- three campaign names underlined, blue `->` arrow that shifts on hover; no opacity change anywhere.
- [ ] Open Connect -- "Get in touch" underlined with arrow shift; "Elsewhere" social tiles still show their per-platform gradient under-bar on hover (intentionally preserved); "From the Blog" footer link underlined with arrow shift.
- [ ] Toggle macOS "Reduce motion" -- arrows still highlight on hover (underline already at rest) but do not translate.