### PR TITLE
fix(home): restore horizontal line above Connect in community-focus

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -213,25 +213,26 @@ html, body {
     minmax(2.75rem, 0.75fr)
     var(--line)                       /* track 5 — single line above community */
     var(--cell-h-community, 401px)    /* track 6 — community cell */
-    0                                 /* track 7 — line absorbed (inside community) */
-    minmax(3.4rem, 0.95fr)            /* track 8 — connect's row (cannot be absorbed; connect lives here) */
+    var(--line)                       /* track 7 — line above connect / gray-d (visible in cols 4–8) */
+    minmax(3.4rem, 0.95fr)            /* track 8 — connect's row */
     var(--line);                      /* track 9 — bottom boundary */
 }
 
-/* Community-focus is the asymmetric absorption case (#322 follow-up).
-   The other multi-row spanning panels (about, projects) absorb tracks
-   that no other panel occupies, so they collapse helper rows to 0
-   uniformly. Community spans tracks 6 / 7 / 8, but Connect lives on
-   track 8 — collapsing it would hide Connect entirely, breaking the
-   "all four colored tiles always visible" invariant. The fix:
-     1. Keep track 7 absorbed (the helper line stays inside community).
-     2. Restore track 8 to a real minmax so Connect renders.
-     3. Stop community from spanning into track 8 so it doesn't bleed
-        into Connect's row in col 2.
-   Mirrors the projects-focus override of `.panel--yellow` grid-row. */
-.mondrian[data-focus="community"] .panel--black {
-  grid-row: 6 / 8;
-}
+/* Community-focus is the asymmetric case (#325).
+   The other multi-row spanning panels (about, projects) absorb their
+   helper rows because no other panel occupies them. Community spans
+   tracks 6 / 7 / 8, but Connect lives on track 8 — collapsing track 8
+   hides Connect, and collapsing track 7 erases the horizontal line
+   above the gray-d / Connect row in cols 4–8. Solution: keep both
+   track 7 (line) and track 8 (minmax) at their normal sizes. Community
+   keeps its default grid-row: 6 / 9, so its column covers tracks 6–8
+   as one continuous cream surface (the panel is on top of the line in
+   col 2), while in cols 4–8 the line at track 7 visually separates the
+   row 6 white spacer from the row 8 gray-d block + Connect tile —
+   matching the about-, projects-, and connect-focus templates that all
+   keep track 7 = var(--line). The .panel-content inside community is
+   `position: absolute; inset: 0` so its content fills the full cell
+   regardless of the extra track 7 + 8 height in col 2. */
 
 .mondrian[data-focus="connect"] {
   grid-template-columns:


### PR DESCRIPTION
Authoring-Agent: claude

Follow-up to [#325](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/325). User flagged two issues with the partial fix: (1) a black band below Community in col 2, and (2) no horizontal black line above Connect / the gray-d block. This PR fixes both.

## What was wrong with #325
#325 set track 8 = minmax (so Connect renders) and overrode `.panel--black { grid-row: 6 / 8 }` (so Community wouldn't span into Connect's row). That left col 2 of track 8 EMPTY — no panel placed, so the `.mondrian` background (black) showed through as a band below Community.

It also kept track 7 = 0 (absorbed). All other focus states (about, projects, connect) keep track 7 = `var(--line)`. Community-focus was the outlier — meaning no Mondrian separator line between the row 6 spacers and the row 8 tiles in cols 4–8.

## The fix ([src/styles/global.css:217-218](src/styles/global.css))
Two changes:

1. **Track 7 restored to `var(--line)`** — same as about-focus, projects-focus, and connect-focus. The line is visible in cols 4–8 between the white spacer at row 6 and the gray-d block / Connect tile at row 8. Inside community's col 2 the line is covered by the panel (which uses default `grid-row: 6 / 9`), so community visually remains one continuous cream surface from content top to the bottom boundary line.

2. **Drop the `.panel--black { grid-row: 6 / 8 }` override** added in #325. Community uses its default grid-row again. Its column tiles down through track 8 as cream, eliminating the black band. The existing `.block--gray-d` (col 4, row 8) and Connect (cols 6–8, row 8) tile the rest of the row.

The `.panel-content` inside community is `position: absolute; inset: 0`, so its content fills the full panel cell regardless of the extra track 7 + 8 height in col 2 — content stays at the top, cream extends below.

## Visual diff
Before this PR (post-#325): black band below Community, no line above Connect.
After this PR: cream Community fills col 2 down to bottom; black `var(--line)` separator visible above gray-d / Connect; all four colored Mondrian tiles visible.

## Testing
- [x] Programmatic audit re-run across all five focus states (`none`, `about`, `projects`, `community`, `connect`). Every panel non-zero in every state.
- [x] Visual screenshot confirms the line appears above Connect / gray-d row. No black band below Community.
- [x] Build succeeds — verified locally; HMR picked up the change cleanly.

| Focus | About | Projects | Community | Connect |
|---|---|---|---|---|
| `community` (after) | 592×196 | 234×101 | 486×630 | 234×109 |

Community at 486×630 is taller than #325 (486×512) because col 2 of track 8 is now filled with community (instead of empty/black). Connect at 234×109 is comparable. The other three focus states are untouched.

## Self-Review
- [x] Correctness: bug reproduced from user's screenshot (black band visible). After this PR: programmatic audit shows no zero-height panels and visual screenshot shows the line above Connect.
- [x] Regression risk: low. CSS-only change scoped to `[data-focus="community"]`. No other state's grid-template or panel grid-row touched. The `.block--gray-d` placement at col 4 / row 8 is unchanged and now properly visible alongside Connect.
- [x] Style and conventions: track 7 = `var(--line)` matches the value used in the three other focus states (about, projects, connect) — community-focus joins the same convention. The 13-line comment block above the rule explains the asymmetry so a future reader doesn't try to "absorb" the line again.
- [x] Test coverage: no new code paths.
- [x] Security and dependency hygiene: zero dependency changes.

## Review path
+17 / −16 in a single CSS file. Sub-threshold; no protected paths. Internal review only.

## Sequence note
- [#325](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/325) is already on production with the partial fix (Connect visible but black band present). This PR closes the visual gap. After merge + deploy, the Mondrian composition reads cleanly in community-hover.
