### PR TITLE
fix(home): invert panel-label default so CSP-blocked-script users see labels (#344)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -133,14 +133,29 @@ const ogImageUrl = ogImage.includes('?') ? `${ogImage}&v=${buildTime}` : `${ogIm
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
   <!-- Gate Mondrian panel labels behind webfont readiness so the boxed
        "Nathan Payne" + tile labels don't visibly swap from system
-       fallback to Cormorant Garamond on first paint. CSS hides .panel-label
-       until [data-fonts-ready] lands, then fades it in. 1.5s timeout
-       reveals labels regardless if document.fonts isn't supported or
-       fonts are slow to load (better than indefinite invisibility). -->
+       fallback to Cormorant Garamond on first paint. The pattern is
+       opt-OUT, not opt-IN, so CSP-blocked-inline-script and JS-disabled
+       users degrade to visible labels with a FOUT (better than
+       invisible labels until a 1.5s timeout fallback fires).
+
+       Mechanism: the script tags `<html data-fonts-pending>` SYNCHRONOUSLY
+       in <head>, before the <body> parses, so labels paint hidden
+       on first frame for normal users. CSS hides .panel-label only
+       while that attribute is present. document.fonts.ready (or a 1.5s
+       timeout fallback) removes the attribute and triggers the fade-in.
+
+       If the script is blocked or never runs (CSP strict mode, NoScript
+       extension, fully-disabled JS, etc.), `data-fonts-pending` is
+       never set, the hide rule never matches, and labels render visible
+       from first paint with whatever font is currently available. The
+       FOUT swap when Cormorant Garamond loads later is acceptable —
+       it's the same trade-off every webfont-using site makes for
+       JS-restricted users. See #344. -->
   <script is:inline>
     (function () {
       var html = document.documentElement;
-      var reveal = function () { html.dataset.fontsReady = ''; };
+      html.dataset.fontsPending = '';
+      var reveal = function () { delete html.dataset.fontsPending; };
       if (document.fonts && document.fonts.ready && typeof document.fonts.ready.then === 'function') {
         document.fonts.ready.then(reveal);
         setTimeout(reveal, 1500);
@@ -149,12 +164,6 @@ const ogImageUrl = ogImage.includes('?') ? `${ogImage}&v=${buildTime}` : `${ogIm
       }
     })();
   </script>
-  <noscript>
-    <!-- JS-disabled users never get [data-fonts-ready] applied; fall back
-         to visible labels with the original FOUT behavior so the homepage
-         still has navigational affordances. -->
-    <style>.panel-label { opacity: 1 !important; }</style>
-  </noscript>
 </head>
 <body class={bodyClass}>
   <slot />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -314,18 +314,24 @@ html, body {
   text-align: left;
   pointer-events: none;
   font-family: "Cormorant Garamond", Garamond, serif;
-  /* Hidden until Cormorant Garamond is ready, then fades in. Prevents
-     the visible swap from system-fallback to Cormorant on first paint
-     (most noticeable on the boxed "Nathan Payne" label). The
-     [data-fonts-ready] attribute is set by the inline script in
-     BaseLayout.astro that waits on document.fonts.ready (with a 1.5s
-     timeout fallback). */
-  opacity: 0;
+  /* Visible by default so CSP-blocked-inline-script and JS-disabled
+     users never hit invisible labels. The hide-while-fonts-load gate
+     below is opt-IN: only triggers when the inline script in
+     BaseLayout.astro tags <html data-fonts-pending> synchronously in
+     <head>. When that script is blocked or never runs, the gate never
+     applies and labels render with the system-font FOUT instead of
+     waiting on a 1.5s timeout fallback. See #344. */
+  opacity: 1;
   transition: opacity var(--motion-hover) var(--ease-standard);
 }
 
-html[data-fonts-ready] .panel-label {
-  opacity: 1;
+/* Webfont-readiness gate. The inline script sets this attribute
+   synchronously before <body> parses, so labels paint hidden on first
+   frame for users whose script runs (no FOUT swap to Cormorant). The
+   attribute is removed when document.fonts.ready resolves or after a
+   1.5s timeout, fading labels in. */
+html[data-fonts-pending] .panel-label {
+  opacity: 0;
 }
 
 .panel-label--name {


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Resolves #344 (audit verdict: AMBIGUOUS, decided in-thread to **fix it**). Panel labels on the homepage Mondrian were hidden by default and revealed by an inline script that set `[data-fonts-ready]` once Cormorant Garamond loaded. The pattern covered fully-disabled-JS users via a `<noscript>` style override but missed users whose **browser/extension blocks inline scripts via CSP** — the script never ran, the `<noscript>` never triggered (JS is technically "enabled"), and labels stayed invisible until the 1.5s rAF timeout fallback fired.

This PR inverts the default: labels are visible by CSS, and the inline script tags `<html data-fonts-pending>` synchronously in `<head>` to trigger an opt-IN hide rule. When the script doesn't run (CSP, no-JS, extension blocking), the gate never matches and labels render visible from first paint with whatever font is currently available. The Cormorant FOUT becomes acceptable for the JS-restricted minority — the same trade-off every webfont-using site makes.

The `<noscript>` style override is removed: the new default already covers JS-disabled users.

## Behavioral matrix

| User population              | Before                          | After                                |
|------------------------------|---------------------------------|--------------------------------------|
| Normal (script runs)         | Hidden then fade in on fonts    | Hidden then fade in on fonts (unchanged) |
| Fully-disabled JS            | Visible (via `<noscript>`)      | Visible (via inverted default)       |
| CSP-blocked inline script    | Hidden until 1.5s timeout       | **Visible immediately, then FOUT**   |

## Self-Review

- **Correctness:** the script is in `<head>` and sets the attribute on `document.documentElement` synchronously before `<body>` parses, so for normal users the label still paints hidden on first frame (no FOUT swap to Cormorant). Verified in preview that opacity transitions match the matrix above (pending: 0, ready: 1, never-set: 1). All 159 tests pass.
- **Regression risk:** low. Only two files touched (`BaseLayout.astro`, `global.css`). The data attribute name changed (`data-fonts-ready` → `data-fonts-pending`); grep confirmed nothing else in `src/` references either name. The transition timing on `.panel-label` is unchanged, so the fade-in feel after fonts ready is identical for normal users.
- **Style:** matches existing inline-script + dataset gating pattern. Comments updated in both files explaining the new opt-IN gate. The `<noscript>` block is deleted rather than left as a dead defensive layer.
- **Test coverage:** opacity matrix verified via preview `eval` (script-just-ran, fonts-ready, gate-never-set). No new automated test added — the existing test suite passes and the failure mode this fixes is environmental (CSP / extension behavior) which would need browser-environment instrumentation to exercise reliably.
- **Security / dependency hygiene:** no new dependencies, no new attack surface. The inline script is the same shape as before, just toggling a different attribute. Removing the `<noscript>` style block reduces the page's CSS surface by one rule.

## Test plan

- [x] `npm run build` passes (25 pages)
- [x] `npm test -- --run` passes (159/159)
- [x] Preview verified: `data-fonts-pending` set → labels opacity 0 ✓; attribute removed → labels opacity 1 ✓; attribute never set → labels opacity 1 ✓
- [x] Visual: homepage Mondrian renders with all four labels visible after fonts load (no behavior change for normal users)
- [ ] Manual CSP simulation in browser (optional): load with strict CSP `script-src 'self'` (which blocks inline scripts) and confirm labels render visible on first paint

## Closes

- #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)