### PR TITLE
fix(home): pulse sequence collapses to 1ms in production builds

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -463,11 +463,18 @@ const homepageJsonLd = {
       // Read spec-locked timings from CSS custom properties so the
       // values stay controllable from one place (src/styles/global.css
       // :root) and the JS doesn't drift from the CSS keyframe duration.
+      // Vite/lightningcss minifies durations to whichever serialization
+      // is shorter — `700ms` is emitted as `.7s` in production — so the
+      // parser has to honor both units. parseFloat alone would read
+      // `.7s` as 0.7 and collapse the entire 1.4s sequence to 1.4ms.
       const motionTokens = getComputedStyle(document.documentElement);
       const readMs = (name, fallback) => {
         const raw = motionTokens.getPropertyValue(name).trim();
-        const n = parseFloat(raw);
-        return Number.isFinite(n) ? n : fallback;
+        const m = raw.match(/^([+-]?[\d.]+)\s*(ms|s)\s*$/i);
+        if (!m) return fallback;
+        const n = parseFloat(m[1]);
+        if (!Number.isFinite(n)) return fallback;
+        return m[2].toLowerCase() === 's' ? n * 1000 : n;
       };
       const PULSE_INITIAL_DELAY = readMs('--pulse-initial-delay', 700);
       const PULSE_INTERVAL = readMs('--pulse-interval', 370);


### PR DESCRIPTION
User reported the on-load clockwise pulse sequence (#305) was not visibly firing on the deployed site after PR #306 shipped.

## Root cause
Vite/lightningcss minifies CSS durations to whichever serialization is shorter, so the new tokens emit as `.7s` / `.37s` / `.25s` in production (verified via the live `global.CRTD5GZ-.css`). The JS parser in `src/pages/index.astro` used a bare `parseFloat` and read `.7s` as `0.7` — interpreted as milliseconds — so:

- `PULSE_INITIAL_DELAY = 0.7` instead of `700`
- `PULSE_INTERVAL = 0.37` instead of `370`
- `PULSE_DURATION = 0.25` instead of `250`

All four pulses fired within ~1ms of each other on load and the `.panel--pulsing` class was removed before the keyframe could play — hence "no visible animation". Dev mode masked the bug because Vite does not minify durations there.

## Fix
Make `readMs` unit-aware. Honors both `ms` and `s` and falls back gracefully on empty/garbage input. Verified in node against the production-minified values:

```
"700ms"  => 700        ".7s"   => 700
"370ms"  => 370        ".37s"  => 370
"250ms"  => 250        ".25s"  => 250
""/null/"abc"/"700"   => fallback
```

Authoring-Agent: claude

## Self-Review
- Correctness: regex `^([+-]?[\d.]+)\s*(ms|s)\s*$` matches both serializations and rejects malformed input cleanly. Fallback path preserved.
- Regression risk: `readMs` is only called by the on-load pulse sequence; no other callers.
- Test coverage: validated against the actual production CSS values + edge cases via a node REPL run captured in the commit body.
- Security/dependency hygiene: none.

## Test plan
- [ ] Hard reload nathanpayne.com on a deploy of this commit. Red → yellow → blue → black pulse clockwise over ~1.4s starting 700ms after the page becomes visible.
- [ ] Reduced motion still no-ops.
- [ ] Dev mode (`npm run dev`) still works (was always working).