### PR TITLE
chore(home): css-token audit follow-up (#306, #307)

### DIFF
--- a/docs/agents/code-modification-rules.md
+++ b/docs/agents/code-modification-rules.md
@@ -29,8 +29,9 @@ All cells transition to a warm parchment tone when opened.
 --motion-hover:          170ms  (hover states)
 --motion-plane:          280ms  (panel expand / grid morph, on-load settle)
 --motion-load:           300ms  (section entrance)
---motion-pulse:          700ms  (discoverability breath)
---motion-stagger-step:    65ms  (per-sibling delay in staggered groups)
+--pulse-initial-delay:   300ms  (delay before on-load pulse sequence fires; removed --motion-pulse in #306)
+--pulse-interval:        370ms  (time between successive panel pulse starts)
+--pulse-duration:        250ms  (per-panel brightness/saturation breath)
 ```
 
 #### Motion — Easing
@@ -58,8 +59,9 @@ All animation timing is governed by the motion tokens above. No hard-coded durat
 | Panel morph | `--motion-plane` (280ms) | `--ease-sharp` | Mondrian grid transitions |
 | Settle on load | `--motion-plane` (280ms) | `--ease-standard` | Per-block entrance scale (Mondrian discoverability) |
 | Section load | `--motion-load` (300ms) | `--ease-standard` | Entrance animations |
-| Discoverability breath | `--motion-pulse` (700ms) | `--ease-linear` | Brightness/saturation pulse on idle panels |
-| Stagger step | `--motion-stagger-step` (65ms) | n/a | Per-sibling delay in staggered groups |
+| On-load pulse (delay) | `--pulse-initial-delay` (300ms) | n/a | Pause after label fade-in before sequence fires (#306) |
+| On-load pulse (interval) | `--pulse-interval` (370ms) | n/a | Time between successive panel pulse starts |
+| On-load pulse (per-panel) | `--pulse-duration` (250ms) | `--ease-out` | Per-panel brightness/saturation breath |
 
 #### Scroll Guard
 JavaScript adds `.is-scrolling` to `<body>` during active scroll (debounced at 100ms). CSS suspends hover transitions on interactive elements while this class is present, preventing scroll + hover easing conflicts.


### PR DESCRIPTION
## Summary

Follow-up audit of the two CSS-token cleanup PRs (#306, #307).

### Pass 1 — Stale `--motion-pulse` / `--motion-stagger-step` references

**Finding:** `docs/agents/code-modification-rules.md` still listed both removed tokens.

| File | Lines | Change |
|------|-------|--------|
| `docs/agents/code-modification-rules.md` | 32–33 (token table) | Replaced `--motion-pulse` and `--motion-stagger-step` with the new `--pulse-initial-delay`, `--pulse-interval`, `--pulse-duration` tokens added in #306 |
| `docs/agents/code-modification-rules.md` | 61–62 (motion system rules table) | Replaced "Discoverability breath" / "Stagger step" rows with three "On-load pulse" rows pointing at the new `--pulse-*` tokens |

All other non-CSS files (README, AGENTS, CLAUDE.md, .ai_context.md, specs/, scripts/, remaining docs/) were clean.
CSS comments inside `src/styles/global.css` were not touched (historical notes are intentionally kept there).

### Pass 2 — Naive `parseFloat` on CSS duration tokens

**Clean.** The only matches in `src/` are the three lines comprising the canonical `readMs` helper already introduced in #307 (`src/pages/index.astro:468–477`). No other call site reads a CSS custom property and strips units unsafely.

---

Authoring-Agent: claude

## Self-Review

- **Correctness:** Token names and values copied directly from `src/styles/global.css` :root (lines 40–46). No values are guessed.
- **Regression risk:** Documentation-only change. Zero functional behavior modified.
- **Style:** Prose and table format match the surrounding document.
- **Test coverage:** No tests required — no code changed.
- **Security/dependency hygiene:** No new dependencies. No secrets touched.

https://claude.ai/code/session_01TUMtbEuChaTqvYpWqiWAC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUMtbEuChaTqvYpWqiWAC6)_