### PR TITLE
docs(specs): add Mondrian rebalance animation spec (#331)

### DIFF
--- a/specs/mondrian-rebalance-animation.md
+++ b/specs/mondrian-rebalance-animation.md
@@ -1,0 +1,83 @@
+---
+spec_id: mondrian-rebalance-animation
+title: Mondrian Rebalance Animation
+---
+
+# Mondrian Rebalance Animation
+
+## Overview
+
+The homepage panel-open / panel-close interaction reorganizes the Mondrian composition around the focused tile in one rectilinear movement. At rest, the page is a finished composition: colored rectangles, black grid lines, labels placed with restraint. When a user intentionally enters a tile, the grid lines glide to a new arrangement, the selected tile becomes a parchment reading surface, content fades in only after the plane settles, and closing reverses the sequence so the page returns to a complete static composition.
+
+The interaction should feel like a curator sliding panels in a gallery wall, not like a web accordion.
+
+## Curatorial framing
+
+- Crisp orthogonal movement only — no scaling, bouncing, rotation, shadows, or springiness.
+- Fixed black line weight; grid lines remain visually authoritative.
+- Cream / parchment as the reading surface — never blank for long.
+- Labels yield gracefully to content; text is delayed until the geometry is stable.
+- One active subject at a time; the animation never chases the cursor.
+
+## Sequences
+
+### Open (idle → open)
+
+```
+hover intent
+  → lock hover state changes
+  → grid morphs (--motion-plane), cream cell expands, label fades out
+  → after morph, fade content in (--motion-fast)
+  → unlock; re-resolve hover target via document.elementFromPoint
+```
+
+### Close (open → idle)
+
+```
+fade content out (--motion-fast)
+  → grid morphs back (--motion-plane), cream returns to base, label fades in
+  → unlock; re-resolve hover target
+```
+
+### Switch (open A → open B)
+
+```
+fade A content out (--motion-fast)
+  → swap is-open / data-focus to B; grid morphs A→B (--motion-plane)
+  → fade B content in (--motion-fast)
+  → unlock; re-resolve hover target
+```
+
+## Requirements
+
+1. **Geometry and content reveal are separate concerns.** `data-focus` only moves the grid lines; content reveal is gated by an independent class (`.is-content-visible`), added late in the open sequence and removed early on close.
+2. **Content reveal must transition, not snap.** `display: none / block` cannot be transitioned, so content visibility is governed by `opacity`, `visibility`, and `pointer-events` instead.
+3. **An interaction state machine governs hover.** The states are `idle`, `opening`, `open`, `switching`, `closing`. While the state is `opening` / `switching` / `closing`, hover intent is queued, not applied. After `--motion-plane` settles, the JS re-resolves the cursor's actual target via `document.elementFromPoint(lastX, lastY)` and only then promotes a queued hover.
+4. **Click, keyboard, and focus bypass the hover-state guard.** They are deliberate user intent and must always work, including mid-morph.
+5. **Each transition phase is invalidatable.** A new transition starting mid-flight (user opens A, then immediately opens B) must not allow stale callbacks to complete on top of the new state.
+6. **No `auto` tracks during animation.** Every track size in `grid-template-rows` and `grid-template-columns` for animated rules must be an explicit, interpolable length (`var(--line)`, `minmax(...)`, or a `var(--cell-h-*)` custom property). `auto` tracks change type at animation start and produce visible 0-length frames.
+7. **Content-driven cell sizes are measured in JS.** The focused panel's content height is measured once after `document.fonts.ready` and on every resize; the value is exposed as `--cell-h-{about,projects,community,connect}` on `.mondrian` for the focus-state CSS to consume in `calc()`-free expressions. See [responsive-layout.md](responsive-layout.md) §8–§10 for which focus states consume which variables and the deliberate community-focus exception.
+8. **Hover at a row-line boundary does not oscillate.** The combination of (a) hover-lock during morph and (b) `elementFromPoint` re-resolution after morph is what makes this hold. Either alone is insufficient.
+9. **Animation duration matches the curatorial intent.** `--motion-plane` is 460ms paired with `--ease-standard` (gentle in/out). The previous 280ms / `--ease-sharp` combination read as a card expanding rather than a composition shifting.
+10. **The user must never see a long-lived blank cream tile.** Cream is the reading surface; it must either contain content or be in a very short transition toward containing content.
+
+## Implementation references
+
+- Interaction state machine: [src/pages/index.astro](../src/pages/index.astro) — search for `state =` and `requestPanel`.
+- Content reveal class management: same file — search for `is-content-visible`.
+- Content height measurement: same file — `measureContentHeights()`.
+- Focus-state grid templates: [src/styles/global.css](../src/styles/global.css) — `.mondrian[data-focus="..."]` rules and the comment block introducing them.
+- Panel pulse on load: same file — `@keyframes panel-pulse{,-neutral,-blue}` plus the `.panel--pulsing` selector.
+
+## Related specs
+
+- [responsive-layout.md](responsive-layout.md) — grid template structure, breakpoint scale, and focus-state cell-sizing rules.
+- [panel-interaction.md](panel-interaction.md) — higher-level interaction model (click / hover / focus, mobile guard, link-inside-panel).
+- [keyboard-navigation.md](keyboard-navigation.md) — keyboard-driven open/close paths that bypass the hover guard.
+
+## Out of scope
+
+- Accordion-style or card-style expansion patterns (explicitly rejected).
+- Any motion that scales, rotates, or distorts the grid lines.
+- Cross-page or full-page transitions; this spec is scoped to the homepage Mondrian only.
+- Breakpoint or width-cap behavior (settled in [responsive-layout.md](responsive-layout.md)).

--- a/specs/mondrian-rebalance-animation.md
+++ b/specs/mondrian-rebalance-animation.md
@@ -1,6 +1,17 @@
 ---
 spec_id: mondrian-rebalance-animation
 title: Mondrian Rebalance Animation
+tested: false
+reason: |
+  This spec captures the choreography of an existing implementation that
+  shipped piecemeal across #313, #314, #315, #325-#329, and #330. The
+  high-level interaction (click / hover / focus, only-one-open, mobile
+  guard) is exercised by tests/panel-interaction.test.js. The
+  fine-grained phase ordering, content-fade timing, --motion-plane
+  duration, and JS-measured --cell-h-* contracts described here are
+  not yet covered by dedicated tests. A follow-up ticket will add a
+  Playwright animation smoke test that asserts the open / close /
+  switch sequences hold in observable order.
 ---
 
 # Mondrian Rebalance Animation

--- a/specs/mondrian-rebalance-animation.md
+++ b/specs/mondrian-rebalance-animation.md
@@ -23,7 +23,7 @@ The interaction should feel like a curator sliding panels in a gallery wall, not
 
 ### Open (idle → open)
 
-```
+```text
 hover intent
   → lock hover state changes
   → grid morphs (--motion-plane), cream cell expands, label fades out
@@ -33,7 +33,7 @@ hover intent
 
 ### Close (open → idle)
 
-```
+```text
 fade content out (--motion-fast)
   → grid morphs back (--motion-plane), cream returns to base, label fades in
   → unlock; re-resolve hover target
@@ -41,7 +41,7 @@ fade content out (--motion-fast)
 
 ### Switch (open A → open B)
 
-```
+```text
 fade A content out (--motion-fast)
   → swap is-open / data-focus to B; grid morphs A→B (--motion-plane)
   → fade B content in (--motion-fast)

--- a/specs/panel-interaction.md
+++ b/specs/panel-interaction.md
@@ -18,3 +18,7 @@ The Mondrian grid contains four expandable panels (about, projects, community, c
 5. Mouse-leaving a panel schedules a delayed close (120 ms).
 6. On mobile / stack viewports (max-width 1023px, below `--bp-stack`), panels do not open on click or hover.
 7. Clicking a link inside a panel does not trigger panel open logic.
+
+## Related specs
+
+- [mondrian-rebalance-animation.md](mondrian-rebalance-animation.md) — the choreography spec for how the grid morphs, when content fades in/out, and how the interaction state machine prevents oscillation at row-line boundaries.


### PR DESCRIPTION
Authoring-Agent: claude

Closes #331. Captures the homepage Mondrian panel-open / panel-close choreography spec as a tracked spec file. The implementation has shipped piecemeal — #313 / #314 / #315 (state machine + geometry-content-reveal split + --motion-plane bump + JS-measured cell heights), #325–#329 (focus-state grid template iteration), and #330 (selective content-sizing for about / projects / connect). #331 puts the curatorial framing they were all converging on into one place so a future agent reads the spec before the diff.

## Files

**New: [specs/mondrian-rebalance-animation.md](specs/mondrian-rebalance-animation.md)** — 83 lines. Sections:
- Overview + curatorial framing (no scaling/bouncing/rotation, fixed line weight, cream as reading surface, one subject at a time, never chase the cursor).
- Open / Close / Switch sequences with explicit phase ordering.
- 10 implementation requirements covering geometry-vs-content-reveal separation, opacity-driven fades, the interaction state machine and its hover-lock guarantee, click/keyboard/focus bypass, transition invalidation, no-auto-tracks-during-animation, JS-measured `--cell-h-*` cell sizing, row-line-boundary stability via `elementFromPoint`, `--motion-plane: 460ms` + `--ease-standard`, and the never-blank-cream rule.
- Implementation references pointing at the actual code locations in `src/pages/index.astro` (state machine, `measureContentHeights()`, `is-content-visible` toggling) and `src/styles/global.css` (focus-state templates, pulse keyframes).
- Related-specs cross-references to [responsive-layout.md](specs/responsive-layout.md), [panel-interaction.md](specs/panel-interaction.md), and [keyboard-navigation.md](specs/keyboard-navigation.md).

**Modified: [specs/panel-interaction.md](specs/panel-interaction.md)** — adds a "Related specs" section pointing at the new file, so a reader of the higher-level interaction model can find the choreography spec.

## Why a separate spec file
- `panel-interaction.md` is the high-level requirements (click/hover/focus, only-one-open, mobile guard, link-inside-panel) — it answers "what happens when a user does X."
- `responsive-layout.md` is the grid template + breakpoint contract — "what shape the page takes at viewport Y."
- The choreography is a third concern: "what the in-between of X feels like." It's prose-heavy (curatorial framing, phase sequences), longer than the existing specs, and references both of them.

Splitting it out keeps each spec's scope tight and makes the cross-references explicit. The bulk of the spec content is the issue body itself — only edits were format alignment with other spec files (frontmatter, ##/### structure, removing TODO checkboxes since this is now the contract not the work plan).

## Testing
- [x] Tests pass — docs-only.
- [x] Build succeeds — Astro doesn't read `specs/`.
- [x] Manual verification — read both spec files end-to-end. Cross-references resolve to existing files. The implementation references match the actual code locations (`measureContentHeights`, `is-content-visible`, focus-state templates).

## Self-Review
- [x] Correctness: every requirement in the spec has a matching implementation that's already shipped. No requirement describes future work.
- [x] Regression risk: zero. Astro's content collection schema doesn't include `specs/` (no Zod validation), so adding a file there can't fail the build. The cross-reference link in `panel-interaction.md` is a relative path within the same directory — a future spec rename would need a corresponding link update, but there's no reason to rename this file.
- [x] Style and conventions: matches `responsive-layout.md` and `panel-interaction.md` frontmatter (`spec_id` / `title`) and section style (`## Overview`, `## Requirements`, `## Out of scope`).
- [x] Test coverage: not applicable.
- [x] Security and dependency hygiene: zero dependency changes.

## Review path
+87 / −0 across 2 files. Sub-threshold; no protected paths. Internal review only — merge as nathanjohnpayne after CodeRabbit clears.
