### PR TITLE
Harden Swipe Watch autoplay fallback

### DIFF
--- a/specs/project-pages.md
+++ b/specs/project-pages.md
@@ -148,7 +148,7 @@ Any project can render a vertical Mux video in the hero instead of a static scre
 
 - **Autoplay + loop**: `<mux-background-video>` creates a muted, looped, plays-inline video to match the feel of the animated GIFs that the static hero slot previously used.
 - **Analytics**: pages with a Mux hero load `mux-embed` before registering `<mux-background-video>`. Mux Data monitoring is automatic for the background video and infers the env key from the `stream.mux.com` URL; no `PUBLIC_MUX_ENV_KEY` is read by this site.
-- **Fallback**: the existing `screenshotSrc` image renders in `<noscript>`, while the Mux thumbnail renders inside `<mux-background-video>` as the pre-upgrade poster.
+- **Fallback**: the existing `screenshotSrc` image renders in `<noscript>` and is also the autoplay-failure fallback. On JavaScript-enabled pages, the Mux thumbnail renders inside `<mux-background-video>` as the pre-upgrade poster; if the custom element fails to register, the media errors, or the shadow `<video>` does not make real playback progress within the autoplay window, the component lazy-loads the `screenshotSrc` GIF, fades the stalled video out, and reveals a compact manual play button.
 - **Bundle cost**: the Mux custom element is registered only when a page contains a `<mux-background-video>` element. Projects without `muxPlaybackId` do not load `mux-embed` or the background-video package at runtime.
 
 ### Aspect ratio

--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -13,8 +13,9 @@
 //   chrome, internal autoplay orchestration, and the Safari behavior
 //   this project actually needs.
 //
-// When `playbackId` is unset, falls back to the `fallbackSrc` image so the
-// hero never goes blank.
+// When autoplay fails, swaps to the Mux-generated `fallbackSrc` GIF so the
+// hero still reads like an animated product capture. When `playbackId` is
+// unset, falls back to the `fallbackSrc` image directly.
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -99,13 +100,36 @@ if (isSvgFallback) {
 
 {playbackId ? (
   <>
-    <mux-background-video
-      src={streamSrc}
-      preload="auto"
-      class="project-screenshot__mux"
+    <div
+      class="project-screenshot__mux-frame"
+      data-mux-hero
+      data-playback-state="loading"
+      role="img"
+      aria-label={altText}
     >
-      <img src={posterSrc} alt={altText} />
-    </mux-background-video>
+      <img
+        class="project-screenshot__mux-gif-fallback"
+        data-src={fallbackSrc}
+        alt=""
+        aria-hidden="true"
+        decoding="async"
+      />
+      <mux-background-video
+        src={streamSrc}
+        preload="auto"
+        class="project-screenshot__mux"
+        aria-hidden="true"
+      >
+        <img class="project-screenshot__mux-poster" src={posterSrc} alt="" aria-hidden="true" />
+      </mux-background-video>
+      <button
+        class="project-screenshot__mux-play"
+        type="button"
+        data-mux-play
+        aria-label={`Play ${title} demo`}
+        hidden
+      ></button>
+    </div>
     <noscript>
       <img src={fallbackSrc} alt={altText} loading="eager" />
     </noscript>
@@ -118,6 +142,103 @@ if (isSvgFallback) {
 
 <script>
   const muxHero = document.querySelector('mux-background-video');
+  const muxFrame = muxHero?.closest('[data-mux-hero]');
+  const gifFallback = muxFrame?.querySelector('[data-src]');
+  const playButton = muxFrame?.querySelector('[data-mux-play]');
+  const AUTOPLAY_FALLBACK_DELAY = 2800;
+
+  function hidePlayButton() {
+    if (playButton instanceof HTMLButtonElement) {
+      playButton.hidden = true;
+    }
+  }
+
+  function showPlayButton() {
+    if (playButton instanceof HTMLButtonElement) {
+      playButton.hidden = false;
+    }
+  }
+
+  function showAnimatedFallback() {
+    if (!muxFrame || muxFrame.dataset.playbackState === 'playing') return;
+
+    if (gifFallback instanceof HTMLImageElement && gifFallback.dataset.src && !gifFallback.src) {
+      gifFallback.src = gifFallback.dataset.src;
+    }
+
+    muxFrame.dataset.playbackState = 'fallback';
+    showPlayButton();
+  }
+
+  function markPlaybackProgress(timer) {
+    if (!muxFrame) return;
+
+    window.clearTimeout(timer);
+    muxFrame.dataset.playbackState = 'playing';
+    hidePlayButton();
+  }
+
+  function requestManualPlayback(video) {
+    if (!muxFrame) return;
+
+    muxFrame.dataset.playbackState = 'loading';
+    hidePlayButton();
+
+    const manualTimer = window.setTimeout(showAnimatedFallback, AUTOPLAY_FALLBACK_DELAY);
+    video.muted = true;
+    video.playsInline = true;
+
+    const playAttempt = video.play();
+    if (playAttempt && typeof playAttempt.catch === 'function') {
+      playAttempt.catch(() => {
+        window.clearTimeout(manualTimer);
+        showAnimatedFallback();
+      });
+    }
+  }
+
+  function monitorMuxPlayback() {
+    if (!muxHero || !muxFrame) return;
+
+    const video = muxHero.shadowRoot?.querySelector('video');
+    let sawPlayback = false;
+    const fallbackTimer = window.setTimeout(() => {
+      if (!sawPlayback) showAnimatedFallback();
+    }, AUTOPLAY_FALLBACK_DELAY);
+
+    const markPlaying = () => {
+      sawPlayback = true;
+      markPlaybackProgress(fallbackTimer);
+    };
+
+    if (!video) {
+      window.clearTimeout(fallbackTimer);
+      showAnimatedFallback();
+      return;
+    }
+
+    if (video.currentTime > 0) {
+      markPlaying();
+      return;
+    }
+
+    const markFailure = () => {
+      window.clearTimeout(fallbackTimer);
+      showAnimatedFallback();
+    };
+    const handleTimeUpdate = () => {
+      if (video.currentTime > 0) {
+        video.removeEventListener('timeupdate', handleTimeUpdate);
+        video.removeEventListener('playing', handleTimeUpdate);
+        markPlaying();
+      }
+    };
+
+    video.addEventListener('playing', handleTimeUpdate);
+    video.addEventListener('timeupdate', handleTimeUpdate);
+    video.addEventListener('error', markFailure, { once: true });
+    playButton?.addEventListener('click', () => requestManualPlayback(video));
+  }
 
   function loadMuxEmbed() {
     if (globalThis.mux) return Promise.resolve();
@@ -160,7 +281,10 @@ if (isSvgFallback) {
   // infers the env key from the stream.mux.com URL.
   if (muxHero) {
     loadMuxEmbed().finally(() => {
-      import('@mux/mux-background-video/html');
+      import('@mux/mux-background-video/html')
+        .then(() => customElements.whenDefined('mux-background-video'))
+        .then(monitorMuxPlayback)
+        .catch(showAnimatedFallback);
     });
   }
 </script>

--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -100,28 +100,28 @@ if (isSvgFallback) {
 
 {playbackId ? (
   <>
-    <div
-      class="project-screenshot__mux-frame"
-      data-mux-hero
-      data-playback-state="loading"
-      role="img"
-      aria-label={altText}
-    >
-      <img
-        class="project-screenshot__mux-gif-fallback"
-        data-src={fallbackSrc}
-        alt=""
-        aria-hidden="true"
-        decoding="async"
-      />
-      <mux-background-video
-        src={streamSrc}
-        preload="auto"
-        class="project-screenshot__mux"
-        aria-hidden="true"
+    <div class="project-screenshot__mux-shell" data-mux-hero data-playback-state="loading">
+      <div
+        class="project-screenshot__mux-frame"
+        role="img"
+        aria-label={altText}
       >
-        <img class="project-screenshot__mux-poster" src={posterSrc} alt="" aria-hidden="true" />
-      </mux-background-video>
+        <img
+          class="project-screenshot__mux-gif-fallback"
+          data-src={fallbackSrc}
+          alt=""
+          aria-hidden="true"
+          decoding="async"
+        />
+        <mux-background-video
+          src={streamSrc}
+          preload="auto"
+          class="project-screenshot__mux"
+          aria-hidden="true"
+        >
+          <img class="project-screenshot__mux-poster" src={posterSrc} alt="" aria-hidden="true" />
+        </mux-background-video>
+      </div>
       <button
         class="project-screenshot__mux-play"
         type="button"
@@ -159,7 +159,7 @@ if (isSvgFallback) {
     }
   }
 
-  function showAnimatedFallback() {
+  function showAnimatedFallback(manualPlayAvailable = false) {
     if (!muxFrame || muxFrame.dataset.playbackState === 'playing') return;
 
     if (gifFallback instanceof HTMLImageElement && gifFallback.dataset.src && !gifFallback.src) {
@@ -167,7 +167,11 @@ if (isSvgFallback) {
     }
 
     muxFrame.dataset.playbackState = 'fallback';
-    showPlayButton();
+    if (manualPlayAvailable) {
+      showPlayButton();
+    } else {
+      hidePlayButton();
+    }
   }
 
   function markPlaybackProgress(timer) {
@@ -184,7 +188,7 @@ if (isSvgFallback) {
     muxFrame.dataset.playbackState = 'loading';
     hidePlayButton();
 
-    const manualTimer = window.setTimeout(showAnimatedFallback, AUTOPLAY_FALLBACK_DELAY);
+    const manualTimer = window.setTimeout(() => showAnimatedFallback(true), AUTOPLAY_FALLBACK_DELAY);
     video.muted = true;
     video.playsInline = true;
 
@@ -192,7 +196,7 @@ if (isSvgFallback) {
     if (playAttempt && typeof playAttempt.catch === 'function') {
       playAttempt.catch(() => {
         window.clearTimeout(manualTimer);
-        showAnimatedFallback();
+        showAnimatedFallback(true);
       });
     }
   }
@@ -203,7 +207,7 @@ if (isSvgFallback) {
     const video = muxHero.shadowRoot?.querySelector('video');
     let sawPlayback = false;
     const fallbackTimer = window.setTimeout(() => {
-      if (!sawPlayback) showAnimatedFallback();
+      if (!sawPlayback) showAnimatedFallback(true);
     }, AUTOPLAY_FALLBACK_DELAY);
 
     const markPlaying = () => {
@@ -213,7 +217,7 @@ if (isSvgFallback) {
 
     if (!video) {
       window.clearTimeout(fallbackTimer);
-      showAnimatedFallback();
+      showAnimatedFallback(false);
       return;
     }
 
@@ -224,7 +228,7 @@ if (isSvgFallback) {
 
     const markFailure = () => {
       window.clearTimeout(fallbackTimer);
-      showAnimatedFallback();
+      showAnimatedFallback(true);
     };
     const handleTimeUpdate = () => {
       if (video.currentTime > 0) {

--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -145,6 +145,8 @@ if (isSvgFallback) {
   const muxFrame = muxHero?.closest('[data-mux-hero]');
   const gifFallback = muxFrame?.querySelector('[data-src]');
   const playButton = muxFrame?.querySelector('[data-mux-play]');
+  // Long enough for Safari/WebKit to prove real frame progress on slower
+  // networks; short enough that a blocked hero reads as intentional fallback.
   const AUTOPLAY_FALLBACK_DELAY = 2800;
 
   function hidePlayButton() {
@@ -226,16 +228,22 @@ if (isSvgFallback) {
       return;
     }
 
+    let cleanup = () => {};
+    const handleTimeUpdate = () => {
+      if (video.currentTime > 0) {
+        cleanup();
+        markPlaying();
+      }
+    };
     const markFailure = () => {
+      cleanup();
       window.clearTimeout(fallbackTimer);
       showAnimatedFallback(true);
     };
-    const handleTimeUpdate = () => {
-      if (video.currentTime > 0) {
-        video.removeEventListener('timeupdate', handleTimeUpdate);
-        video.removeEventListener('playing', handleTimeUpdate);
-        markPlaying();
-      }
+    cleanup = () => {
+      video.removeEventListener('playing', handleTimeUpdate);
+      video.removeEventListener('timeupdate', handleTimeUpdate);
+      video.removeEventListener('error', markFailure);
     };
 
     video.addEventListener('playing', handleTimeUpdate);
@@ -288,7 +296,7 @@ if (isSvgFallback) {
       import('@mux/mux-background-video/html')
         .then(() => customElements.whenDefined('mux-background-video'))
         .then(monitorMuxPlayback)
-        .catch(showAnimatedFallback);
+        .catch(() => showAnimatedFallback(false));
     });
   }
 </script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1254,12 +1254,16 @@ body.blog-page {
    bars. Width is capped by the surrounding .project-screenshot--narrow
    container's 320px max-width so pages stay visually consistent
    between img and video modes. */
-.project-screenshot__mux-frame {
+.project-screenshot__mux-shell {
   position: relative;
   width: 100%;
   border-radius: 12px;
   overflow: hidden;
   background: var(--ink);
+}
+
+.project-screenshot__mux-frame {
+  width: 100%;
 }
 
 .project-screenshot__mux {
@@ -1295,11 +1299,11 @@ body.blog-page {
   transition: opacity var(--motion-fast) var(--ease-linear);
 }
 
-.project-screenshot__mux-frame[data-playback-state="fallback"] .project-screenshot__mux {
+.project-screenshot__mux-shell[data-playback-state="fallback"] .project-screenshot__mux {
   opacity: 0;
 }
 
-.project-screenshot__mux-frame[data-playback-state="fallback"] .project-screenshot__mux-gif-fallback {
+.project-screenshot__mux-shell[data-playback-state="fallback"] .project-screenshot__mux-gif-fallback {
   opacity: 1;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1254,21 +1254,100 @@ body.blog-page {
    bars. Width is capped by the surrounding .project-screenshot--narrow
    container's 320px max-width so pages stay visually consistent
    between img and video modes. */
+.project-screenshot__mux-frame {
+  position: relative;
+  width: 100%;
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--ink);
+}
+
 .project-screenshot__mux {
   display: block;
   width: 100%;
   border-radius: 12px;
   overflow: hidden;
+  opacity: 1;
+  transition: opacity var(--motion-fast) var(--ease-linear);
 }
 
 /* Poster frame inside the background-video element. Before JS upgrades
    the custom element, this light-DOM image fills the hero slot so the
    page never flashes blank. */
-.project-screenshot__mux > img {
+.project-screenshot__mux-poster {
   display: block;
   width: 100%;
   height: auto;
   border-radius: 12px;
+}
+
+.project-screenshot__mux-gif-fallback {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 12px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--motion-fast) var(--ease-linear);
+}
+
+.project-screenshot__mux-frame[data-playback-state="fallback"] .project-screenshot__mux {
+  opacity: 0;
+}
+
+.project-screenshot__mux-frame[data-playback-state="fallback"] .project-screenshot__mux-gif-fallback {
+  opacity: 1;
+}
+
+.project-screenshot__mux-play {
+  position: absolute;
+  inset: 50% auto auto 50%;
+  z-index: 2;
+  display: grid;
+  place-items: center;
+  width: 3rem;
+  height: 3rem;
+  padding: 0;
+  border: 1px solid rgba(245, 240, 228, 0.72);
+  border-radius: 999px;
+  background: rgba(17, 16, 13, 0.78);
+  box-shadow: 0 0.35rem 1.2rem rgba(17, 16, 13, 0.26);
+  cursor: pointer;
+  transform: translate(-50%, -50%);
+  transition:
+    background-color var(--motion-hover) var(--ease-standard),
+    border-color var(--motion-hover) var(--ease-standard),
+    transform var(--motion-hover) var(--ease-standard);
+}
+
+.project-screenshot__mux-play::before {
+  content: "";
+  display: block;
+  width: 0;
+  height: 0;
+  margin-left: 0.16rem;
+  border-top: 0.5rem solid transparent;
+  border-bottom: 0.5rem solid transparent;
+  border-left: 0.78rem solid var(--cream);
+}
+
+.project-screenshot__mux-play:hover {
+  background: rgba(17, 16, 13, 0.9);
+  border-color: var(--cream);
+  transform: translate(-50%, calc(-50% - var(--shift-small)));
+}
+
+.project-screenshot__mux-play:focus-visible {
+  outline: 2px solid var(--cream);
+  outline-offset: 3px;
+}
+
+.project-screenshot__mux-play[hidden] {
+  display: none;
 }
 
 /* Stack line — rendered as a <figcaption> inside the screenshot figure.

--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -203,11 +203,13 @@ describe('Project Pages — screenshot aspect variants', () => {
     expect(player.getAttribute('preload')).toBe('auto');
     expect(player.hasAttribute('max-resolution')).toBe(false);
 
-    const frame = document.querySelector('.project-screenshot__mux-frame[data-mux-hero]');
+    const frame = document.querySelector('.project-screenshot__mux-shell[data-mux-hero]');
     expect(frame, 'Swipe Watch mux frame not found').not.toBeNull();
     expect(frame.getAttribute('data-playback-state')).toBe('loading');
-    expect(frame.getAttribute('role')).toBe('img');
-    expect(frame.getAttribute('aria-label')).toBe('Swipe Watch product screenshot');
+
+    const mediaFrame = frame.querySelector('.project-screenshot__mux-frame');
+    expect(mediaFrame.getAttribute('role')).toBe('img');
+    expect(mediaFrame.getAttribute('aria-label')).toBe('Swipe Watch product screenshot');
 
     const gifFallback = frame.querySelector('.project-screenshot__mux-gif-fallback');
     expect(gifFallback, 'Swipe Watch Mux GIF fallback not found').not.toBeNull();

--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -107,13 +107,17 @@ describe('Project Pages — render', () => {
         // <svg> (inline wordmarks; see ProjectMuxPlayer for why SVG fallbacks
         // are inlined rather than referenced via <img src=...>). Either path
         // must carry an accessible name.
-        const img = figure.querySelector('img');
+        const img = figure.querySelector('img[alt]:not([alt=""])');
         const svg = figure.querySelector('svg');
-        expect(img || svg, 'no <img> or <svg> inside .project-screenshot').not.toBeNull();
+        const roleImage = figure.querySelector('[role="img"][aria-label]');
+        expect(
+          img || svg || roleImage,
+          'no accessible image inside .project-screenshot',
+        ).not.toBeNull();
         if (img) {
           expect(img.getAttribute('src')).toBeTruthy();
           expect(img.getAttribute('alt')).toBeTruthy();
-        } else {
+        } else if (svg) {
           // Inline SVG must carry image semantics so screen readers
           // announce it the way an <img alt="..."> would.
           expect(
@@ -199,9 +203,28 @@ describe('Project Pages — screenshot aspect variants', () => {
     expect(player.getAttribute('preload')).toBe('auto');
     expect(player.hasAttribute('max-resolution')).toBe(false);
 
-    const poster = player.querySelector('img');
+    const frame = document.querySelector('.project-screenshot__mux-frame[data-mux-hero]');
+    expect(frame, 'Swipe Watch mux frame not found').not.toBeNull();
+    expect(frame.getAttribute('data-playback-state')).toBe('loading');
+    expect(frame.getAttribute('role')).toBe('img');
+    expect(frame.getAttribute('aria-label')).toBe('Swipe Watch product screenshot');
+
+    const gifFallback = frame.querySelector('.project-screenshot__mux-gif-fallback');
+    expect(gifFallback, 'Swipe Watch Mux GIF fallback not found').not.toBeNull();
+    expect(gifFallback.getAttribute('data-src')).toBe('/images/projects/swipe-watch-hero.gif');
+    expect(gifFallback.hasAttribute('src')).toBe(false);
+    expect(gifFallback.getAttribute('aria-hidden')).toBe('true');
+
+    const playButton = frame.querySelector('.project-screenshot__mux-play[data-mux-play]');
+    expect(playButton, 'Swipe Watch manual play button not found').not.toBeNull();
+    expect(playButton.getAttribute('type')).toBe('button');
+    expect(playButton.getAttribute('aria-label')).toBe('Play Swipe Watch demo');
+    expect(playButton.hasAttribute('hidden')).toBe(true);
+
+    const poster = player.querySelector('.project-screenshot__mux-poster');
     expect(poster, 'Swipe Watch poster img not found').not.toBeNull();
     expect(poster.getAttribute('src')).toBe('https://image.mux.com/wNCRY97981o2uDAJrJ3ExPeK379yldRRFJgUIgSYz00k/thumbnail.jpg?width=1280&time=0');
+    expect(poster.getAttribute('aria-hidden')).toBe('true');
 
     const moduleSrcs = Array.from(
       html.matchAll(/<script type="module" src="([^"]+)"/g),
@@ -213,6 +236,12 @@ describe('Project Pages — screenshot aspect variants', () => {
       .find((code) => code.includes('https://cdn.jsdelivr.net/npm/mux-embed@5.18.0'));
     expect(muxScript, 'Mux runtime module not found').toBeTruthy();
     expect(muxScript).toMatch(/querySelector\((['"])mux-background-video\1\)/);
+    expect(muxScript).toContain('shadowRoot?.querySelector("video")');
+    expect(muxScript).toContain('setTimeout');
+    expect(muxScript).toContain('dataset.playbackState="fallback"');
+    expect(muxScript).toContain('dataset.playbackState="playing"');
+    expect(muxScript).toContain('.play()');
+    expect(muxScript).toContain('currentTime>0');
     expect(html).not.toContain('PUBLIC_MUX_ENV_KEY');
   });
 

--- a/tests/responsive/swipe-watch-mux-fallback.spec.ts
+++ b/tests/responsive/swipe-watch-mux-fallback.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+
+test('Swipe Watch swaps to the Mux GIF fallback when the stream cannot autoplay', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'Desktop 1440', 'One viewport covers this media failure contract.');
+
+  await page.route('https://stream.mux.com/**', (route) => route.abort());
+  await page.goto('/projects/swipe-watch/');
+
+  const frame = page.locator('.project-screenshot__mux-frame');
+  await expect(frame).toHaveAttribute('data-playback-state', 'fallback', { timeout: 7000 });
+
+  const fallback = frame.locator('.project-screenshot__mux-gif-fallback');
+  await expect(fallback).toHaveAttribute('src', /\/images\/projects\/swipe-watch-hero\.gif$/);
+  await expect(fallback).toHaveCSS('opacity', '1');
+
+  const playButton = frame.locator('.project-screenshot__mux-play');
+  await expect(playButton).toBeVisible();
+  await expect(playButton).toHaveAttribute('aria-label', 'Play Swipe Watch demo');
+});

--- a/tests/responsive/swipe-watch-mux-fallback.spec.ts
+++ b/tests/responsive/swipe-watch-mux-fallback.spec.ts
@@ -6,7 +6,7 @@ test('Swipe Watch swaps to the Mux GIF fallback when the stream cannot autoplay'
   await page.route('https://stream.mux.com/**', (route) => route.abort());
   await page.goto('/projects/swipe-watch/');
 
-  const frame = page.locator('.project-screenshot__mux-frame');
+  const frame = page.locator('.project-screenshot__mux-shell');
   await expect(frame).toHaveAttribute('data-playback-state', 'fallback', { timeout: 7000 });
 
   const fallback = frame.locator('.project-screenshot__mux-gif-fallback');

--- a/tests/responsive/swipe-watch-mux-fallback.spec.ts
+++ b/tests/responsive/swipe-watch-mux-fallback.spec.ts
@@ -16,4 +16,10 @@ test('Swipe Watch swaps to the Mux GIF fallback when the stream cannot autoplay'
   const playButton = frame.locator('.project-screenshot__mux-play');
   await expect(playButton).toBeVisible();
   await expect(playButton).toHaveAttribute('aria-label', 'Play Swipe Watch demo');
+
+  await playButton.click();
+  await expect(frame).toHaveAttribute('data-playback-state', 'loading');
+  await expect(playButton).toBeHidden();
+  await expect(frame).toHaveAttribute('data-playback-state', 'fallback', { timeout: 7000 });
+  await expect(playButton).toBeVisible();
 });


### PR DESCRIPTION
Authoring-Agent: codex

## Summary

- harden the Swipe Watch Mux hero so Safari-style autoplay stalls fall back to the Mux-generated GIF
- expose a compact manual play control when the page has fallen back and a real shadow video exists
- add generated HTML and browser coverage for the fallback path, including the manual retry click path

## Root Cause

The hero treated the background video `playing` event as proof that autoplay had succeeded. Safari can reach a visually stalled state where that signal is not enough for the page to feel like an animated GIF, and the prior fallback left no reliable manual start path.

## Self-Review

- Correctness: verified the fallback only counts real playback progress (`currentTime > 0`) as success, hides the play control when there is no shadow video to play, and avoids the import-error path exposing an inert button.
- Regression risk: scoped to project-page Mux heroes; non-Mux project screenshots still render through the existing image/SVG paths.
- Style: follows the existing Astro component plus global CSS pattern, uses existing motion tokens, and keeps the play affordance icon-only with an accessible label.
- Test coverage: updated project-page build assertions and added Playwright coverage for blocked Mux stream fallback plus manual retry behavior.
- Security/dependencies: no new dependencies, no credential/config changes, and no new external asset source beyond the existing Mux-generated GIF path.

## Validation

- `npm run test`
- `npm run test:e2e`
- Playwright WebKit normal path: shadow video reached real `currentTime > 0` playback progress
- Playwright WebKit blocked-stream path: GIF fallback loaded and the manual play button became visible
