### PR TITLE
fix(home): feature-detect requestAnimationFrame in measureContentHeights (#342 → #315 P3)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -585,7 +585,11 @@ const homepageJsonLd = {
           if (restoredVisible) restoredActive.classList.add('is-content-visible');
         }
         void grid.offsetHeight;
-        requestAnimationFrame(() => grid.classList.remove('is-measuring'));
+        if (typeof requestAnimationFrame === 'function') {
+          requestAnimationFrame(() => grid.classList.remove('is-measuring'));
+        } else {
+          grid.classList.remove('is-measuring');
+        }
       }
 
       // Run after fonts load (heights depend on Cormorant Garamond's


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Wrap the `requestAnimationFrame(...)` call inside `measureContentHeights()` in [src/pages/index.astro:588](https://github.com/nathanjohnpayne/nathanpaynedotcom/blob/main/src/pages/index.astro#L588) with a `typeof requestAnimationFrame === 'function'` check, matching the surrounding feature-detection style (the same function already feature-detects `document.fonts.ready` at line 594). When rAF is unavailable, fall back to a direct synchronous removal of `is-measuring`.

Resolves the #315 P3 finding from the [#342 validation pass](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/342#issuecomment-4444682862).

## Self-Review

**Correctness.** rAF is universally supported in modern browsers; this guard only matters in unusual SSR/headless environments where rAF is absent. The fallback path executes the same effect (`grid.classList.remove('is-measuring')`) synchronously, which is correct behavior when no animation frame is available to defer to.

**Regression risk.** Minimal. The behavior change is *additive*: identical in the common path (rAF present), and graceful in the previously-broken path (rAF absent → no-op cleanup of the measure-mode class).

**Style.** Matches `index.astro:594`'s feature-detect pattern (`typeof document !== 'undefined' && document.fonts && document.fonts.ready`).

**Test coverage.** No unit tests exercise this branch (the rAF-absent path is an edge case). All 143 vitest tests + 42 Playwright tests pass on this branch.

**Security / dependency hygiene.** Pure JS edit. No new dependencies.

## Test plan

- [x] `npm test` — 143/143 vitest tests pass.
- [x] `npx playwright test tests/responsive/mondrian-rebalance-animation.spec.ts` — 9/9 desktop tests pass; iPad variants correctly skipped (mobile stack mode short-circuits the measure pass).
- [x] Visual: no observable change in modern browsers (rAF is always present).

Note: 3 other items from issue #342 (#254 yellow panel clamp, #306 panel labels w/o JS, #235 Mux env-key) were re-classified during implementation: #306 + #235 are ALREADY-FIXED on closer inspection (the original validation pass missed the `<noscript>` fallback in BaseLayout.astro and the removal of `env-key` entirely from `ProjectMuxPlayer.astro`); #254 has a documented design rationale in the original PR body that conflicts with the reviewer's blanket "use clamp()" complaint — needs a design call, not a code-only fix. A consolidation comment will land on #342 after the remaining PRs.