### PR TITLE
test: harden Playwright + Vitest specs flagged in #342 (#337, #310, #265)

### DIFF
--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -245,6 +245,13 @@ describe('Project Pages — screenshot aspect variants', () => {
     expect(muxScript).toContain('.play()');
     expect(muxScript).toContain('currentTime>0');
     expect(html).not.toContain('PUBLIC_MUX_ENV_KEY');
+    // #265 regression: when the mux-embed script tag already exists in a
+    // settled (loaded/error) state, the loader must short-circuit to
+    // Promise.resolve() instead of re-attaching listeners that will never
+    // fire. Encoded via the dataset.muxEmbedStatus sentinel.
+    expect(muxScript).toMatch(/muxEmbedStatus===['"]loaded['"]/);
+    expect(muxScript).toMatch(/muxEmbedStatus===['"]error['"]/);
+    expect(muxScript).toContain('Promise.resolve()');
   });
 
   it('only Swipe Watch opts into the Mux hero today', () => {

--- a/tests/responsive/mondrian-rebalance-animation.spec.ts
+++ b/tests/responsive/mondrian-rebalance-animation.spec.ts
@@ -17,13 +17,6 @@ import { test, expect, Page } from '@playwright/test';
 const PANELS = ['about', 'projects', 'community', 'connect'] as const;
 type PanelName = (typeof PANELS)[number];
 
-const COLOR_BY_PANEL: Record<PanelName, string> = {
-  about: 'red',
-  projects: 'yellow',
-  community: 'black',
-  connect: 'blue',
-};
-
 // Skip the entire file on viewports where the state machine is disabled.
 // playwright.config.ts has 1440 as the only desktop viewport; the others
 // (375, 393, 768) fall below --bp-stack.
@@ -92,7 +85,9 @@ test('all four panels render at non-zero dimensions in every focus state (#315 r
       expect(dims[p].height, `[${focus}-focus] ${p}.height`).toBeGreaterThan(0);
     }
     // Close before next iteration.
-    await page.click('main', { position: { x: 5, y: 5 }, force: true }).catch(() => {});
+    await page.click('main', { position: { x: 5, y: 5 }, force: true }).catch((err) => {
+      console.warn(`close-click failed (continuing to assert close via waitForFunction): ${err?.message ?? err}`);
+    });
     await page.waitForFunction(
       (f) => !document.querySelector(`[data-panel="${f}"]`)!.classList.contains('is-open'),
       focus,
@@ -116,7 +111,9 @@ test('about/projects/connect panels are exactly content-sized in their focus sta
     expect(gap, `[${focus}-focus] cream gap below content`).toBeLessThanOrEqual(TOLERANCE);
 
     // Close before next iteration.
-    await page.click('main', { position: { x: 5, y: 5 }, force: true }).catch(() => {});
+    await page.click('main', { position: { x: 5, y: 5 }, force: true }).catch((err) => {
+      console.warn(`close-click failed (continuing to assert close via waitForFunction): ${err?.message ?? err}`);
+    });
     await page.waitForFunction(
       (f) => !document.querySelector(`[data-panel="${f}"]`)!.classList.contains('is-open'),
       focus,

--- a/tests/responsive/swipe-watch-mux-fallback.spec.ts
+++ b/tests/responsive/swipe-watch-mux-fallback.spec.ts
@@ -18,7 +18,11 @@ test('Swipe Watch swaps to the Mux GIF fallback when the stream cannot autoplay'
   await expect(playButton).toHaveAttribute('aria-label', 'Play Swipe Watch demo');
 
   await playButton.click();
-  await expect(frame).toHaveAttribute('data-playback-state', 'loading');
+  // Either we catch the transient "loading" state mid-flight, or the route
+  // abort fires so fast we land straight on "fallback". Both are valid —
+  // the contract being tested is that the click moves us off the prior
+  // "fallback" snapshot, not which intermediate frame Playwright observes.
+  await expect(frame).toHaveAttribute('data-playback-state', /^(loading|fallback)$/);
   await expect(playButton).toBeHidden();
   await expect(frame).toHaveAttribute('data-playback-state', 'fallback', { timeout: 7000 });
   await expect(playButton).toBeVisible();


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Four small test-suite hygiene fixes consolidated from the [#342 validation pass](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/342#issuecomment-4444682862):

- **#337 nit — drop unused `COLOR_BY_PANEL`** in `tests/responsive/mondrian-rebalance-animation.spec.ts`. Defined but never referenced.
- **#337 nit — don't silently swallow click errors** at the two close-the-panel call sites in the same spec. Replace `.catch(() => {})` with a `console.warn` catch. The `waitForFunction` below still gates the next iteration, so test correctness is unchanged.
- **#310 nit — make the transient `loading` state assertion robust to the abort race** in `tests/responsive/swipe-watch-mux-fallback.spec.ts`. With `page.route` aborting the stream, the abort can fire fast enough that Playwright never observes the transient `loading` frame and lands directly on `fallback`. Switch to a regex matcher accepting either state — the contract under test is that the click moves us off the prior `fallback` snapshot, not which intermediate frame is observed.
- **#265 nit — regression test for the settled-existing-script branch** in `tests/project-pages.test.js`. The loader fix in #265 short-circuits to `Promise.resolve()` when the existing `script[data-mux-embed]` tag's `dataset.muxEmbedStatus` is already `loaded` or `error`. Assert both equality comparisons + the `Promise.resolve()` call appear in the bundled module.

## Self-Review

**Correctness.**
- `COLOR_BY_PANEL` removal is mechanically safe (no references).
- The `console.warn` catch on the close-click still produces a green test when the click succeeds (no warn fires), and now produces a CI-visible signal when it doesn't. The downstream `waitForFunction` still enforces that the panel actually closed before the next iteration starts, so a false-negative on the close-click can no longer pass silently.
- The Swipe Watch regex matcher `/^(loading|fallback)$/` is the right boundary — those are the only two states the system can be in immediately post-click. The follow-on `toHaveAttribute('data-playback-state', 'fallback', { timeout: 7000 })` still proves the system settles on `fallback`.
- The #265 regression assertion locks in two patterns (`muxEmbedStatus===\"loaded\"`, `muxEmbedStatus===\"error\"`) and the `Promise.resolve()` short-circuit. If a future refactor drops any of these, this test catches it.

**Regression risk.** Low. Pure test-code changes. No production code touched. The Swipe Watch spec change *relaxes* an assertion in a controlled way — if it now passes on a previously-failing test machine, that's the intended outcome; the eventual-state assertion is unchanged.

**Style.** Matches surrounding spec conventions. Inline comment on the regex matcher explains the abort race.

**Test coverage.** All 143 vitest tests + the 10 affected Playwright specs (Mondrian rebalance + Swipe Watch Mux fallback, Desktop 1440 variants) pass on this branch.

**Security / dependency hygiene.** No new dependencies. No production code changes.

## Test plan

- [x] `npm test` → 143/143 vitest pass (includes the new #265 regression assertion).
- [x] `npx playwright test tests/responsive/mondrian-rebalance-animation.spec.ts tests/responsive/swipe-watch-mux-fallback.spec.ts` → 10 passed, 30 skipped (mobile viewports correctly skip the Mondrian state-machine path).