### PR TITLE
fix(audit): require +1 reaction from Codex bot as clearance signal (#354)

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -109,12 +109,24 @@ jobs:
               // self-approval) consume them, and an earlier version
               // of this script fetched twice. CodeRabbit caught the
               // duplicate on PR #68.
-              const reviewsResp = await github.rest.pulls.listReviews({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: pr.number,
-              });
-              const reviews = reviewsResp.data;
+              //
+              // Paginated — `pulls.listReviews` defaults to 30 per
+              // page and returns in chronological order, so a PR
+              // with many review rounds can hide the *latest* Codex
+              // review beyond the first page. The Check 2 logic below
+              // selects the latest Codex review by `submitted_at` to
+              // anchor the clearance gate, so a stale-history slice
+              // would silently misclassify clearance (Codex P2 catch
+              // on PR #359).
+              const reviews = await github.paginate(
+                github.rest.pulls.listReviews,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                  per_page: 100,
+                }
+              );
 
               // Check 1: Missing Self-Review section
               //
@@ -185,8 +197,38 @@ jobs:
                        reviewerAccounts.includes(r.user.login)
                 );
 
+                // Anchor: latest Codex review by submitted_at, if any.
+                // Used to gate reaction-freshness AND to identify the
+                // review whose inline comments determine the Path 2
+                // gate. Without this anchor, a stale +1 reaction from
+                // an earlier round could satisfy clearance even when
+                // a newer Codex review (still before merge) posted
+                // unaddressed P0/P1 findings — exactly the bypass
+                // this audit is meant to catch. Codex P1 catch on
+                // PR #359.
+                const codexBotReviews = reviews.filter(
+                  r => r.user && r.user.login === codexBotLogin
+                );
+                const latestCodexReview =
+                  codexBotReviews.length > 0
+                    ? codexBotReviews.reduce(
+                        (latest, r) =>
+                          new Date(r.submitted_at) > new Date(latest.submitted_at)
+                            ? r
+                            : latest,
+                        codexBotReviews[0]
+                      )
+                    : null;
+                const latestCodexReviewAt = latestCodexReview
+                  ? new Date(latestCodexReview.submitted_at)
+                  : null;
+
                 // Path 1: +1 reaction on the PR issue from Codex,
-                // dated on or before the merge.
+                // dated on or before the merge AND on or after the
+                // latest Codex review (so a stale reaction from an
+                // earlier round cannot mask a later failing review).
+                // If no Codex review exists, the reaction is the only
+                // signal and any pre-merge reaction is accepted.
                 const reactions = await github.paginate(
                   github.rest.reactions.listForIssue,
                   {
@@ -201,7 +243,9 @@ jobs:
                   r => r.user &&
                        r.user.login === codexBotLogin &&
                        r.content === '+1' &&
-                       new Date(r.created_at) <= mergedAt
+                       new Date(r.created_at) <= mergedAt &&
+                       (latestCodexReviewAt === null ||
+                        new Date(r.created_at) >= latestCodexReviewAt)
                 );
 
                 // Path 2: latest Codex review on the PR has no
@@ -211,16 +255,8 @@ jobs:
                 // shape `![P0 Badge]…` / `![P1 Badge]…` Codex emits
                 // in inline finding bodies — see codex-review-check.sh
                 // for the source of truth.
-                const codexBotReviews = reviews.filter(
-                  r => r.user && r.user.login === codexBotLogin
-                );
                 let codexReviewCleared = false;
-                if (codexBotReviews.length > 0) {
-                  const latestCodexReview = codexBotReviews.reduce(
-                    (latest, r) =>
-                      new Date(r.submitted_at) > new Date(latest.submitted_at) ? r : latest,
-                    codexBotReviews[0]
-                  );
+                if (latestCodexReview) {
                   const inlineComments = await github.paginate(
                     github.rest.pulls.listReviewComments,
                     {

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -150,9 +150,11 @@ jobs:
                 // For the external-review path we accept either:
                 //   - an APPROVED review from a CLI reviewer identity
                 //     (nathanpayne-claude / nathanpayne-codex / etc.), OR
-                //   - a 👍 (+1) clearance reaction from the Codex GitHub
-                //     app bot on the PR issue, dated on or before the
-                //     merge.
+                //   - a Codex GitHub app bot clearance — via EITHER
+                //     a +1 reaction on the PR issue, OR a COMMENTED
+                //     Codex review whose latest inline comments have
+                //     zero unaddressed P0/P1 findings on the merged
+                //     HEAD.
                 //
                 // CLI reviewer identities still require state ===
                 // 'APPROVED' because a non-opinionated COMMENTED review
@@ -163,22 +165,28 @@ jobs:
                 // Phase 4b fallback PR with only a COMMENTED CLI
                 // review pass the audit.
                 //
-                // The Codex bot never emits APPROVED — the GitHub app's
-                // clearance signal is a +1 reaction on the PR issue,
-                // which is also what `scripts/codex-review-check.sh`
-                // enforces at merge time. An earlier version of this
-                // gate accepted "any review from the Codex bot,
-                // regardless of state" as clearance — but that
-                // includes Codex reviews that posted P0/P1 findings
-                // and were never cleared (a non-clearance signal
-                // masquerading as one). Issue #354 surfaced that gap.
-                // We now require the explicit reaction, so the audit
-                // matches the merge gate.
+                // The Codex two-path clearance shape mirrors the
+                // merge-time gate in `scripts/codex-review-check.sh`
+                // (gate (c)). An earlier draft of this audit accepted
+                // "any review from the Codex bot, regardless of state"
+                // as clearance — but that includes Codex reviews that
+                // posted P0/P1 findings and were never cleared, a
+                // non-clearance signal masquerading as one (#354).
+                // A subsequent draft tightened to "+1 reaction only,"
+                // which fixed the false-negative but introduced a
+                // false-positive: PRs cleared via the review-only
+                // path (Codex commented, no P0/P1 findings, no
+                // reaction) would be falsely flagged. The check below
+                // accepts both paths so the audit matches the merge
+                // gate exactly. Codex caught the false-positive on
+                // PR #359.
                 const cliApprovedReviews = reviews.filter(
                   r => r.state === 'APPROVED' &&
                        reviewerAccounts.includes(r.user.login)
                 );
 
+                // Path 1: +1 reaction on the PR issue from Codex,
+                // dated on or before the merge.
                 const reactions = await github.paginate(
                   github.rest.reactions.listForIssue,
                   {
@@ -196,11 +204,49 @@ jobs:
                        new Date(r.created_at) <= mergedAt
                 );
 
+                // Path 2: latest Codex review on the PR has no
+                // unaddressed P0/P1 inline comments tied to it.
+                // Mirrors `scripts/codex-review-check.sh:548-561`.
+                // The badge regex matches the canonical markdown
+                // shape `![P0 Badge]…` / `![P1 Badge]…` Codex emits
+                // in inline finding bodies — see codex-review-check.sh
+                // for the source of truth.
+                const codexBotReviews = reviews.filter(
+                  r => r.user && r.user.login === codexBotLogin
+                );
+                let codexReviewCleared = false;
+                if (codexBotReviews.length > 0) {
+                  const latestCodexReview = codexBotReviews.reduce(
+                    (latest, r) =>
+                      new Date(r.submitted_at) > new Date(latest.submitted_at) ? r : latest,
+                    codexBotReviews[0]
+                  );
+                  const inlineComments = await github.paginate(
+                    github.rest.pulls.listReviewComments,
+                    {
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      pull_number: pr.number,
+                      per_page: 100,
+                    }
+                  );
+                  const unaddressedP01 = inlineComments.filter(
+                    c => c.user &&
+                         c.user.login === codexBotLogin &&
+                         c.pull_request_review_id === latestCodexReview.id &&
+                         /!\[P[01] Badge\]/.test(c.body || '')
+                  );
+                  codexReviewCleared = unaddressedP01.length === 0;
+                }
+
+                const codexCleared =
+                  codexClearanceReactions.length > 0 || codexReviewCleared;
+
                 if (hadExternalLabel &&
                     cliApprovedReviews.length === 0 &&
-                    codexClearanceReactions.length === 0) {
+                    !codexCleared) {
                   prViolations.push(
-                    'External-review PR merged with no APPROVED review from a CLI reviewer identity and no +1 clearance reaction from the Codex bot'
+                    'External-review PR merged with no APPROVED review from a CLI reviewer identity and no Codex clearance signal (+1 reaction or COMMENTED review with no unaddressed P0/P1)'
                   );
                 }
 

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -197,17 +197,47 @@ jobs:
                        reviewerAccounts.includes(r.user.login)
                 );
 
-                // Anchor: latest Codex review by submitted_at, if any.
-                // Used to gate reaction-freshness AND to identify the
-                // review whose inline comments determine the Path 2
-                // gate. Without this anchor, a stale +1 reaction from
-                // an earlier round could satisfy clearance even when
-                // a newer Codex review (still before merge) posted
-                // unaddressed P0/P1 findings — exactly the bypass
-                // this audit is meant to catch. Codex P1 catch on
-                // PR #359.
+                const mergedAt = new Date(pr.merged_at);
+
+                // Anchor: latest Codex review by submitted_at,
+                // scoped to the merge-time review set. Used to gate
+                // reaction-freshness AND to identify the review whose
+                // inline comments determine the Path 2 gate.
+                //
+                // Three constraints on the candidate set, matching the
+                // merge-time gate in `scripts/codex-review-check.sh`:
+                //
+                //   1. `state === 'COMMENTED'` — Codex's GitHub app
+                //      only emits COMMENTED reviews; an APPROVED or
+                //      CHANGES_REQUESTED review by something else
+                //      mis-attributed to the bot login (or a future
+                //      GitHub app behavior change) shouldn't satisfy
+                //      the gate.
+                //   2. `submitted_at <= mergedAt` — exclude post-merge
+                //      Codex reruns (someone manually triggered
+                //      `@codex review` after the merge to audit the
+                //      diff). Those say nothing about whether the PR
+                //      was cleared *before* it merged.
+                //   3. `commit_id === pr.head.sha` — exclude reviews
+                //      on prior commits in the branch's history. The
+                //      audit's clearance question is "did Codex
+                //      clear the commit that actually merged", not
+                //      "did Codex ever review anything on this PR".
+                //
+                // Without these, a stale +1 reaction from an earlier
+                // round could satisfy clearance even when a newer
+                // Codex review (still before merge) posted
+                // unaddressed P0/P1 findings (Codex P1 catch on
+                // round 2 of PR #359), AND `latestCodexReview` could
+                // drift to a post-merge or wrong-head review
+                // (CodeRabbit Major catch on round 3 of PR #359).
+                const mergedHeadSha = pr.head && pr.head.sha;
                 const codexBotReviews = reviews.filter(
-                  r => r.user && r.user.login === codexBotLogin
+                  r => r.user &&
+                       r.user.login === codexBotLogin &&
+                       r.state === 'COMMENTED' &&
+                       new Date(r.submitted_at) <= mergedAt &&
+                       r.commit_id === mergedHeadSha
                 );
                 const latestCodexReview =
                   codexBotReviews.length > 0
@@ -227,8 +257,9 @@ jobs:
                 // dated on or before the merge AND on or after the
                 // latest Codex review (so a stale reaction from an
                 // earlier round cannot mask a later failing review).
-                // If no Codex review exists, the reaction is the only
-                // signal and any pre-merge reaction is accepted.
+                // If no merge-time-scoped Codex review exists, the
+                // reaction is the only signal and any pre-merge
+                // reaction is accepted.
                 const reactions = await github.paginate(
                   github.rest.reactions.listForIssue,
                   {
@@ -238,7 +269,6 @@ jobs:
                     per_page: 100,
                   }
                 );
-                const mergedAt = new Date(pr.merged_at);
                 const codexClearanceReactions = reactions.filter(
                   r => r.user &&
                        r.user.login === codexBotLogin &&

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -72,10 +72,9 @@ jobs:
             // unioning them into a single allow-list. See the
             // Check 2 block for the full rationale; the short
             // version is that CLI identities still require
-            // state === 'APPROVED' but the Codex bot can clear
-            // with any review state because the GitHub app never
-            // emits APPROVED — only COMMENTED with a 👍 reaction
-            // or no findings (see #29 for observational evidence).
+            // state === 'APPROVED', and the Codex bot's clearance
+            // signal is a +1 reaction on the PR issue (the GitHub
+            // app never emits APPROVED — see #29 + #354).
 
             const since = new Date();
             since.setDate(since.getDate() - 7);
@@ -151,36 +150,57 @@ jobs:
                 // For the external-review path we accept either:
                 //   - an APPROVED review from a CLI reviewer identity
                 //     (nathanpayne-claude / nathanpayne-codex / etc.), OR
-                //   - ANY review from the Codex GitHub app bot,
-                //     regardless of state, because the Codex app
-                //     never emits APPROVED — only COMMENTED with a
-                //     👍 reaction or no findings (see #29 for the
-                //     observational evidence).
+                //   - a 👍 (+1) clearance reaction from the Codex GitHub
+                //     app bot on the PR issue, dated on or before the
+                //     merge.
                 //
-                // The state-agnostic exception is intentionally
-                // SCOPED to the Codex bot only. CLI reviewer
-                // identities still require state === 'APPROVED'
-                // because a non-opinionated COMMENTED review from
-                // a CLI reviewer is not a clearance signal under
+                // CLI reviewer identities still require state ===
+                // 'APPROVED' because a non-opinionated COMMENTED review
+                // from a CLI reviewer is not a clearance signal under
                 // policy. nathanpayne-codex caught this on PR #68
                 // round 1 — earlier draft accepted any review from
                 // any external approver, which would have let a
                 // Phase 4b fallback PR with only a COMMENTED CLI
                 // review pass the audit.
+                //
+                // The Codex bot never emits APPROVED — the GitHub app's
+                // clearance signal is a +1 reaction on the PR issue,
+                // which is also what `scripts/codex-review-check.sh`
+                // enforces at merge time. An earlier version of this
+                // gate accepted "any review from the Codex bot,
+                // regardless of state" as clearance — but that
+                // includes Codex reviews that posted P0/P1 findings
+                // and were never cleared (a non-clearance signal
+                // masquerading as one). Issue #354 surfaced that gap.
+                // We now require the explicit reaction, so the audit
+                // matches the merge gate.
                 const cliApprovedReviews = reviews.filter(
                   r => r.state === 'APPROVED' &&
                        reviewerAccounts.includes(r.user.login)
                 );
 
-                const codexBotReviews = reviews.filter(
-                  r => r.user.login === codexBotLogin
+                const reactions = await github.paginate(
+                  github.rest.reactions.listForIssue,
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    per_page: 100,
+                  }
+                );
+                const mergedAt = new Date(pr.merged_at);
+                const codexClearanceReactions = reactions.filter(
+                  r => r.user &&
+                       r.user.login === codexBotLogin &&
+                       r.content === '+1' &&
+                       new Date(r.created_at) <= mergedAt
                 );
 
                 if (hadExternalLabel &&
                     cliApprovedReviews.length === 0 &&
-                    codexBotReviews.length === 0) {
+                    codexClearanceReactions.length === 0) {
                   prViolations.push(
-                    'External-review PR merged with no APPROVED review from a CLI reviewer identity and no review from the Codex bot'
+                    'External-review PR merged with no APPROVED review from a CLI reviewer identity and no +1 clearance reaction from the Codex bot'
                   );
                 }
 

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -200,43 +200,6 @@ jobs:
                 const mergedAt = new Date(pr.merged_at);
                 const mergedHeadSha = pr.head && pr.head.sha;
 
-                // Committer date of the merged HEAD commit. Used as the
-                // reaction-freshness anchor when no head-scoped Codex
-                // review exists — without this, an old +1 from a prior
-                // round (on an earlier HEAD) could satisfy clearance on
-                // a merged commit Codex never actually reviewed (Codex
-                // P1 catch on round 4 of PR #359). Mirrors how
-                // `scripts/codex-review-check.sh` uses HEAD_PUSHED_AT
-                // as the reaction-threshold anchor.
-                //
-                // Best-effort: if the commit isn't fetchable (rare,
-                // typically when the branch was force-pushed or the
-                // commit GC'd), leave the anchor null and let the
-                // no-anchor branch in the reaction filter below
-                // refuse to clear via reactions.
-                let mergedHeadCommittedAt = null;
-                if (mergedHeadSha) {
-                  try {
-                    const commitResp = await github.rest.repos.getCommit({
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      ref: mergedHeadSha,
-                    });
-                    if (
-                      commitResp.data &&
-                      commitResp.data.commit &&
-                      commitResp.data.commit.committer &&
-                      commitResp.data.commit.committer.date
-                    ) {
-                      mergedHeadCommittedAt = new Date(
-                        commitResp.data.commit.committer.date
-                      );
-                    }
-                  } catch (e) {
-                    // Leave anchor null; reaction path closes below.
-                  }
-                }
-
                 // Anchor: latest Codex review by submitted_at,
                 // scoped to the merge-time review set. Used to gate
                 // reaction-freshness AND to identify the review whose
@@ -292,20 +255,32 @@ jobs:
 
                 // Path 1: +1 reaction on the PR issue from Codex,
                 // dated on or before the merge AND on or after the
-                // freshness anchor. The anchor is the latest
-                // head-scoped Codex review if one exists, else the
-                // merged HEAD's committer date — that way, an old +1
-                // reaction from an earlier HEAD cannot satisfy
-                // clearance on a commit Codex never actually
-                // reviewed (Codex P1 catch on round 4 of PR #359).
-                // If neither anchor is available (no Codex review on
-                // merged HEAD AND head commit not fetchable above),
-                // the reaction path cannot clear and the audit falls
-                // through to require an APPROVED CLI reviewer.
-                const reactionAnchor =
-                  latestCodexReviewAt !== null
-                    ? latestCodexReviewAt
-                    : mergedHeadCommittedAt;
+                // latest head-scoped Codex review.
+                //
+                // The anchor is ONLY the latest head-scoped Codex
+                // review's submitted_at. There is no fallback
+                // anchor: if no head-scoped Codex review exists,
+                // the reaction path stays closed and the audit
+                // falls through to require an APPROVED CLI
+                // reviewer.
+                //
+                // An earlier draft (round 5) used the merged HEAD
+                // commit's committer date as a fallback anchor when
+                // no head-scoped review existed. nathanpayne-codex's
+                // round-6 CHANGES_REQUESTED on PR #359 caught the
+                // hole: committer date can predate when the SHA
+                // actually became the PR head (cherry-pick, rebase
+                // with `--committer-date-is-author-date`, an old
+                // local commit pushed today). An older Codex +1 from
+                // before the merged commit became HEAD could still
+                // satisfy the audit. There's no robust push-time
+                // signal we can derive from the post-merge state
+                // alone, so the cleaner resolution is to close the
+                // path entirely: a PR with `needs-external-review`
+                // and no head-scoped Codex review on the merged
+                // commit must have an APPROVED CLI reviewer to
+                // clear the audit, regardless of how many +1s the
+                // Codex bot ever left.
                 const reactions = await github.paginate(
                   github.rest.reactions.listForIssue,
                   {
@@ -320,8 +295,8 @@ jobs:
                        r.user.login === codexBotLogin &&
                        r.content === '+1' &&
                        new Date(r.created_at) <= mergedAt &&
-                       reactionAnchor !== null &&
-                       new Date(r.created_at) >= reactionAnchor
+                       latestCodexReviewAt !== null &&
+                       new Date(r.created_at) >= latestCodexReviewAt
                 );
 
                 // Path 2: latest Codex review on the PR has no

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -198,6 +198,44 @@ jobs:
                 );
 
                 const mergedAt = new Date(pr.merged_at);
+                const mergedHeadSha = pr.head && pr.head.sha;
+
+                // Committer date of the merged HEAD commit. Used as the
+                // reaction-freshness anchor when no head-scoped Codex
+                // review exists — without this, an old +1 from a prior
+                // round (on an earlier HEAD) could satisfy clearance on
+                // a merged commit Codex never actually reviewed (Codex
+                // P1 catch on round 4 of PR #359). Mirrors how
+                // `scripts/codex-review-check.sh` uses HEAD_PUSHED_AT
+                // as the reaction-threshold anchor.
+                //
+                // Best-effort: if the commit isn't fetchable (rare,
+                // typically when the branch was force-pushed or the
+                // commit GC'd), leave the anchor null and let the
+                // no-anchor branch in the reaction filter below
+                // refuse to clear via reactions.
+                let mergedHeadCommittedAt = null;
+                if (mergedHeadSha) {
+                  try {
+                    const commitResp = await github.rest.repos.getCommit({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      ref: mergedHeadSha,
+                    });
+                    if (
+                      commitResp.data &&
+                      commitResp.data.commit &&
+                      commitResp.data.commit.committer &&
+                      commitResp.data.commit.committer.date
+                    ) {
+                      mergedHeadCommittedAt = new Date(
+                        commitResp.data.commit.committer.date
+                      );
+                    }
+                  } catch (e) {
+                    // Leave anchor null; reaction path closes below.
+                  }
+                }
 
                 // Anchor: latest Codex review by submitted_at,
                 // scoped to the merge-time review set. Used to gate
@@ -231,7 +269,6 @@ jobs:
                 // round 2 of PR #359), AND `latestCodexReview` could
                 // drift to a post-merge or wrong-head review
                 // (CodeRabbit Major catch on round 3 of PR #359).
-                const mergedHeadSha = pr.head && pr.head.sha;
                 const codexBotReviews = reviews.filter(
                   r => r.user &&
                        r.user.login === codexBotLogin &&
@@ -255,11 +292,20 @@ jobs:
 
                 // Path 1: +1 reaction on the PR issue from Codex,
                 // dated on or before the merge AND on or after the
-                // latest Codex review (so a stale reaction from an
-                // earlier round cannot mask a later failing review).
-                // If no merge-time-scoped Codex review exists, the
-                // reaction is the only signal and any pre-merge
-                // reaction is accepted.
+                // freshness anchor. The anchor is the latest
+                // head-scoped Codex review if one exists, else the
+                // merged HEAD's committer date — that way, an old +1
+                // reaction from an earlier HEAD cannot satisfy
+                // clearance on a commit Codex never actually
+                // reviewed (Codex P1 catch on round 4 of PR #359).
+                // If neither anchor is available (no Codex review on
+                // merged HEAD AND head commit not fetchable above),
+                // the reaction path cannot clear and the audit falls
+                // through to require an APPROVED CLI reviewer.
+                const reactionAnchor =
+                  latestCodexReviewAt !== null
+                    ? latestCodexReviewAt
+                    : mergedHeadCommittedAt;
                 const reactions = await github.paginate(
                   github.rest.reactions.listForIssue,
                   {
@@ -274,8 +320,8 @@ jobs:
                        r.user.login === codexBotLogin &&
                        r.content === '+1' &&
                        new Date(r.created_at) <= mergedAt &&
-                       (latestCodexReviewAt === null ||
-                        new Date(r.created_at) >= latestCodexReviewAt)
+                       reactionAnchor !== null &&
+                       new Date(r.created_at) >= reactionAnchor
                 );
 
                 // Path 2: latest Codex review on the PR has no


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Tighten the weekly external-review audit's Codex-side clearance check, per the design discussion in [#354](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/354).

The previous gate at `.github/workflows/pr-audit.yml:175-181` accepted **any** review from `chatgpt-codex-connector[bot]` as satisfying the external-review requirement, regardless of whether the review represented clearance or unaddressed P0/P1 findings. That left a real hole: a Codex review that posted P0/P1 findings and was never cleared would still pass the post-hoc audit. The merge-time gate in `scripts/codex-review-check.sh` would catch it at merge, but the weekly audit is the safety net for cases where the merge gate was bypassed.

## What changed

Replace `codexBotReviews.length > 0` with a check for a 👍 (+1) reaction on the PR issue from the Codex bot, dated on or before the merge:

```js
const reactions = await github.paginate(
  github.rest.reactions.listForIssue,
  { owner, repo, issue_number: pr.number, per_page: 100 }
);
const mergedAt = new Date(pr.merged_at);
const codexClearanceReactions = reactions.filter(
  r => r.user &&
       r.user.login === codexBotLogin &&
       r.content === '+1' &&
       new Date(r.created_at) <= mergedAt
);
```

That's the same clearance signal `scripts/codex-review-check.sh` enforces at merge time, so the audit now matches the merge gate.

Also updated:
- Top-of-file comment block on the Codex bot's review semantics
- Check 2 inline rationale (called out #354 + the old "presence-only" semantics)
- Violation message text to name the new signal explicitly

## Self-Review

**Correctness.** The reactions API for an issue (`/repos/{owner}/{repo}/issues/{number}/reactions`) returns top-level reactions on the issue body, which is where Codex posts its 👍 clearance signal — verified by reading `scripts/codex-review-check.sh`. Filter on `r.user.login === codexBotLogin && r.content === '+1' && created_at <= mergedAt`. Defensive `r.user &&` guards against API responses where `user` is null (rare but possible on deleted accounts).

**Regression risk.**
- PRs that *correctly* received a +1 reaction from Codex before merge continue to pass. No false positives expected here.
- PRs where Codex never +1'd but the PR was merged via a CLI reviewer approval continue to pass via the unchanged `cliApprovedReviews.length === 0` half of the gate.
- The only new false-positive class is "PR had `needs-external-review` label, was merged with a CLI reviewer approval but no Codex +1, AND we don't trust the CLI approval to be sufficient." That's the case the audit *should* flag — it's the gap the issue identified.

**Style.** Comment density matches the surrounding script. Cross-references `#354` and the merge-time gate. The audit is YAML so I verified parse cleanliness with `yq eval '.jobs' …` after the edit.

**Test coverage.** No unit-test framework covers GitHub Actions workflow JS in this repo. The workflow runs weekly via cron + manual `workflow_dispatch`. After merge, the first scheduled run (or a manual dispatch) will exercise the change end-to-end against the prior week's merged PRs.

**Security / dependency hygiene.** No new dependencies. The new API call (`reactions.listForIssue`) is read-only and reuses the existing `REVIEWER_ASSIGNMENT_TOKEN` PAT.

**External review.** Touches `.github/**` which is in `external_review_paths` in `.github/review-policy.yml`, so this PR is subject to mandatory Phase 4 Codex review regardless of line count.

## Test plan

- [x] `yq eval '.jobs' .github/workflows/pr-audit.yml` → parses cleanly.
- [x] Node string check confirms two occurrences of `codexClearanceReactions` (declared + used), no lingering `codexBotReviews` references.
- [x] `npm test` → 162/162 vitest (no production code touched, sanity only).
- [ ] First scheduled audit run after merge will exercise the new gate against last week's merged PRs. Manual `workflow_dispatch` is available if validation needs to happen sooner.

Closes #354.
