### PR TITLE
content(home): vertical Community label, on-load pulse, webfont gate

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -149,6 +149,12 @@ const ogImageUrl = ogImage.includes('?') ? `${ogImage}&v=${buildTime}` : `${ogIm
       }
     })();
   </script>
+  <noscript>
+    <!-- JS-disabled users never get [data-fonts-ready] applied; fall back
+         to visible labels with the original FOUT behavior so the homepage
+         still has navigational affordances. -->
+    <style>.panel-label { opacity: 1 !important; }</style>
+  </noscript>
 </head>
 <body class={bodyClass}>
   <slot />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -131,6 +131,24 @@ const ogImageUrl = ogImage.includes('?') ? `${ogImage}&v=${buildTime}` : `${ogIm
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <!-- Gate Mondrian panel labels behind webfont readiness so the boxed
+       "Nathan Payne" + tile labels don't visibly swap from system
+       fallback to Cormorant Garamond on first paint. CSS hides .panel-label
+       until [data-fonts-ready] lands, then fades it in. 1.5s timeout
+       reveals labels regardless if document.fonts isn't supported or
+       fonts are slow to load (better than indefinite invisibility). -->
+  <script is:inline>
+    (function () {
+      var html = document.documentElement;
+      var reveal = function () { html.dataset.fontsReady = ''; };
+      if (document.fonts && document.fonts.ready && typeof document.fonts.ready.then === 'function') {
+        document.fonts.ready.then(reveal);
+        setTimeout(reveal, 1500);
+      } else {
+        reveal();
+      }
+    })();
+  </script>
 </head>
 <body class={bodyClass}>
   <slot />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -460,9 +460,18 @@ const homepageJsonLd = {
       // the persistent cursor-pointer affordance only.
       const reduceMotion = matchesQuery('(prefers-reduced-motion: reduce)');
       const PULSE_ORDER = ['panel--red', 'panel--yellow', 'panel--blue', 'panel--black'];
-      const PULSE_INITIAL_DELAY = 700;
-      const PULSE_INTERVAL = 370;
-      const PULSE_DURATION = 250;
+      // Read spec-locked timings from CSS custom properties so the
+      // values stay controllable from one place (src/styles/global.css
+      // :root) and the JS doesn't drift from the CSS keyframe duration.
+      const motionTokens = getComputedStyle(document.documentElement);
+      const readMs = (name, fallback) => {
+        const raw = motionTokens.getPropertyValue(name).trim();
+        const n = parseFloat(raw);
+        return Number.isFinite(n) ? n : fallback;
+      };
+      const PULSE_INITIAL_DELAY = readMs('--pulse-initial-delay', 700);
+      const PULSE_INTERVAL = readMs('--pulse-interval', 370);
+      const PULSE_DURATION = readMs('--pulse-duration', 250);
       let pulseFired = false;
 
       function pulsePanel(className) {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -159,7 +159,10 @@ const homepageJsonLd = {
       <div class="block block--white-b" aria-hidden="true"></div>
 
       <article class="panel panel--black" data-panel="community" data-label="Community" role="region" aria-label="Community organizing and fundraising">
-        <div class="panel-label" tabindex="0" role="button" aria-label="Open Community section">Community</div>
+        <div class="panel-label" tabindex="0" role="button" aria-label="Open Community section">
+          <span class="panel-label__h" data-label-orientation="horizontal">Community</span>
+          <span class="panel-label__v" data-label-orientation="vertical" aria-hidden="true">Community</span>
+        </div>
         <div class="panel-content">
           <div class="content-inner">
             <h2>Giving &amp; Governing</h2>
@@ -423,113 +426,72 @@ const homepageJsonLd = {
         });
       });
 
-      // ─── Discoverability nudges (#271) ───
-      // 1. On-load settle: subtle staggered scale on each panel.
-      //    Plays on every device — touch users still benefit from a
-      //    "this page is alive" cue. Skipped under reduced-motion.
-      // 2. Inactivity nudge: after 5s of no panel hover/focus/click,
-      //    pulse the Vibe Coding panel; after another 10s, pulse a
-      //    second panel. Stops after two fires; no looping. Skipped
-      //    on touch (no mouse to track) and under reduced-motion
-      //    (replaced by a one-time static label underline).
+      // ─── Community label horizontal/vertical aria toggle (#304) ───
+      // The cross-fade itself is CSS-driven (opacity transitions keyed
+      // off [data-focus] on the grid). JS only flips aria-hidden on the
+      // two label variants so screen readers announce exactly one.
+      const communityPanel = grid.querySelector('.panel--black');
+      const labelH = communityPanel && communityPanel.querySelector('.panel-label__h');
+      const labelV = communityPanel && communityPanel.querySelector('.panel-label__v');
+
+      function syncCommunityLabelAria() {
+        if (!labelH || !labelV) return;
+        // Vertical only when Vibe Coding (data-focus="projects") is
+        // open — that's the only expansion that compresses Community
+        // narrow enough to truncate "COMMUNITY". Match the CSS rule.
+        const useVertical = grid.dataset.focus === 'projects';
+        labelH.setAttribute('aria-hidden', useVertical ? 'true' : 'false');
+        labelV.setAttribute('aria-hidden', useVertical ? 'false' : 'true');
+      }
+      syncCommunityLabelAria();
+
+      // Keep aria-hidden in lockstep with the grid's data-focus
+      // attribute (which openPanel/closePanel already manage). A
+      // MutationObserver avoids having to thread the call into each
+      // existing call site.
+      new MutationObserver(syncCommunityLabelAria)
+        .observe(grid, { attributes: true, attributeFilter: ['data-focus'] });
+
+      // ─── On-load discoverability pulse sequence (#305) ───
+      // Four primary panels pulse clockwise once on initial load:
+      // red (Nathan Payne) → yellow (Vibe Coding) → blue (Connect)
+      // → black (Community). Total ~1.4s, fired once per page load,
+      // deferred until the tab is visible. Reduced-motion users get
+      // the persistent cursor-pointer affordance only.
       const reduceMotion = matchesQuery('(prefers-reduced-motion: reduce)');
+      const PULSE_ORDER = ['panel--red', 'panel--yellow', 'panel--blue', 'panel--black'];
+      const PULSE_INITIAL_DELAY = 700;
+      const PULSE_INTERVAL = 370;
+      const PULSE_DURATION = 250;
+      let pulseFired = false;
 
-      if (!reduceMotion) {
-        panels.forEach((panel, i) => {
-          panel.style.setProperty('--settle-index', String(i));
-          panel.classList.add('panel--settling');
-          // Drop the class once the settle finishes so `will-change`
-          // doesn't keep a permanent compositor hint on every panel.
-          panel.addEventListener('animationend', function onSettleEnd(e) {
-            if (e.animationName !== 'panel-settle') return;
-            panel.classList.remove('panel--settling');
-            panel.style.removeProperty('--settle-index');
-            panel.removeEventListener('animationend', onSettleEnd);
-          });
+      function pulsePanel(className) {
+        const target = grid.querySelector('.' + className);
+        if (!target) return;
+        target.classList.add('panel--pulsing');
+        setTimeout(() => target.classList.remove('panel--pulsing'), PULSE_DURATION);
+      }
+
+      function runPulseSequence() {
+        if (pulseFired || reduceMotion) return;
+        pulseFired = true;
+        PULSE_ORDER.forEach((className, i) => {
+          setTimeout(() => pulsePanel(className), PULSE_INITIAL_DELAY + i * PULSE_INTERVAL);
         });
       }
 
-      // Two-stage nudge sequence with pause/resume on tab visibility.
-      const NUDGE_TARGETS = ['panel--yellow', 'panel--blue']; // Vibe Coding → Connect
-      const NUDGE_DELAYS = [5000, 10000];
-      let nudgeStage = 0; // 0 = not started; 1..N = waiting on stage N; N+1 = done
-      let nudgeTimer = null;
-      let nudgeTimerEnd = null;
-      let nudgeTimerRemaining = null;
-
-      function scheduleNudge(stage) {
-        if (stage > NUDGE_TARGETS.length) {
-          nudgeStage = NUDGE_TARGETS.length + 1;
-          return;
-        }
-        nudgeStage = stage;
-        nudgeTimerRemaining = NUDGE_DELAYS[stage - 1];
-        nudgeTimerEnd = Date.now() + nudgeTimerRemaining;
-        nudgeTimer = setTimeout(() => fireNudge(stage), nudgeTimerRemaining);
+      if (document.visibilityState === 'visible') {
+        runPulseSequence();
+      } else {
+        // Loaded in a background tab — wait until the user surfaces
+        // the page so the discoverability cue isn't missed.
+        const onVisible = () => {
+          if (document.visibilityState !== 'visible') return;
+          document.removeEventListener('visibilitychange', onVisible);
+          runPulseSequence();
+        };
+        document.addEventListener('visibilitychange', onVisible);
       }
-
-      function pauseNudgeTimer() {
-        if (!nudgeTimer) return;
-        clearTimeout(nudgeTimer);
-        nudgeTimer = null;
-        nudgeTimerRemaining = Math.max(0, nudgeTimerEnd - Date.now());
-      }
-
-      function resumeNudgeTimer() {
-        if (nudgeTimer) return;
-        if (nudgeTimerRemaining == null) return;
-        if (nudgeStage > NUDGE_TARGETS.length) return;
-        nudgeTimerEnd = Date.now() + nudgeTimerRemaining;
-        nudgeTimer = setTimeout(() => fireNudge(nudgeStage), nudgeTimerRemaining);
-      }
-
-      function cancelAllNudges() {
-        if (nudgeTimer) clearTimeout(nudgeTimer);
-        nudgeTimer = null;
-        nudgeTimerRemaining = null;
-        nudgeStage = NUDGE_TARGETS.length + 1;
-      }
-
-      function fireNudge(stage) {
-        nudgeTimer = null;
-        const target = grid.querySelector('.' + NUDGE_TARGETS[stage - 1]);
-        if (target) {
-          target.classList.add('panel--nudging');
-          setTimeout(() => target.classList.remove('panel--nudging'), 800);
-        }
-        if (stage < NUDGE_TARGETS.length) {
-          scheduleNudge(stage + 1);
-        } else {
-          nudgeStage = NUDGE_TARGETS.length + 1;
-        }
-      }
-
-      if (reduceMotion) {
-        // Reduced-motion fallback: one-time static border-bottom on
-        // each panel label at the same 5s mark — same signaling job,
-        // no animation. Does not fire a second event.
-        setTimeout(() => {
-          panels.forEach((p) => p.classList.add('has-static-hint'));
-        }, 5000);
-      } else if (canHover()) {
-        scheduleNudge(1);
-      }
-
-      // Any panel interaction cancels the entire nudge sequence —
-      // the user has discovered interactivity without our help.
-      panels.forEach((panel) => {
-        ['mouseenter', 'focusin', 'click'].forEach((evt) => {
-          panel.addEventListener(evt, cancelAllNudges);
-        });
-      });
-
-      // Tab switches pause/resume; mouse-leaving-window without a
-      // tab switch is intentionally not paused (the timer is a UX
-      // cadence, not a precision instrument).
-      document.addEventListener('visibilitychange', () => {
-        if (document.hidden) pauseNudgeTimer();
-        else resumeNudgeTimer();
-      });
     })();
   </script>
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -33,8 +33,23 @@
   --motion-plane: 280ms;
   --motion-load: 300ms;
 
+  /* Spec-locked motion for the on-load discoverability pulse (#305)
+     and the Community label cross-fade (#304). Defined as tokens so
+     timing stays controllable from one place; the inline script in
+     src/pages/index.astro reads --pulse-* via getComputedStyle. */
+  --pulse-initial-delay: 700ms;   /* settle before the sequence fires */
+  --pulse-interval: 370ms;        /* time between successive pulse starts */
+  --pulse-duration: 250ms;        /* per-panel pulse length */
+  --label-fade: 100ms;            /* per-orientation cross-fade duration */
+  --label-fade-delay-in: 150ms;   /* hold before the new orientation fades in
+                                     so the container reshape leads the swap */
+  --label-fade-delay-out: 250ms;  /* hold before the original orientation
+                                     returns on collapse so the container
+                                     reshapes back first */
+
   --ease-standard: cubic-bezier(0.4, 0.0, 0.2, 1);
   --ease-sharp: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --ease-out: cubic-bezier(0, 0, 0.2, 1);
   --ease-linear: linear;
 
   --shift-small: 2px;
@@ -174,7 +189,7 @@ html, body {
      BaseLayout.astro that waits on document.fonts.ready (with a 1.5s
      timeout fallback). */
   opacity: 0;
-  transition: opacity 180ms ease;
+  transition: opacity var(--motion-hover) var(--ease-standard);
 }
 
 html[data-fonts-ready] .panel-label {
@@ -832,7 +847,7 @@ a:focus-visible .link-arrow,
 .panel--black .panel-label__h,
 .panel--black .panel-label__v {
   position: absolute;
-  transition: opacity 100ms ease;
+  transition: opacity var(--label-fade) var(--ease-standard);
 }
 
 .panel--black .panel-label__h {
@@ -841,7 +856,7 @@ a:focus-visible .link-arrow,
   left: 17%;
   bottom: 16%;
   opacity: 1;
-  transition-delay: 250ms;
+  transition-delay: var(--label-fade-delay-out);
 }
 
 .panel--black .panel-label__v {
@@ -868,7 +883,7 @@ a:focus-visible .link-arrow,
 }
 .mondrian[data-focus="projects"] .panel--black .panel-label__v {
   opacity: 1;
-  transition-delay: 150ms;
+  transition-delay: var(--label-fade-delay-in);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -2838,7 +2853,7 @@ a.tag:hover {
 }
 
 .panel--pulsing {
-  animation: panel-pulse 250ms var(--ease-out, ease-out);
+  animation: panel-pulse var(--pulse-duration) var(--ease-out);
   will-change: filter;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2847,7 +2847,7 @@ a.tag:hover {
   50%      { filter: brightness(1.08) saturate(1.05); }
 }
 
-@keyframes panel-pulse--neutral {
+@keyframes panel-pulse-neutral {
   0%, 100% { filter: none; }
   50%      { filter: brightness(1.16); }
 }
@@ -2858,7 +2858,7 @@ a.tag:hover {
 }
 
 .panel--black.panel--pulsing {
-  animation-name: panel-pulse--neutral;
+  animation-name: panel-pulse-neutral;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -32,8 +32,6 @@
   --motion-hover: 170ms;
   --motion-plane: 280ms;
   --motion-load: 300ms;
-  --motion-pulse: 700ms;          /* discoverability breath (#271) */
-  --motion-stagger-step: 65ms;    /* per-sibling delay in staggered groups (#271) */
 
   --ease-standard: cubic-bezier(0.4, 0.0, 0.2, 1);
   --ease-sharp: cubic-bezier(0.2, 0.8, 0.2, 1);
@@ -169,6 +167,18 @@ html, body {
   text-align: left;
   pointer-events: none;
   font-family: "Cormorant Garamond", Garamond, serif;
+  /* Hidden until Cormorant Garamond is ready, then fades in. Prevents
+     the visible swap from system-fallback to Cormorant on first paint
+     (most noticeable on the boxed "Nathan Payne" label). The
+     [data-fonts-ready] attribute is set by the inline script in
+     BaseLayout.astro that waits on document.fonts.ready (with a 1.5s
+     timeout fallback). */
+  opacity: 0;
+  transition: opacity 180ms ease;
+}
+
+html[data-fonts-ready] .panel-label {
+  opacity: 1;
 }
 
 .panel-label--name {
@@ -803,6 +813,69 @@ a:focus-visible .link-arrow,
   justify-content: flex-start;
   padding-left: 17%;
   padding-bottom: 16%;
+}
+
+/* Community label variants (#304).
+   The horizontal variant matches the rest of the Mondrian panel labels.
+   The vertical variant only renders when the Community block compresses
+   (i.e. some other panel is expanded), so the word never truncates as
+   "COMMUNI" inside a narrowed column. Markup keeps both variants in the
+   DOM and toggles aria-hidden via JS so screen readers announce only the
+   active one.
+
+   Cross-fade timing matches the spec sequence in #304:
+   - On compression  : horizontal fades out immediately, vertical fades in
+                       after 150ms (after the container has begun reshaping).
+   - On expansion    : vertical fades out immediately, horizontal fades in
+                       after 250ms (after the container has reshaped back).
+   prefers-reduced-motion swaps the variants instantly. */
+.panel--black .panel-label__h,
+.panel--black .panel-label__v {
+  position: absolute;
+  transition: opacity 100ms ease;
+}
+
+.panel--black .panel-label__h {
+  /* Inherits the .panel-label flex/padding placement; sits where the
+     original "Community" word always sat. */
+  left: 17%;
+  bottom: 16%;
+  opacity: 1;
+  transition-delay: 250ms;
+}
+
+.panel--black .panel-label__v {
+  /* Bottom-anchored, reads bottom-to-top to match the .accent-blue-label
+     "Latest" pattern on the blog index. */
+  left: clamp(0.6rem, 1.4vw, 1.2rem);
+  bottom: clamp(0.8rem, 1.6vw, 1.4rem);
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  transform: rotate(180deg);
+  transform-origin: center;
+  opacity: 0;
+  transition-delay: 0ms;
+}
+
+/* Vibe Coding (data-focus="projects") is the only state that compresses
+   Community narrow enough to truncate "COMMUNITY" → "COMMUNI". Other
+   expansions (Connect, About) reshape elsewhere and leave Community wide
+   enough for the horizontal label, so the vertical variant stays out of
+   the way unless it's actually solving the truncation problem. */
+.mondrian[data-focus="projects"] .panel--black .panel-label__h {
+  opacity: 0;
+  transition-delay: 0ms;
+}
+.mondrian[data-focus="projects"] .panel--black .panel-label__v {
+  opacity: 1;
+  transition-delay: 150ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .panel--black .panel-label__h,
+  .panel--black .panel-label__v {
+    transition: none;
+  }
 }
 
 .block--white-c { grid-column: 4 / 7; grid-row: 6; background: var(--paper); }
@@ -2745,40 +2818,37 @@ a.tag:hover {
  * animations are suppressed and the JS swaps in a one-time static
  * border-bottom on each panel label at the same ~5s mark. */
 
-@keyframes panel-settle {
-  from { transform: scale(0.992); opacity: 0.94; }
-  to   { transform: scale(1);     opacity: 1;    }
-}
-
+/* On-load discoverability pulse (#305).
+   Each interactive panel pulses once on initial load, in clockwise order
+   (red -> yellow -> blue -> black), to communicate "these tiles are
+   interactive" without a permanent UI affordance. The .panel--pulsing
+   class is added by JS for one ~250ms breath, then removed. The
+   keyframe peaks at brightness 1.08 / saturate 1.05 for the colored
+   panels; .panel--black gets a brightness boost (1.16) since saturation
+   has near-zero effect on a neutral fill.
+   Supersedes #271 (inactivity nudges + on-load settle). */
 @keyframes panel-pulse {
   0%, 100% { filter: none; }
   50%      { filter: brightness(1.08) saturate(1.05); }
 }
 
-.panel--settling {
-  animation: panel-settle var(--motion-plane) var(--ease-standard) both;
-  animation-delay: calc(var(--settle-index, 0) * var(--motion-stagger-step));
-  transform-origin: center center;
-  will-change: transform, opacity;
+@keyframes panel-pulse--neutral {
+  0%, 100% { filter: none; }
+  50%      { filter: brightness(1.16); }
 }
 
-.panel--nudging {
-  animation: panel-pulse var(--motion-pulse) var(--ease-linear);
+.panel--pulsing {
+  animation: panel-pulse 250ms var(--ease-out, ease-out);
   will-change: filter;
 }
 
+.panel--black.panel--pulsing {
+  animation-name: panel-pulse--neutral;
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .panel--settling,
-  .panel--nudging {
+  .panel--pulsing {
     animation: none;
-  }
-  /* Static hint sits under the label *text* (the panel itself is
-   * full-bleed; a border-bottom on .panel-label would land at the
-   * bottom edge of the panel, not under the visible label). */
-  .panel.has-static-hint .panel-label {
-    text-decoration: underline;
-    text-decoration-thickness: 1px;
-    text-underline-offset: 0.18em;
   }
 }
 


### PR DESCRIPTION
Closes #304, closes #305. Three coordinated polish changes that all touch the Mondrian first-paint experience.

## #304 — vertical Community label
- Add a horizontal/vertical pair of label spans inside the `.panel--black` panel-label. The horizontal variant renders at rest; the vertical variant only appears when **Vibe Coding is open** (`data-focus="projects"`), which is the one expansion that actually compresses Community narrow enough to truncate "COMMUNITY" → "COMMUNI" (per review feedback).
- Cross-fade is CSS-driven via opacity transitions keyed off the existing `[data-focus]` attribute. `transition-delay` implements the spec sequence: horizontal fades out immediately on compression, vertical fades in 150ms later; reverse on collapse with a 250ms delay so the container reshapes back before the horizontal returns.
- A `MutationObserver` watches `grid.dataset.focus` and toggles `aria-hidden` so screen readers announce only the active orientation.
- Vertical typography mirrors the `.accent-blue-label` "Latest" pattern on the blog index (`writing-mode: vertical-rl`, rotated 180deg for bottom-to-top reading).
- `prefers-reduced-motion` drops the cross-fade — orientation switches instantly.

## #305 — clockwise pulse sequence on load
- Replace the entire #271 inactivity-nudge system (`panel--settling`, `panel--nudging`, `has-static-hint`, two-stage timer with pause/resume) with a single on-load sequence: red → yellow → blue → black, 250ms each, 370ms apart, fired **once** 700ms after the page becomes visible.
- If the page loads in a background tab, the sequence is deferred until the next `visibilitychange` to "visible" so the discoverability cue is never missed.
- Filter is `brightness(1.08) saturate(1.05)` on the colored panels; `.panel--black` gets `brightness(1.16)` instead since saturation does little on a near-neutral fill.
- `prefers-reduced-motion` disables the sequence; the existing `cursor: pointer` on `.panel` covers the static fallback.
- Removes the now-unused `--motion-pulse` and `--motion-stagger-step` tokens along with the dead `.panel--settling`/`.panel--nudging`/`.has-static-hint` rules and `panel-settle` keyframe.

## Webfont flash fix (out-of-band)
- Inline script in `BaseLayout.astro` sets `[data-fonts-ready]` on `<html>` once `document.fonts.ready` resolves, with a 1.5s timeout fallback for browsers without the API or pathologically slow font fetches.
- `.panel-label` renders at `opacity: 0` by default and fades to 1 over 180ms once the attribute lands. Eliminates the visible swap from the system fallback to Cormorant Garamond on first paint, which was most noticeable on the boxed "Nathan Payne" label.
- Not in either issue ticket but pairs naturally — both #304 and #305 touch the same first-paint moment, and addressing the flash here keeps the Mondrian-on-load experience coherent. Site owner asked for the fix inline during the preview pass.

Authoring-Agent: claude

## Self-Review
- **Correctness:** Programmatically verified all four states for the Community label (rest, Vibe Coding open, Connect open, About open). Only the projects/Vibe Coding case flips horizontal → vertical and toggles `aria-hidden`. Pulse sequence verified to fire once per load with the documented timing. Font gate verified to render labels invisible until `[data-fonts-ready]` lands and visible after.
- **Regression risk:** `.panel--settling` / `.panel--nudging` / `.has-static-hint` are fully removed from both JS and CSS (greped clean). Two unused CSS custom properties (`--motion-pulse`, `--motion-stagger-step`) tagged for #271 are dropped at the same time. The cursor-pointer affordance for #305 s static fallback is the existing `.panel { cursor: pointer; }` rule, unchanged.
- **Reduced motion:** Gated on the same `matchesQuery` helper used elsewhere; pulse sequence is no-op, label cross-fade is instant.
- **Visibility deferral:** Branched on `document.visibilityState` and re-armed via `visibilitychange` listener.
- **Test coverage:** None for these classes; verified via dev preview and DOM-inspected computed styles.
- **Security / dependency hygiene:** None.

## Test plan
- [ ] Hard reload — labels fade in cleanly in Cormorant Garamond, no system-fallback flash.
- [ ] After the labels settle (~700ms), the four primary panels pulse clockwise: red → yellow → blue → black.
- [ ] Hover over Vibe Coding — Community block compresses; "COMMUNITY" cross-fades from horizontal to vertical (bottom-to-top, matching the blog "Latest" treatment) without truncation. Move off — vertical fades out, container reshapes back, horizontal fades in.
- [ ] Hover over Connect or About — Community label stays horizontal (only Vibe Coding triggers the flip).
- [ ] Toggle macOS Reduce Motion — the on-load pulse does not play; Community label switches instantly between orientations.
- [ ] Load page in a background tab, then bring it forward — pulse sequence fires on the visibility change.