### PR TITLE
sync: fix(workflows): use PR author login for Dependabot exemptions (#148, #162) (#169) (mergepath@c3b0df0)

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -92,6 +92,7 @@ jobs:
     needs: [load-config]
     if: >
       github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
       (github.event.action == 'opened' || github.event.action == 'ready_for_review')
     runs-on: ubuntu-latest
     outputs:
@@ -168,6 +169,7 @@ jobs:
     if: >
       always() &&
       github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
       (github.event.action == 'opened' || github.event.action == 'ready_for_review' || github.event.action == 'labeled')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   self-review-check:
     name: Self-Review Required
-    if: github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check for Self-Review section


### PR DESCRIPTION
Auto-propagated from [mergepath@c3b0df0](https://github.com/nathanjohnpayne/mergepath/commit/c3b0df0d97a55e1a45b305b90bb771d9bbbb7cfd) by `scripts/sync-to-downstream.sh` (v0.2.0-layer3-canonical, see [#168](https://github.com/nathanjohnpayne/mergepath/issues/168)).

## Files synced
  - .github/workflows/agent-review.yml
  - .github/workflows/pr-review-policy.yml

## Source

fix(workflows): use PR author login for Dependabot exemptions (#148, #162) (#169)

https://github.com/nathanjohnpayne/mergepath/commit/c3b0df0d97a55e1a45b305b90bb771d9bbbb7cfd

Authoring-Agent: claude

## Self-Review
- Correctness: mirrors mergepath@c3b0df0 verbatim per the upstream manifest. The change has already been reviewed in the upstream Mergepath PR.
- Regression risk: low. Verbatim mirror of an already-reviewed upstream change.
- Style: N/A (mirror).
- Test coverage: relies on the consumer repo CI. No test changes shipped.
- Security: no new attack surface; the sync script never ran with elevated privileges in this consumer.