### PR TITLE
fix(home): tighten Vibe Coding entry spacing; trim Matchline copy (#311)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -121,7 +121,7 @@ const homepageJsonLd = {
                 <div class="p-head">
                   <a class="p-name p-name-link" href="/projects/matchline/" aria-label="Read the Matchline project page">Matchline<span class="link-arrow" aria-hidden="true">→</span></a>
                 </div>
-                <p>A career CRM for one person running a serious job search. Turns work history into structured, reusable evidence, maps that evidence against specific job requirements, and generates applications grounded in what the user has actually done. Not a resume builder—a discipline.</p>
+                <p>A career CRM for one person running a serious job search. Turns work history into structured, reusable evidence, maps that evidence against specific job requirements, and generates applications grounded in what the user has actually done.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -613,7 +613,7 @@ a:focus-visible .link-arrow,
 }
 
 .panel--yellow .p-head {
-  margin-bottom: 0.15rem;
+  margin-bottom: 0;
 }
 
 .panel--yellow .content-inner {


### PR DESCRIPTION
Authoring-Agent: claude

Closes #311.

## Summary

- Tightens the gap between each Vibe Coding entry's title line and its first line of description so the two read as a single unit (heading + paragraph) rather than as two stacked elements.
- Trims the closing positioning line "Not a resume builder—a discipline." from Matchline's homepage description; the line is preserved on the Matchline detail page (frontmatter description / deck).

## What changed

`src/styles/global.css`
- `.panel--yellow .p-head { margin-bottom: 0.15rem }` → `0`. The visible gap between the title baseline and the first description line is now carried by font leading alone (~5px), close to the in-paragraph leading (~6.5px), so the title attaches to the paragraph it introduces.

`src/pages/index.astro`
- Matchline's homepage `<p>` now ends after "...what the user has actually done." Six entries now have visually consistent description lengths.

## Why not adjust title weight or body size first

The acceptance criteria call for shrinking the gap; the issue's notes treat weight/size as a fallback only if the gap fix isn't sufficient. The gap fix is sufficient — visual rhythm now matches in-paragraph leading — so no typography changes are needed.

## Self-Review

**Correctness.** Verified at desktop in the dev server: all six `.p-head`
elements now report `margin-bottom: 0px` and the box-edge gap between
each `.p-head` and its sibling `<p>` is `0px`, with the visible spacing
driven by leading. All six description text bodies confirmed clear of
"Not a resume builder—a discipline." Matchline detail page keeps the
positioning line via the frontmatter description (used as the deck in
`src/pages/projects/[slug].astro`).

**Regression risk.** `.p-head` is scoped — it only exists inside
`.panel--yellow` (Vibe Coding). Nathan Payne, Community, and Connect
panels do not use the class, confirmed via DOM query. There are no
mobile-specific overrides on `.p-head` in `global.css`, so the change
applies uniformly across breakpoints; rem-based sizing keeps the
rhythm scaling proportionally on smaller viewports.

**Style.** No new selectors; modified one existing rule and one inline
description string. No emojis, no comments added.

**Test coverage.** `npm test` (astro build + 16 vitest files / 143 tests)
passes. No new tests are needed: the change is a one-property CSS tweak
plus a description string trim, both visually verified in the dev server.

**Security / dependency hygiene.** No dependency changes, no new code
paths, no user-input surfaces touched.

## Acceptance criteria

- [x] Vertical space between title line and first description line reduced across all six Vibe Coding entries
- [x] Title and description read as a single unit (heading + paragraph)
- [x] Matchline description ends after "...what the user has actually done."
- [x] No regressions in mobile breakpoint (`.p-head` has no mobile overrides; rem-based sizing scales)
- [x] Borders, arrows, and other entry styling unchanged
- [x] Project detail page for Matchline keeps the positioning line (frontmatter description / deck)

## Test plan

- [x] `npm test` (astro build + vitest) passes locally
- [x] Manual visual check at desktop in dev server (all six entries)
- [x] Matchline detail page deck still shows "Not a resume builder—a discipline." (verified via frontmatter)