### PR TITLE
chore: gitignore .codex/hooks.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ logs/
 .cursor/state/
 .cursor/plans/
 
+# Codex CLI local settings
+.codex/hooks.json
+
 # Coverage
 coverage/
 


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
Adds `.codex/hooks.json` to `.gitignore` to prevent the same accidental include that happened on #323 (where my `git add -A` swept the file into the rebrand commit and required a `git rm --cached` follow-up). The file is a per-machine Codex CLI agent hooks config, written when Codex CLI sets up local guardrails — equivalent in role to `.claude/settings.local.json` (already ignored).

## Approach
Followed the existing convention in `.gitignore`:
- `.claude/` ignores **specific local files** (`settings.local.json`, `launch.json`, `worktrees/`) while keeping the directory itself tracked, because `.claude/agents/`, `.claude/hooks/`, etc. are repo config.
- `.cursor/` ignores **specific runtime subdirs** (`cache/`, `state/`, `plans/`) the same way.

Mirrored that pattern: ignore only `.codex/hooks.json`, not the entire `.codex/` directory. Future tracked Codex config (e.g., shared agent definitions) can land in `.codex/` without needing a `.gitignore` exception.

## Verification
- `git check-ignore -v .codex/hooks.json` returns: `.gitignore:43:.codex/hooks.json	.codex/hooks.json` — rule resolves and applies.
- `.gitignore` diff is +3 / -0 (a comment, the rule, and a blank line for section separation).
- Whitespace conventions match neighboring sections.

## Self-Review
- [x] Correctness: rule pattern matches the file path used by Codex CLI; spot-verified.
- [x] Regression risk: zero. `.gitignore` is read by git only; no build, runtime, or test path consults it.
- [x] Style and conventions: matches the existing per-agent-tool comment-and-rule convention in this file.
- [x] Test coverage: not applicable.
- [x] Security and dependency hygiene: zero dependency changes.

## Review path
3 lines added across 1 file. Sub-threshold; no protected paths; internal review only.

## Background
- The original sweep happened on the #323 branch; details in [the PR #323 description](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/323) under "Branch hygiene note." This PR closes that gap so it can't recur.
- Branched from `main` before #323 merged; the change is disjoint from that branch's edits, so no rebase needed.
