### PR TITLE
chore: comment raw 480/768 breakpoints with matching --bp-* tokens (#332)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1733,6 +1733,8 @@ body.blog-page {
 }
 
 /* ── Responsive: metadata + layout ── */
+/* 768px matches --bp-tablet on :root. CSS does not allow var() in @media
+   conditions; the literal value is used here for browser support. (#332) */
 @media (max-width: 768px) {
   /* Wide 4-col → 2×2 at tablet */
   .metadata-strip--grid-4 {
@@ -1751,6 +1753,7 @@ body.blog-page {
   }
 }
 
+/* 480px matches --bp-narrow on :root. (#332) */
 @media (max-width: 480px) {
   /* All metadata → single column */
   .metadata-strip--grid-4 {
@@ -2200,6 +2203,7 @@ a.tag:hover {
 .e-yellow-b  { grid-column: 6; grid-row: 6;   background: var(--yellow); }
 .e-white-c   { grid-column: 8; grid-row: 6;   background: var(--paper); }
 
+/* 768px matches --bp-tablet on :root. (#332) */
 @media (max-width: 768px) {
   .error-mondrian {
     grid-template-columns: 1fr;
@@ -3126,6 +3130,7 @@ a:focus-visible {
   outline-offset: 2px;
 }
 
+/* 480px matches --bp-narrow on :root. (#332) */
 @media (max-width: 480px) {
   .project-hero__header {
     padding: 1rem 1rem 1.15rem;


### PR DESCRIPTION
Authoring-Agent: claude

Closes #332. Pure documentation alignment — adds a one-line comment above each of the four `@media` rules in `src/styles/global.css` that use a raw `480px` or `768px` value, naming the matching `--bp-narrow` / `--bp-tablet` token defined on `:root` from #330.

## Why this is comment-only
Plain CSS does not permit `var()` inside `@media` conditions (verified with the spec rationale captured on #330's PR). Reusing the tokens at the rule-condition level would require either `@custom-media` (Media Queries Level 5, limited browser support) or a build-time preprocessor like PostCSS Custom Media. The literal value remains the runtime contract; the comment is the cross-reference back to the token scale so a future reader sees both:

```css
/* 768px matches --bp-tablet on :root. (#332) */
@media (max-width: 768px) { ... }
```

## What changed (4 locations in 1 file)

| Section | Selector | Breakpoint | Token |
|---|---|---|---|
| Project pages metadata strip | `.metadata-strip--grid-4` (4-col → 2×2) | 768 | `--bp-tablet` |
| Project pages metadata strip | `.metadata-strip--grid-4` (→ 1-col) + project hero | 480 | `--bp-narrow` |
| 404 page | `.error-mondrian` (collapse to single column) | 768 | `--bp-tablet` |
| Project pages | `.project-hero__header` (padding tighten) | 480 | `--bp-narrow` |

## Testing
- [x] Tests pass — comment-only edit; zero CSS rule changes.
- [x] Build succeeds — verified locally; HMR ate it without warning, dev server logs clean.
- [x] Manual verification not required — no rendering change at any viewport. (Spot-checked the diff to confirm the four edits land exactly above the four `@media` rules and don't collide with any existing comment.)

## Self-Review
- [x] Correctness: the four locations match the audit in [#332](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/332)'s body (line numbers shifted from the original audit since the file moved during today's PRs, but the four `@media (max-width: 480|768)` rules are the same set). Each comment names the correct token.
- [x] Regression risk: zero. CSS comments don't affect computed styles or media-query matching.
- [x] Style and conventions: matches the pattern established in #330's `:root` block which describes the CSS-level limitation (no `var()` in `@media`).
- [x] Test coverage: not applicable.
- [x] Security and dependency hygiene: zero dependency changes.

## Review path
+5 / -0 in 1 file. Sub-threshold; no protected paths. Internal review only — merge as nathanjohnpayne after CodeRabbit clears.