### PR TITLE
fix(home): pulse waits for label fade-in to complete before firing

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -476,9 +476,13 @@ const homepageJsonLd = {
         if (!Number.isFinite(n)) return fallback;
         return m[2].toLowerCase() === 's' ? n * 1000 : n;
       };
-      const PULSE_INITIAL_DELAY = readMs('--pulse-initial-delay', 700);
+      const PULSE_INITIAL_DELAY = readMs('--pulse-initial-delay', 300);
       const PULSE_INTERVAL = readMs('--pulse-interval', 370);
       const PULSE_DURATION = readMs('--pulse-duration', 250);
+      // Outer cap: BaseLayout's font gate falls open after 1500ms even if
+      // document.fonts.ready never resolves; pulse should still fire in
+      // that case, just from the failsafe path.
+      const FONTS_READY_FAILSAFE = 1700;
       let pulseFired = false;
 
       function pulsePanel(className) {
@@ -491,9 +495,27 @@ const homepageJsonLd = {
       function runPulseSequence() {
         if (pulseFired || reduceMotion) return;
         pulseFired = true;
-        PULSE_ORDER.forEach((className, i) => {
-          setTimeout(() => pulsePanel(className), PULSE_INITIAL_DELAY + i * PULSE_INTERVAL);
-        });
+        // Wait for the panel labels to settle before pulsing. Fonts.ready
+        // resolves once Cormorant Garamond is loaded; the labels then
+        // fade in over --motion-hover (~170ms); --pulse-initial-delay
+        // (~300ms) gives the page a visible breath before motion starts.
+        // Failsafe: if document.fonts is unavailable or never resolves,
+        // fire after FONTS_READY_FAILSAFE so the discoverability cue
+        // doesn't get stranded.
+        let scheduled = false;
+        const start = function () {
+          if (scheduled) return;
+          scheduled = true;
+          PULSE_ORDER.forEach(function (className, i) {
+            setTimeout(function () { pulsePanel(className); }, PULSE_INITIAL_DELAY + i * PULSE_INTERVAL);
+          });
+        };
+        if (document.fonts && document.fonts.ready && typeof document.fonts.ready.then === 'function') {
+          document.fonts.ready.then(start);
+          setTimeout(start, FONTS_READY_FAILSAFE);
+        } else {
+          start();
+        }
       }
 
       if (document.visibilityState === 'visible') {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -37,7 +37,11 @@
      and the Community label cross-fade (#304). Defined as tokens so
      timing stays controllable from one place; the inline script in
      src/pages/index.astro reads --pulse-* via getComputedStyle. */
-  --pulse-initial-delay: 700ms;   /* settle before the sequence fires */
+  --pulse-initial-delay: 300ms;   /* breath after panel labels finish fading
+                                     in before the sequence fires; the fade-in
+                                     itself runs at --motion-hover (~170ms),
+                                     so this leaves the page visibly settled
+                                     before any motion starts */
   --pulse-interval: 370ms;        /* time between successive pulse starts */
   --pulse-duration: 250ms;        /* per-panel pulse length */
   --label-fade: 100ms;            /* per-orientation cross-fade duration */


### PR DESCRIPTION
User noted a residual flash on load: panel labels were still mid-fade-in (the font-readiness gate from #306) when the on-load pulse sequence (#305) started its first brightness shift. The two animations overlapped and read as a single hard flash.

## Fix
Chain the pulse on `document.fonts.ready` so the labels fully resolve in Cormorant Garamond before any motion starts. Failsafe path (`setTimeout` 1700ms) ensures the cue still fires if `document.fonts` is unavailable or never resolves — matches `BaseLayout`s 1500ms font gate timeout plus a 200ms safety margin.

## Token retune
`--pulse-initial-delay`: 700ms → 300ms.
- Was "settle from page load"; now "breath after panel labels finish fading in before the sequence fires".
- Labels themselves fade over `--motion-hover` (~170ms) once `fonts.ready` resolves; 300ms leaves the page visibly settled before motion.
- With cached fonts, total time-to-first-pulse is ~480ms (was 700ms). With cold fonts it is bounded by `fonts.ready + 300ms` (typically <800ms).

Issue #305 originally specified 700ms as a settle delay from load on the assumption that nothing else was animating during that window. With the font-gate fade-in now occupying the early window, the spec intent ("page demonstrates its interactivity once it has settled") is better met by chaining on the actual settle event rather than guessing the duration up front.

Authoring-Agent: claude

## Self-Review
- **Correctness:** `runPulseSequence` now wraps the existing `setTimeout` chain in a `start` closure that resolves on either `document.fonts.ready` or the 1700ms failsafe. Inner `scheduled` flag prevents double-fire if both paths resolve. The outer `pulseFired` guard still keeps it once-per-load.
- **Regression risk:** Reduced-motion path unchanged (still no-ops). Background-tab visibility deferral unchanged. Failsafe matches the upstream font gate so the worst-case path still completes.
- **Test coverage:** None for these classes; verified the production CSS now serializes `--pulse-initial-delay` as `.3s` and the `readMs` parser (PR #307) reads it as 300ms.
- **Security / dependency hygiene:** None.

## Test plan
- [ ] Hard reload nathanpayne.com — labels fade in in Cormorant Garamond, then ~300ms later the four panels pulse clockwise (red → yellow → blue → black). No overlap between the two motions.
- [ ] Reduce Motion enabled — pulse no-ops; label fade transition collapses to instant per existing rule.
- [ ] Load in a background tab, then surface — sequence still defers to `visibilitychange`.