### PR TITLE
refactor(scripts): swap hand-rolled frontmatter parser for js-yaml (#193, #64)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@astrojs/sitemap": "^3.0.0",
     "@playwright/test": "^1.59.1",
     "astro": "^6.1.0",
+    "js-yaml": "^4.1.1",
     "jsdom": "^29.0.2",
     "unist-util-visit": "^5.1.0",
     "vitest": "^4.1.4"

--- a/scripts/lib/parse-frontmatter.mjs
+++ b/scripts/lib/parse-frontmatter.mjs
@@ -23,34 +23,38 @@
  * explicit and decouple from Astro version drift.
  */
 
-import { load as parseYaml } from 'js-yaml';
+import { load as parseYaml, FAILSAFE_SCHEMA } from 'js-yaml';
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
 
 /**
- * Top-level primitive coercion. js-yaml correctly types scalars (a bare
- * `123` parses to a JS number, `true` to a boolean, etc.), but the
- * production callers (`refresh-hero-images.mjs`, `refresh-mux-gifs.mjs`)
- * inherited the previous hand-rolled parser's "every value is a string"
- * contract: e.g. `data?.screenshotSrc?.startsWith('/')` would throw a
- * TypeError if the value parsed to a number, and `parseGithubRepo(githubUrl)`
- * calls `.match()` on its input. Coerce top-level primitives back to
- * strings to preserve the old contract, leaving arrays / nested objects
- * untouched (those are new capabilities the old parser silently mangled).
+ * Schema choice: FAILSAFE_SCHEMA, not the default.
  *
- * Codex P2 catch on PR #348.
+ * js-yaml's DEFAULT_SCHEMA resolves implicit tags for numbers, booleans,
+ * null, AND timestamps (ISO-like bare scalars → Date objects). The
+ * production callers in this repo (`refresh-hero-images.mjs`,
+ * `refresh-mux-gifs.mjs`) inherited the previous hand-rolled parser's
+ * "every leaf is a string" contract — e.g.
+ *   data?.screenshotSrc?.startsWith('/')
+ *   parseGithubRepo(githubUrl).match(...)
+ * would throw `TypeError: …is not a function` on a number or Date.
+ *
+ * FAILSAFE_SCHEMA resolves only `!!str`, `!!seq`, `!!map`. Bare scalars
+ * stay as strings ("42", "true", "2026-05-13" remain strings, not
+ * coerced to JS number / boolean / Date). Containers — arrays and
+ * nested objects — are still parsed structurally (the actual #193 +
+ * #64 win), but their leaf values are strings too.
+ *
+ * This matches the production contract exactly. Two Codex P2 catches
+ * on PR #348 led to this choice:
+ *   1. Top-level number/boolean coercion needed (first pass: solved
+ *      via post-parse coerceTopLevelPrimitives()).
+ *   2. Top-level Date coercion needed (DEFAULT_SCHEMA auto-converts
+ *      `lastUpdated: 2026-05-13` to a JS Date). Adding Date to the
+ *      post-parse coercion would have worked but kept piling up
+ *      special cases. Switching schemas closes the whole class.
  */
-function coerceTopLevelPrimitives(obj) {
-  for (const [key, value] of Object.entries(obj)) {
-    if (value === null || value === undefined) continue;
-    const t = typeof value;
-    if (t === 'number' || t === 'boolean' || t === 'bigint') {
-      obj[key] = String(value);
-    }
-    // strings: no-op. arrays / objects: untouched.
-  }
-  return obj;
-}
+const SCHEMA = FAILSAFE_SCHEMA;
 
 /**
  * Extract and parse the YAML frontmatter block from a Markdown string.
@@ -58,10 +62,9 @@ function coerceTopLevelPrimitives(obj) {
  * frontmatter block. Throws if the block exists but fails to parse —
  * caller decides whether to swallow.
  *
- * Top-level primitive scalars (numbers, booleans, bigints) are coerced
- * to strings to preserve the legacy hand-rolled parser's "every value
- * is a string" contract for production callers. Arrays and nested
- * objects pass through with their js-yaml types intact.
+ * Uses js-yaml's FAILSAFE_SCHEMA so every leaf scalar stays a string,
+ * matching the legacy hand-rolled parser's contract. Arrays and nested
+ * objects parse structurally; their leaf values are strings too.
  *
  * @param {string} markdown - the full Markdown file contents
  * @returns {object | null} parsed frontmatter, or null when absent
@@ -69,7 +72,7 @@ function coerceTopLevelPrimitives(obj) {
 export function parseFrontmatter(markdown) {
   const match = markdown.match(FRONTMATTER_RE);
   if (!match) return null;
-  const parsed = parseYaml(match[1]);
+  const parsed = parseYaml(match[1], { schema: SCHEMA });
   // js-yaml returns undefined for an empty document; normalize to {}
   // so consumers can do `data?.field` without an extra null check.
   if (parsed === undefined || parsed === null) return {};
@@ -79,5 +82,5 @@ export function parseFrontmatter(markdown) {
     // Returning {} keeps consumers safe.
     return {};
   }
-  return coerceTopLevelPrimitives(parsed);
+  return parsed;
 }

--- a/scripts/lib/parse-frontmatter.mjs
+++ b/scripts/lib/parse-frontmatter.mjs
@@ -28,10 +28,40 @@ import { load as parseYaml } from 'js-yaml';
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
 
 /**
+ * Top-level primitive coercion. js-yaml correctly types scalars (a bare
+ * `123` parses to a JS number, `true` to a boolean, etc.), but the
+ * production callers (`refresh-hero-images.mjs`, `refresh-mux-gifs.mjs`)
+ * inherited the previous hand-rolled parser's "every value is a string"
+ * contract: e.g. `data?.screenshotSrc?.startsWith('/')` would throw a
+ * TypeError if the value parsed to a number, and `parseGithubRepo(githubUrl)`
+ * calls `.match()` on its input. Coerce top-level primitives back to
+ * strings to preserve the old contract, leaving arrays / nested objects
+ * untouched (those are new capabilities the old parser silently mangled).
+ *
+ * Codex P2 catch on PR #348.
+ */
+function coerceTopLevelPrimitives(obj) {
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === null || value === undefined) continue;
+    const t = typeof value;
+    if (t === 'number' || t === 'boolean' || t === 'bigint') {
+      obj[key] = String(value);
+    }
+    // strings: no-op. arrays / objects: untouched.
+  }
+  return obj;
+}
+
+/**
  * Extract and parse the YAML frontmatter block from a Markdown string.
  * Returns the parsed data object, or `null` if the input has no
  * frontmatter block. Throws if the block exists but fails to parse —
  * caller decides whether to swallow.
+ *
+ * Top-level primitive scalars (numbers, booleans, bigints) are coerced
+ * to strings to preserve the legacy hand-rolled parser's "every value
+ * is a string" contract for production callers. Arrays and nested
+ * objects pass through with their js-yaml types intact.
  *
  * @param {string} markdown - the full Markdown file contents
  * @returns {object | null} parsed frontmatter, or null when absent
@@ -49,5 +79,5 @@ export function parseFrontmatter(markdown) {
     // Returning {} keeps consumers safe.
     return {};
   }
-  return parsed;
+  return coerceTopLevelPrimitives(parsed);
 }

--- a/scripts/lib/parse-frontmatter.mjs
+++ b/scripts/lib/parse-frontmatter.mjs
@@ -1,0 +1,53 @@
+/**
+ * parse-frontmatter.mjs — minimal YAML frontmatter extractor for the
+ * prebuild scripts (`refresh-hero-images.mjs`, `refresh-mux-gifs.mjs`).
+ *
+ * Runtime frontmatter parsing happens inside Astro's Content Loader
+ * (see `src/content.config.ts`). This helper exists only for the
+ * prebuild step, which needs to read `src/content/projects/*.md`
+ * before Astro starts building, to decide whether to refresh GitHub
+ * social images and Mux GIFs.
+ *
+ * Previous implementations of this function in each script were
+ * hand-rolled line-by-line splitters that only stripped double quotes
+ * and silently dropped single-quoted strings, arrays, multi-line
+ * scalars, and nested objects (#193, #64). All those forms appear in
+ * the project frontmatter today (e.g. `tags: ["Consumer", ...]` and
+ * the nested `metadata:` block on every project page). Production
+ * callers only access flat string fields so the bug was not
+ * load-bearing, but the brittle parsing made the surface easy to
+ * regress whenever a new prebuild consumer touched a richer key.
+ *
+ * `js-yaml` is already in the dep graph transitively (Astro consumes
+ * it); we pin a direct devDependency to make the import contract
+ * explicit and decouple from Astro version drift.
+ */
+
+import { load as parseYaml } from 'js-yaml';
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
+
+/**
+ * Extract and parse the YAML frontmatter block from a Markdown string.
+ * Returns the parsed data object, or `null` if the input has no
+ * frontmatter block. Throws if the block exists but fails to parse —
+ * caller decides whether to swallow.
+ *
+ * @param {string} markdown - the full Markdown file contents
+ * @returns {object | null} parsed frontmatter, or null when absent
+ */
+export function parseFrontmatter(markdown) {
+  const match = markdown.match(FRONTMATTER_RE);
+  if (!match) return null;
+  const parsed = parseYaml(match[1]);
+  // js-yaml returns undefined for an empty document; normalize to {}
+  // so consumers can do `data?.field` without an extra null check.
+  if (parsed === undefined || parsed === null) return {};
+  if (typeof parsed !== 'object') {
+    // Top-level scalar frontmatter (e.g. just `123` between dashes)
+    // is technically valid YAML but never appears in this codebase.
+    // Returning {} keeps consumers safe.
+    return {};
+  }
+  return parsed;
+}

--- a/scripts/refresh-hero-images.mjs
+++ b/scripts/refresh-hero-images.mjs
@@ -24,6 +24,7 @@
 import { readFile, writeFile, readdir } from 'node:fs/promises';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { parseFrontmatter } from './lib/parse-frontmatter.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -41,22 +42,6 @@ async function fetchWithTimeout(url, options = {}) {
   } finally {
     clearTimeout(timer);
   }
-}
-
-function parseFrontmatter(markdown) {
-  const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!match) return null;
-  const body = match[1];
-  const data = {};
-  for (const line of body.split('\n')) {
-    const m = line.match(/^(\w+):\s*(.*)$/);
-    if (!m) continue;
-    const [, key, rawValue] = m;
-    let value = rawValue.trim();
-    if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
-    data[key] = value;
-  }
-  return data;
 }
 
 function parseGithubRepo(url) {

--- a/scripts/refresh-mux-gifs.mjs
+++ b/scripts/refresh-mux-gifs.mjs
@@ -28,6 +28,7 @@
 import { readFile, writeFile, readdir } from 'node:fs/promises';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { parseFrontmatter } from './lib/parse-frontmatter.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -54,22 +55,6 @@ async function fetchWithTimeout(url, options = {}) {
   } finally {
     clearTimeout(timer);
   }
-}
-
-function parseFrontmatter(markdown) {
-  const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!match) return null;
-  const body = match[1];
-  const data = {};
-  for (const line of body.split('\n')) {
-    const m = line.match(/^(\w+):\s*(.*)$/);
-    if (!m) continue;
-    const [, key, rawValue] = m;
-    let value = rawValue.trim();
-    if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
-    data[key] = value;
-  }
-  return data;
 }
 
 function muxGifUrl(playbackId) {

--- a/tests/parse-frontmatter.test.js
+++ b/tests/parse-frontmatter.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { parseFrontmatter } from '../scripts/lib/parse-frontmatter.mjs';
+
+// Unit tests for the prebuild-script frontmatter parser. Exercises forms
+// that the previous hand-rolled parser silently mangled (#193, #64),
+// plus the production-path forms the refresh-* scripts depend on.
+
+describe('parseFrontmatter (scripts/lib/parse-frontmatter.mjs)', () => {
+  it('returns null when no frontmatter block is present', () => {
+    expect(parseFrontmatter('Just body, no frontmatter.\n')).toBeNull();
+    expect(parseFrontmatter('')).toBeNull();
+  });
+
+  it('returns {} for a whitespace-only frontmatter block', () => {
+    // The closing `---` must sit on its own line, so the minimal
+    // empty form is `---\n\n---\n` (one blank line in between).
+    expect(parseFrontmatter('---\n\n---\nBody\n')).toEqual({});
+  });
+
+  it('parses flat string fields the production callers depend on', () => {
+    const md = [
+      '---',
+      'slug: "swipe-watch"',
+      'heroRefresh: "github-social"',
+      'githubUrl: "https://github.com/owner/repo"',
+      'muxPlaybackId: "abc123"',
+      'screenshotSrc: "/images/projects/swipe-watch-hero.gif"',
+      '---',
+      'Body',
+    ].join('\n');
+    const data = parseFrontmatter(md);
+    expect(data).toEqual({
+      slug: 'swipe-watch',
+      heroRefresh: 'github-social',
+      githubUrl: 'https://github.com/owner/repo',
+      muxPlaybackId: 'abc123',
+      screenshotSrc: '/images/projects/swipe-watch-hero.gif',
+    });
+  });
+
+  it('parses single-quoted strings (the old parser dropped these)', () => {
+    const md = "---\ntitle: 'Single Quotes'\n---\n";
+    expect(parseFrontmatter(md)).toEqual({ title: 'Single Quotes' });
+  });
+
+  it('parses inline arrays (the old parser stringified these)', () => {
+    const md = '---\ntags: ["Consumer", "Streaming", "Vanilla JS"]\n---\n';
+    const data = parseFrontmatter(md);
+    expect(Array.isArray(data.tags)).toBe(true);
+    expect(data.tags).toEqual(['Consumer', 'Streaming', 'Vanilla JS']);
+  });
+
+  it('parses nested objects (the old parser silently dropped these)', () => {
+    const md = [
+      '---',
+      'metadata:',
+      '  format: "Repository standard"',
+      '  focus: "Agent governance"',
+      '---',
+    ].join('\n');
+    const data = parseFrontmatter(md);
+    expect(data.metadata).toEqual({
+      format: 'Repository standard',
+      focus: 'Agent governance',
+    });
+  });
+
+  it('handles CRLF line endings in the frontmatter block', () => {
+    const md = '---\r\nslug: "x"\r\nfoo: "bar"\r\n---\r\nBody\r\n';
+    expect(parseFrontmatter(md)).toEqual({ slug: 'x', foo: 'bar' });
+  });
+
+  it('throws on malformed YAML rather than silently returning a partial object', () => {
+    // js-yaml raises on bad indentation; the prebuild scripts intentionally
+    // do not catch this so the build fails loudly on a corrupt content file.
+    const md = '---\nbad: : :\n  : not yaml\n---\n';
+    expect(() => parseFrontmatter(md)).toThrow();
+  });
+});

--- a/tests/parse-frontmatter.test.js
+++ b/tests/parse-frontmatter.test.js
@@ -43,7 +43,7 @@ describe('parseFrontmatter (scripts/lib/parse-frontmatter.mjs)', () => {
     expect(parseFrontmatter(md)).toEqual({ title: 'Single Quotes' });
   });
 
-  it('parses inline arrays (the old parser stringified these)', () => {
+  it('parses inline arrays as proper arrays (the old parser stringified the whole block)', () => {
     const md = '---\ntags: ["Consumer", "Streaming", "Vanilla JS"]\n---\n';
     const data = parseFrontmatter(md);
     expect(Array.isArray(data.tags)).toBe(true);
@@ -70,15 +70,18 @@ describe('parseFrontmatter (scripts/lib/parse-frontmatter.mjs)', () => {
     expect(parseFrontmatter(md)).toEqual({ slug: 'x', foo: 'bar' });
   });
 
-  it('coerces top-level primitive scalars (number/boolean) back to strings', () => {
-    // Preserves the old hand-rolled parser's "every top-level value is a
-    // string" contract for production callers like
-    // `data.screenshotSrc.startsWith("/")`. Codex P2 catch on PR #348.
+  it('keeps every leaf scalar as a string under FAILSAFE_SCHEMA', () => {
+    // FAILSAFE_SCHEMA resolves only !!str / !!seq / !!map, so bare
+    // numbers, booleans, null, and ISO-like dates all parse as strings.
+    // Preserves the legacy hand-rolled parser's contract for production
+    // callers like `data.screenshotSrc.startsWith("/")`. Codex P2 catches
+    // on PR #348 (numbers/booleans, then Date timestamps).
     const md = [
       '---',
       'count: 42',
       'enabled: true',
       'disabled: false',
+      'lastUpdated: 2026-05-13',
       'name: "still a string"',
       '---',
     ].join('\n');
@@ -86,22 +89,25 @@ describe('parseFrontmatter (scripts/lib/parse-frontmatter.mjs)', () => {
     expect(data.count).toBe('42');
     expect(data.enabled).toBe('true');
     expect(data.disabled).toBe('false');
+    expect(data.lastUpdated).toBe('2026-05-13'); // NOT a Date object
     expect(data.name).toBe('still a string');
   });
 
-  it('leaves arrays and nested objects untouched by the coercion pass', () => {
+  it('preserves array + object structure but strings inside them too', () => {
     const md = [
       '---',
-      'tags: [1, 2, 3]',            // an inline array of numbers
+      'tags: [1, 2, 3]',            // inline array of bare scalars
       'metadata:',
-      '  count: 5',                  // a nested number
+      '  count: 5',                  // nested bare scalar
+      '  flag: true',
       '---',
     ].join('\n');
     const data = parseFrontmatter(md);
     expect(Array.isArray(data.tags)).toBe(true);
-    expect(data.tags).toEqual([1, 2, 3]);   // not stringified
+    expect(data.tags).toEqual(['1', '2', '3']);   // strings under FAILSAFE
     expect(typeof data.metadata).toBe('object');
-    expect(data.metadata.count).toBe(5);    // nested values keep their type
+    expect(data.metadata.count).toBe('5');         // strings under FAILSAFE
+    expect(data.metadata.flag).toBe('true');
   });
 
   it('throws on malformed YAML rather than silently returning a partial object', () => {

--- a/tests/parse-frontmatter.test.js
+++ b/tests/parse-frontmatter.test.js
@@ -70,6 +70,40 @@ describe('parseFrontmatter (scripts/lib/parse-frontmatter.mjs)', () => {
     expect(parseFrontmatter(md)).toEqual({ slug: 'x', foo: 'bar' });
   });
 
+  it('coerces top-level primitive scalars (number/boolean) back to strings', () => {
+    // Preserves the old hand-rolled parser's "every top-level value is a
+    // string" contract for production callers like
+    // `data.screenshotSrc.startsWith("/")`. Codex P2 catch on PR #348.
+    const md = [
+      '---',
+      'count: 42',
+      'enabled: true',
+      'disabled: false',
+      'name: "still a string"',
+      '---',
+    ].join('\n');
+    const data = parseFrontmatter(md);
+    expect(data.count).toBe('42');
+    expect(data.enabled).toBe('true');
+    expect(data.disabled).toBe('false');
+    expect(data.name).toBe('still a string');
+  });
+
+  it('leaves arrays and nested objects untouched by the coercion pass', () => {
+    const md = [
+      '---',
+      'tags: [1, 2, 3]',            // an inline array of numbers
+      'metadata:',
+      '  count: 5',                  // a nested number
+      '---',
+    ].join('\n');
+    const data = parseFrontmatter(md);
+    expect(Array.isArray(data.tags)).toBe(true);
+    expect(data.tags).toEqual([1, 2, 3]);   // not stringified
+    expect(typeof data.metadata).toBe('object');
+    expect(data.metadata.count).toBe(5);    // nested values keep their type
+  });
+
   it('throws on malformed YAML rather than silently returning a partial object', () => {
     // js-yaml raises on bad indentation; the prebuild scripts intentionally
     // do not catch this so the build fails loudly on a corrupt content file.


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

The prebuild scripts (`scripts/refresh-hero-images.mjs`, `scripts/refresh-mux-gifs.mjs`) each carried an identical hand-rolled frontmatter parser that read line-by-line `key: value` text and only stripped double quotes:

```js
for (const line of body.split('\n')) {
  const m = line.match(/^(\w+):\s*(.*)$/);
  ...
  if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
}
```

Single-quoted strings, inline arrays, and nested objects were silently mangled. Production callers happened to only access flat string fields (`heroRefresh`, `muxPlaybackId`, `slug`, `screenshotSrc`, `githubUrl`) so the bug was not load-bearing — but the brittle parsing made the surface easy to regress whenever a new prebuild consumer touched a richer key.

This PR replaces both copies with a shared helper at `scripts/lib/parse-frontmatter.mjs` that uses `js-yaml`. The dep is already in the project's dep graph transitively (Astro consumes it); we pin a direct `devDependency` here so the import contract is explicit and decoupled from Astro version drift.

Resolves the #193 P1 + #64 nit findings from the [#342 validation pass](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/342#issuecomment-4444682862). The nit is a duplicate of the P1 — both close together.

## Self-Review

**Correctness.** I verified the new parser against every project markdown file under `src/content/projects/` and confirmed it produces the same flat-string field values as before, while now correctly preserving:

- `tags: ["Consumer", "Streaming", ...]` arrays (the old parser stored them as a string)
- nested `metadata:` blocks (the old parser silently dropped them)
- single-quoted strings (the old parser dropped these)
- CRLF line endings (the regex on the closing `\r?\n---` is unchanged)

No production caller accesses `tags` or `metadata` today, so this is forward-protection rather than a behavior change.

**Regression risk.** Low. The new helper is a strict superset of the old parser's contract — every input the old parser handled correctly is still handled correctly, and inputs the old parser mishandled are now handled per YAML 1.1.

**Style.** The shared helper sits alongside the consumers (`scripts/lib/parse-frontmatter.mjs`), matching the existing `scripts/lib/` convention. Both prebuild scripts import via a single named export.

**Test coverage.** Added `tests/parse-frontmatter.test.js` with seven cases covering the forms the old parser mishandled (single-quoted strings, inline arrays, nested objects, CRLF endings, throws on malformed YAML) plus the production-path flat-field forms. Total vitest suite: 151 passed (143 baseline + 8 new).

**Security / dependency hygiene.** Adds `js-yaml ^4.1.1` as a direct `devDependency`. `js-yaml` is the canonical YAML parser for Node, has no transitive runtime deps in its core path, and was already present in `node_modules` via Astro. The pinned range matches the version Astro pulls. Pure dev-time dep — does not affect production bundle.

## Test plan

- [x] `npm test` → 151/151 vitest tests pass.
- [x] Spot-check: parsed `slug`, `heroRefresh`, `muxPlaybackId`, `screenshotSrc`, `githubUrl` for all 6 projects → identical to old parser output.
- [x] Spot-check: `tags` and `metadata` on the same set of files now parse to their real structured shapes (array / object respectively) rather than the string-or-empty shapes the old parser produced.
- [ ] CI lane will re-run `npm test` + the Playwright suite.

Note: this PR does not run the prebuild scripts themselves (those hit the network — GitHub for social images, Mux for GIFs). Their parser swap is exercised by the unit test + the spot-check above; the network behavior is unchanged.
