### PR TITLE
test: lock in cross-platform path conversion for build scripts (#355)

### DIFF
--- a/tests/path-conversion.test.js
+++ b/tests/path-conversion.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * path-conversion.test.js — lock in the cross-platform contract for
+ * `import.meta.url` → filesystem-path conversion in build scripts.
+ *
+ * PR #174 fixed a Windows-only break where a build script used
+ *
+ *     const filePath = import.meta.url.replace('file://', '');
+ *
+ * to convert a module URL to a path. On POSIX that almost works
+ * (modulo a leading slash); on Windows it produces invalid paths like
+ * `/C:/Users/...` that no filesystem call accepts.
+ *
+ * The fix is to use `fileURLToPath(import.meta.url)` from `node:url`,
+ * which handles both platforms correctly. This test locks that
+ * contract in two ways:
+ *
+ *   1. **Platform contract** — assert that `fileURLToPath` on
+ *      `import.meta.url` (this test file itself) yields a string that
+ *      has no scheme prefix and that `existsSync` accepts. Catches a
+ *      regression in the Node runtime / build environment.
+ *
+ *   2. **Source-shape contract** — assert that the production build
+ *      scripts (`refresh-hero-images.mjs`, `refresh-mux-gifs.mjs`)
+ *      both contain the `fileURLToPath(import.meta.url)` pattern and
+ *      do NOT contain the buggy `import.meta.url.replace(` pattern.
+ *      Fragile to *intentional* refactor — that's the point. If someone
+ *      ever refactors back into a string replacement on a Mac/Linux
+ *      machine, this test fails on every CI lane the repo runs.
+ *
+ * See issue #355 for the design conversation that led to choosing
+ * this targeted test over a full Windows CI lane.
+ */
+
+const REPO_ROOT = resolve(fileURLToPath(import.meta.url), '..', '..');
+
+const BUILD_SCRIPTS = [
+  'scripts/refresh-hero-images.mjs',
+  'scripts/refresh-mux-gifs.mjs',
+];
+
+// The buggy pattern. Match the call form, not the literal substring —
+// `import.meta.url.replace(...)` with any args is suspicious in the
+// context of these scripts. `String.prototype.replace` exists for
+// real reasons elsewhere, so this regex is scoped to call sites on
+// `import.meta.url` specifically.
+const BUGGY_REPLACE = /import\.meta\.url\s*\.\s*replace\s*\(/;
+
+// The good pattern.
+const GOOD_FILEURL_CALL = /fileURLToPath\s*\(\s*import\.meta\.url\s*\)/;
+
+describe('cross-platform path conversion (#174 / #355)', () => {
+  it('fileURLToPath(import.meta.url) yields a usable filesystem path', () => {
+    const path = fileURLToPath(import.meta.url);
+    expect(path).not.toMatch(/^file:/);
+    expect(path).not.toContain('://');
+    // The path resolves to this very test file, which obviously exists.
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it.each(BUILD_SCRIPTS)(
+    '%s converts import.meta.url via fileURLToPath, not string replacement',
+    (relativeScriptPath) => {
+      const fullPath = resolve(REPO_ROOT, relativeScriptPath);
+      const source = readFileSync(fullPath, 'utf-8');
+      expect(
+        GOOD_FILEURL_CALL.test(source),
+        `${relativeScriptPath} should call fileURLToPath(import.meta.url) — the cross-platform path-conversion idiom`,
+      ).toBe(true);
+      expect(
+        BUGGY_REPLACE.test(source),
+        `${relativeScriptPath} must not use \`import.meta.url.replace(...)\` — that string-munging pattern breaks on Windows (see PR #174, issue #355)`,
+      ).toBe(false);
+    },
+  );
+});


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Lock in the cross-platform path-conversion contract for the prebuild scripts via a targeted unit test, per the design discussion in [#355](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/355).

The reviewer concern from [PR #174](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/174#discussion_r3081943260) — that no CI catches the next regression in the `import.meta.url` → filesystem path conversion class — is addressed without paying the cost of a Windows CI matrix on a static site with no Windows-targeted features.

## What the test covers

`tests/path-conversion.test.js` adds two assertions:

1. **Platform contract.** `fileURLToPath(import.meta.url)` on the test file itself yields a string with no `file:` prefix that `existsSync()` accepts. Catches a Node runtime / CI environment regression in the API behavior the build scripts depend on.

2. **Source-shape contract.** Each of `scripts/refresh-hero-images.mjs` and `scripts/refresh-mux-gifs.mjs` (via `it.each`) is asserted to:
   - contain the `fileURLToPath(import.meta.url)` pattern, and
   - NOT contain the buggy `import.meta.url.replace(` pattern.

   Fragile to intentional refactor — that's the point. If someone refactors back into string replacement on a Mac/Linux dev machine, this test fails on every CI lane the repo already runs, so the Windows-only regression class can't ship.

## Self-Review

**Correctness.** The regexes are scoped:
- `GOOD_FILEURL_CALL = /fileURLToPath\s*\(\s*import\.meta\.url\s*\)/` — matches the canonical Node idiom with whitespace tolerance.
- `BUGGY_REPLACE = /import\.meta\.url\s*\.\s*replace\s*\(/` — narrower than a bare `.replace(` substring search; matches only call sites *on* `import.meta.url`, not unrelated `String.prototype.replace` usage elsewhere.

The platform-contract test uses `import.meta.url` of the test file itself, so it's self-validating — if the assertion fails it means Node's `url` module broke, which is a runtime problem worth knowing about.

**Regression risk.** Pure test addition. No production code touched. The source-shape regex correctly recognizes both scripts on current `main` (verified — both scripts use `dirname(fileURLToPath(import.meta.url))` at the top).

**Style.** Header comment explains the bug class, the design choice (targeted test over Windows lane), and links to #355 for the discussion. Two-assertion shape matches the rest of `tests/`.

**Test coverage.** Vitest goes from 159 → 162 (1 platform-contract + 2 source-shape, one per script).

**Security / dependency hygiene.** No new dependencies. The test imports only from `node:` builtins and the production scripts' source.

## Test plan

- [x] `npm test` → 162/162 vitest.
- [x] Manual mental-walkthrough of the negative case: introducing `import.meta.url.replace(...)` in either build script would trip the per-script `it.each` assertion with a script-named failure message.

## Why not Windows CI?

Discussed at length in [#355](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/355). Short version: this site has zero Windows-targeted features, so a full Windows CI lane would pay slow + expensive runner cost on every PR to protect a one-file regression class. A targeted unit test catches the same regression class for ~30 lines of test code and runs on the existing Linux lanes.

If the site ever needs to *build* on Windows for real (contributors, Windows-based agents, etc.), revisit the Windows-lane option then. Until then this is the proportional response.

Closes #355.
