### PR TITLE
sync: bulk reconcile to mergepath@7c626c2

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -267,7 +267,17 @@ jobs:
           github-token: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           script: |
             const fs = require('fs');
+            const path = require('path');
             const yaml = require('js-yaml');
+
+            // Decision logic lives in scripts/disagreement-detector.js
+            // so the workflow and the fixture-driven test
+            // (scripts/ci/check_disagreement_detector) exercise the
+            // exact same code. See #259 for the regression this
+            // factoring closes.
+            const { decide } = require(
+              path.resolve(process.env.GITHUB_WORKSPACE, 'scripts/disagreement-detector.js')
+            );
 
             let reviewerAccounts;
             try {
@@ -277,26 +287,18 @@ jobs:
               reviewerAccounts = ['nathanpayne-claude', 'nathanpayne-codex', 'nathanpayne-cursor'];
             }
 
-            const reviews = await github.rest.pulls.listReviews({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-            });
-
-            // Track each reviewer's last opinionated state (APPROVED or CHANGES_REQUESTED).
-            // Ignore COMMENTED reviews — they don't change a reviewer's effective position.
-            const latestByReviewer = {};
-            for (const review of reviews.data) {
-              if (reviewerAccounts.includes(review.user.login)) {
-                if (review.state === 'APPROVED' || review.state === 'CHANGES_REQUESTED') {
-                  latestByReviewer[review.user.login] = review.state;
-                }
+            // Paginate reviews — long histories (>30) otherwise truncate and
+            // mask the latest-on-HEAD signal. Mirrors the pagination
+            // fix in pr-audit.yml (PR #255 P2).
+            const reviews = await github.paginate(
+              github.rest.pulls.listReviews,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                per_page: 100,
               }
-            }
-
-            const states = Object.values(latestByReviewer);
-            const hasApproval = states.includes('APPROVED');
-            const hasChangesRequested = states.includes('CHANGES_REQUESTED');
+            );
 
             // Check if the label is currently applied
             const labels = await github.rest.issues.listLabelsOnIssue({
@@ -306,27 +308,31 @@ jobs:
             });
             const hasLabel = labels.data.some(l => l.name === 'needs-human-review');
 
-            if (hasApproval && hasChangesRequested) {
-              // Disagreement exists — apply label if not already present
-              if (!hasLabel) {
-                await github.rest.issues.addLabels({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.payload.pull_request.number,
-                  labels: ['needs-human-review'],
-                });
+            const decision = decide({
+              reviews,
+              reviewerAccounts,
+              headSha: context.payload.pull_request.head.sha,
+              hasLabel,
+            });
 
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.payload.pull_request.number,
-                  body: '**Agent disagreement detected.** One reviewer approved and another requested changes. Escalating to @nathanjohnpayne for human tiebreaker per REVIEW_POLICY.md.',
-                });
-              }
-            } else if (hasLabel && !(hasApproval && hasChangesRequested)) {
-              // Disagreement resolved — reviewers are no longer in a mixed state
-              // (either all approved, all requesting changes, or only one opinion
-              // remains). Remove the label automatically.
+            if (decision === 'apply') {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: ['needs-human-review'],
+              });
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: '**Agent disagreement detected.** One reviewer approved and another requested changes on the current HEAD. Escalating to @nathanjohnpayne for human tiebreaker per REVIEW_POLICY.md.',
+              });
+            } else if (decision === 'remove') {
+              // No live disagreement on the current HEAD — remove the
+              // label. Covers the #259 case: a stale CHANGES_REQUESTED
+              // on an older SHA is superseded by an APPROVED on HEAD.
               try {
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
@@ -338,13 +344,14 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: context.payload.pull_request.number,
-                  body: '**Agent disagreement resolved.** Reviewers are no longer in a mixed state. Removing `needs-human-review` label.',
+                  body: '**Agent disagreement resolved.** No live conflict on the current HEAD (latest review per reviewer, non-DISMISSED, commit_id == HEAD). Removing `needs-human-review` label.',
                 });
               } catch (e) {
                 // Label may already be removed — ignore 404
                 if (e.status !== 404) throw e;
               }
             }
+            // decision === 'noop' — nothing to do.
 
   # ──────────────────────────────────────────────
   # Job 5: Block self-approval

--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -1,0 +1,336 @@
+name: Auto-clear blocking labels
+
+# Closes the manual-label-removal toil documented in #191.
+#
+# When the codex-review-check.sh merge gate clears (CI green +
+# reviewer-identity APPROVED + Codex cleared on HEAD), this workflow
+# removes the `needs-external-review` label automatically. Without it,
+# every over-threshold PR requires the human to do
+# `gh pr edit <N> --remove-label needs-external-review` after agents
+# have done all the actual review work.
+#
+# Scope: ONLY removes `needs-external-review`. `needs-human-review`
+# and `policy-violation` remain manual-only by design (see
+# REVIEW_POLICY.md § Agent prohibitions). The doctrine carve-out for
+# this workflow ships in #196.
+
+on:
+  pull_request_target:
+    types: [synchronize, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted]
+  # workflow_run fires on completion of OTHER workflows. We target
+  # the three that produce the required-check signals codex-review-
+  # check.sh inspects: PR Review Policy (Label Gate, Self-Review,
+  # External Review Check), Agent Review Pipeline (auto-merge-on-
+  # approval, detect-disagreement, etc.), and repo-lint (lint).
+  # This replaces the prior `check_suite` trigger, which (per codex
+  # P1 on PR #202) does NOT fire for suites created by GitHub
+  # Actions — only for external CI providers. Without workflow_run,
+  # the common path of "reviewer approves → Actions CI catches up →
+  # gate now passes" produced no event and the label stayed stuck.
+  workflow_run:
+    workflows:
+      - "PR Review Policy"
+      - "Agent Review Pipeline"
+      - "repo-lint"
+    types: [completed]
+  # Periodic sweep — catches the 👍-after-last-push case (codex
+  # reacts on the PR issue but no synchronize / review / workflow_run
+  # event fires, so the event-driven path stays inert). Runs every
+  # 15 minutes against any open PR carrying needs-external-review.
+  # Idempotent (no-op when label absent or gate not yet met). Sub-C
+  # of #191. See scheduled-sweep job below for the cadence knob.
+  schedule:
+    - cron: '*/15 * * * *'
+
+permissions:
+  pull-requests: write
+  contents: read
+  checks: read
+
+jobs:
+  evaluate-and-clear:
+    name: Re-evaluate codex-review-check gate
+    runs-on: ubuntu-latest
+    # Self-fire loop guard: when this workflow's label removal fires
+    # the `unlabeled` event for `needs-external-review`, skip — we
+    # just removed it; nothing to do.
+    # Schedule guard: cron runs the scheduled-sweep job below; the
+    # event-driven path is moot for scheduled invocations. CR Major
+    # on PR #213 r2 — without this, every 15-min cron paid for an
+    # extra checkout-only no-op job.
+    if: |
+      github.event_name != 'schedule' &&
+      !(
+        github.event_name == 'pull_request_target' &&
+        github.event.action == 'unlabeled' &&
+        github.event.label.name == 'needs-external-review'
+      )
+    steps:
+      - name: Checkout repo (for codex-review-check.sh)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # SECURITY: pin to the default branch so we always run the
+          # TRUSTED copy of scripts/codex-review-check.sh — never the
+          # PR's own version. Without this, on pull_request_review
+          # events GITHUB_REF defaults to refs/pull/<N>/merge and
+          # actions/checkout pulls the PR's HEAD; combined with this
+          # workflow's `pull-requests: write` permission, a malicious
+          # PR could modify the gate script to remove arbitrary labels
+          # or post arbitrary comments. CR Critical on PR #202 r2.
+          ref: ${{ github.event.repository.default_branch }}
+          # Need full history so codex-review-check can inspect the
+          # PR HEAD against base. The script doesn't currently do that
+          # but a future tightening might.
+          fetch-depth: 0
+
+      - name: Resolve PR number from event
+        id: pr
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_JSON: ${{ toJSON(github.event) }}
+        run: |
+          # Each event surfaces PR number(s) differently. Emit a
+          # newline-separated list (most events have exactly one PR).
+          # workflow_run.completed can attach to multiple PRs in
+          # principle, so we enumerate.
+          case "$EVENT_NAME" in
+            pull_request_target|pull_request_review)
+              prs=$(jq -r '.pull_request.number' <<<"$EVENT_JSON")
+              ;;
+            workflow_run)
+              # Only act on successful runs of the listened workflows;
+              # a failed lint or PR Review Policy run won't have
+              # changed the gate state, so don't bother re-evaluating.
+              conclusion=$(jq -r '.workflow_run.conclusion' <<<"$EVENT_JSON")
+              if [ "$conclusion" != "success" ]; then
+                echo "workflow_run conclusion=$conclusion (not success); skipping." >&2
+                echo "numbers=" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              prs=$(jq -r '.workflow_run.pull_requests[].number' <<<"$EVENT_JSON")
+              ;;
+            *)
+              echo "Unsupported event: $EVENT_NAME" >&2
+              exit 0  # don't fail; just skip
+              ;;
+          esac
+          if [ -z "$prs" ]; then
+            echo "No PR number resolvable from event; skipping." >&2
+            echo "numbers=" >> "$GITHUB_OUTPUT"
+          else
+            # Multi-line output: use a heredoc per Actions docs.
+            {
+              echo 'numbers<<EOF'
+              echo "$prs"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Re-evaluate gate per PR + remove label on pass
+        if: steps.pr.outputs.numbers != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBERS: ${{ steps.pr.outputs.numbers }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # codex-review-check.sh exits:
+          #   0 = gate passes
+          #   1 = gate fails (one or more of CI/reviewer/codex not met)
+          #   3 = config/arg error (real infrastructure failure)
+          # CR Major on PR #202 r1: every gh call gets explicit error
+          # handling so a transient failure (rate limit, 5xx) on one
+          # PR doesn't abort the sweep, AND no early gh failure is
+          # silently swallowed by an asymmetric set -e/+e dance.
+          # CR Major on PR #202 r2: rc=3 (infrastructure error) sets a
+          # sentinel; after the sweep finishes we exit non-zero if any
+          # PR hit it, so the workflow doesn't go green when gate
+          # evaluation was actually impossible.
+          had_infra_error=0
+          while IFS= read -r PR; do
+            [ -z "$PR" ] && continue
+            echo "::group::Evaluating PR #$PR"
+
+            # Skip if label not present (no-op, common case on
+            # synchronize/workflow_run for under-threshold PRs).
+            if ! HAS_LABEL=$(gh pr view "$PR" --repo "$REPO" --json labels \
+              --jq '[.labels[].name] | contains(["needs-external-review"])'); then
+              echo "::warning::Failed to query labels for PR #$PR; skipping."
+              echo "::endgroup::"
+              continue
+            fi
+            if [ "$HAS_LABEL" != "true" ]; then
+              echo "Label needs-external-review not present; nothing to clear."
+              echo "::endgroup::"
+              continue
+            fi
+
+            set +e
+            scripts/codex-review-check.sh "$PR"
+            rc=$?
+            set -e
+
+            case "$rc" in
+              0)
+                echo "Gate passes — removing needs-external-review label."
+                if ! gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review; then
+                  echo "::warning::Failed to remove needs-external-review on PR #$PR"
+                  echo "::endgroup::"
+                  continue
+                fi
+                # Direct string body (NOT a heredoc — heredoc closing
+                # delimiter must be column-0 unless using `<<-` with
+                # tabs; YAML run blocks make that brittle).
+                comment_body='**Automated label removal.** `scripts/codex-review-check.sh` cleared the merge gate on this HEAD (CI green + reviewer-identity APPROVED + Codex cleared). Removed `needs-external-review` so Label Gate passes and the PR can merge. See [.github/workflows/auto-clear-blocking-labels.yml](.github/workflows/auto-clear-blocking-labels.yml) (#191/#195) for the trigger doctrine.'
+                gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
+                  || echo "::warning::Failed to post attribution comment for PR #$PR"
+                ;;
+              1)
+                echo "Gate not yet met — leaving label in place."
+                ;;
+              3)
+                echo "::error::codex-review-check.sh config/arg error (rc=3) on PR #$PR"
+                # Don't exit non-zero mid-loop — keep sweeping other
+                # PRs on a multi-PR workflow_run trigger. But set
+                # the sentinel so the job exits non-zero at the end.
+                had_infra_error=1
+                ;;
+              *)
+                echo "::error::codex-review-check.sh unexpected rc=$rc on PR #$PR (contract drift — failing job)"
+                # Fail-closed: any rc outside 0/1/3 is contract drift.
+                # Better to fail loudly than leave the label stuck
+                # behind a silently-broken gate. CR Major on PR #202 r3.
+                had_infra_error=1
+                ;;
+            esac
+            echo "::endgroup::"
+          done <<<"$PR_NUMBERS"
+          exit "$had_infra_error"
+
+  scheduled-sweep:
+    name: Periodic sweep for stale needs-external-review labels
+    # Catches the 👍-after-last-push case (#197). Only fires on
+    # schedule; the event-driven evaluate-and-clear job above
+    # handles the common path. Idempotent: running twice on the
+    # same PR with no state change is a no-op (label-present check
+    # + read-only gate evaluation).
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo (for codex-review-check.sh)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Schedule events have no PR context, so default GITHUB_REF
+          # is the default branch already — pin explicitly for
+          # consistency with the security stance of the event-driven
+          # job above.
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+
+      - name: Find PRs carrying needs-external-review
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Read the per-repo cadence/enable knob from review-policy.yml.
+          # Defaults: enabled=true. Operators can opt out by setting
+          #   auto_clear_labels:
+          #     scheduled_sweep_enabled: false
+          # in their .github/review-policy.yml.
+          CONFIG=".github/review-policy.yml"
+          enabled=true
+          if [ -f "$CONFIG" ]; then
+            # CR Major on PR #213: strip trailing YAML comments
+            # before comparing — `false  # opt out` was previously
+            # being parsed as `false#optout`, leaving the sweep
+            # enabled even when the operator explicitly disabled it.
+            val=$(awk '
+              /^auto_clear_labels:/ {in_block=1; next}
+              in_block && /^[^[:space:]]/ {exit}
+              in_block && /^[[:space:]]+scheduled_sweep_enabled:/ {
+                sub(/#.*/, "")
+                gsub(/.*: */, "")
+                gsub(/[[:space:]]/, "")
+                print
+                exit
+              }
+            ' "$CONFIG")
+            [ "$val" = "false" ] && enabled=false
+          fi
+          if [ "$enabled" = "false" ]; then
+            echo "Scheduled sweep disabled for $REPO via review-policy.yml; skipping."
+            echo "prs=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # List open PRs carrying the label. CR Major on PR #213:
+          # `--limit 500` overrides gh's default of 30 so the sweep
+          # processes ALL matching PRs in repos with high open-PR
+          # counts. 500 is comfortably above any realistic limit for
+          # a single repo's needs-external-review queue (would imply
+          # ~500 PRs awaiting review — itself an alarm).
+          # CR Major on PR #213 r2: capture gh output + exit status
+          # separately. The prior `mapfile -t prs < <(gh ...)` form
+          # swallowed gh's exit code via process substitution, so a
+          # gh failure (auth, rate limit, network) silently became
+          # "0 PRs found" and the sweep no-op'd instead of failing
+          # loudly.
+          if ! prs_raw=$(gh pr list --repo "$REPO" --state open \
+            --label needs-external-review --limit 500 \
+            --json number --jq '.[].number'); then
+            echo "::error::Failed to list open PRs with needs-external-review on $REPO"
+            exit 1
+          fi
+          prs=()
+          if [ -n "$prs_raw" ]; then
+            mapfile -t prs <<<"$prs_raw"
+          fi
+          echo "Found ${#prs[@]} PR(s) with needs-external-review on $REPO"
+          if [ "${#prs[@]}" -eq 0 ]; then
+            echo "prs=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo 'prs<<EOF'
+            printf '%s\n' "${prs[@]}"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Re-evaluate gate per PR
+        if: steps.find.outputs.prs != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRS: ${{ steps.find.outputs.prs }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          had_infra_error=0
+          while IFS= read -r PR; do
+            [ -z "$PR" ] && continue
+            echo "::group::Sweep PR #$PR"
+            set +e
+            scripts/codex-review-check.sh "$PR"
+            rc=$?
+            set -e
+            case "$rc" in
+              0)
+                echo "Gate passes — removing needs-external-review label."
+                if gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review; then
+                  comment_body='**Automated label removal (scheduled sweep).** `scripts/codex-review-check.sh` cleared the merge gate on this HEAD between event triggers (typical: Codex 👍 after the last push, with no synchronize / review / workflow_run event to fire the event-driven path). Removed `needs-external-review`. See [.github/workflows/auto-clear-blocking-labels.yml](.github/workflows/auto-clear-blocking-labels.yml) (#191/#197) for the sweep doctrine.'
+                  gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
+                    || echo "::warning::Failed to post attribution comment for PR #$PR"
+                else
+                  echo "::warning::Failed to remove needs-external-review on PR #$PR"
+                fi
+                ;;
+              1) echo "Gate not yet met — leaving label in place." ;;
+              3) echo "::error::codex-review-check.sh rc=3 on PR #$PR"; had_infra_error=1 ;;
+              *) echo "::error::unexpected rc=$rc on PR #$PR"; had_infra_error=1 ;;
+            esac
+            echo "::endgroup::"
+          done <<<"$PRS"
+          exit "$had_infra_error"

--- a/.github/workflows/codex-p1-gate.yml
+++ b/.github/workflows/codex-p1-gate.yml
@@ -1,0 +1,249 @@
+name: Codex P1 Gate
+
+# Enforces nathanjohnpayne/mergepath#235: Codex P1 inline-review findings
+# must be resolved (via the GitHub UI's "Resolve conversation" button or
+# the GraphQL `resolveReviewThread` mutation) before a PR can merge.
+#
+# Reports "Codex P1 unresolved: N" via scripts/codex-p1-gate.sh. The
+# script exits 1 (gate fails) when any Codex P1 thread on the current
+# HEAD is unresolved.
+#
+# Gate ON/OFF is controlled by codex.p1_gate.enabled in
+# .github/review-policy.yml. Mergepath sets it to true (the canonical
+# source). Downstream consumers default to false until the override
+# pattern is shaken out here (per #235's "start narrow" recommendation).
+#
+# Re-runs on every push to a PR AND on every review-related event, so
+# a human who clicks "Resolve conversation" on a P1 thread sees the
+# gate go green without needing a push.
+#
+# Trigger shape note (#257 codex CR): GitHub Actions does NOT document
+# `pull_request_review_thread` as a workflow trigger. It exists as a
+# webhook event for GitHub Apps, but the Actions
+# "events-that-trigger-workflows" reference omits it
+# (https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows),
+# and adding it to `on:` is a no-op in practice — clicking "Resolve
+# conversation" produces no workflow run. To cover the UI-resolve
+# case we combine:
+#   - pull_request + pull_request_review + pull_request_review_comment
+#     for the event-driven path (push, review submit/edit/dismiss,
+#     inline comment activity).
+#   - schedule (every 15 minutes) as the safety net for the
+#     UI-resolve case, since no other event fires when a human
+#     clicks "Resolve conversation" on a thread. Same pattern as
+#     auto-clear-blocking-labels.yml § scheduled-sweep (#197).
+# The schedule job is read-only and idempotent (no-op when no open
+# PRs match), so the 15-min cadence is safe to run unconditionally
+# across this repo.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  # pull_request_review_comment fires when a reviewer posts (or edits /
+  # deletes) an inline diff comment. Catches the case where Codex
+  # posts a new P1 mid-review without a fresh review-submission event.
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  # Periodic sweep — catches the "human clicks Resolve conversation
+  # on a Codex P1 thread" case. The thread-resolution webhook fires
+  # but does NOT trigger Actions workflows (no Actions event for it
+  # per GitHub docs), so without the schedule the required check
+  # would stay red until the next push or manual rerun. 15-min
+  # cadence mirrors auto-clear-blocking-labels.yml § scheduled-sweep.
+  schedule:
+    - cron: "*/15 * * * *"
+
+permissions:
+  contents: read
+  pull-requests: read
+  # `checks: write` is required for the scheduled sweep job: it posts
+  # a check_run on each open PR's head SHA so a UI-resolve clears the
+  # stuck-red required check without a push. The event-driven job
+  # below produces its check natively (Actions auto-creates the check
+  # on the PR's head when triggered by pull_request* events) and
+  # would not need this permission on its own.
+  checks: write
+
+jobs:
+  codex-p1-gate:
+    name: Codex P1 unresolved threads
+    runs-on: ubuntu-latest
+    # Event-driven path. The scheduled sweep below runs the same
+    # gate but on every open PR via the Checks API; gating this job
+    # to non-schedule events avoids paying for an empty no-op run.
+    if: github.event_name != 'schedule'
+    steps:
+      - name: Checkout repo (for scripts/codex-p1-gate.sh)
+        # actions/checkout's default for pull_request events checks
+        # out the PR's HEAD ref, which is what this read-only gate
+        # wants — the gate script evolves alongside the PR diff.
+        # No `with:` block needed; actionlint/CodeRabbit rejects an
+        # empty `with:` (round-2 #257 fix).
+        # Unlike auto-clear-blocking-labels.yml (which writes labels
+        # and pins to main's TRUSTED copy to defend against a
+        # malicious PR editing the gate logic), this workflow is
+        # strictly read-only and can't be weaponized.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Resolve PR number
+        id: pr
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_JSON: ${{ toJSON(github.event) }}
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            pull_request|pull_request_review|pull_request_review_comment)
+              pr=$(jq -r '.pull_request.number' <<<"$EVENT_JSON")
+              ;;
+            *)
+              echo "Unsupported event: $EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
+            echo "Could not resolve PR number from event payload." >&2
+            exit 1
+          fi
+          echo "number=$pr" >> "$GITHUB_OUTPUT"
+
+      - name: Run scripts/codex-p1-gate.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # The script is the source of truth for what blocks merge.
+          # Exit codes:
+          #   0 = no unresolved P1s on HEAD (or gate disabled)
+          #   1 = unresolved P1s present (gate blocks)
+          #   2 = config / usage error (CI failure, not a gate block)
+          set +e
+          scripts/codex-p1-gate.sh "$PR_NUMBER" "$REPO"
+          rc=$?
+          set -e
+          if [ "$rc" -eq 2 ]; then
+            echo "::error::codex-p1-gate.sh exited 2 (config/usage error)"
+            exit 1
+          fi
+          exit "$rc"
+
+  scheduled-sweep:
+    name: Codex P1 scheduled sweep
+    # Periodic re-evaluation across every open PR. Required because:
+    #   - GitHub Actions does NOT support pull_request_review_thread
+    #     as a workflow trigger (see top-of-file comment + #257).
+    #   - When a human clicks "Resolve conversation" on a Codex P1
+    #     thread, no Actions event fires — so the required check
+    #     `Codex P1 unresolved threads` stays red on the PR's head
+    #     SHA until a push or manual rerun.
+    # This sweep walks every open PR, runs the same gate script, and
+    # posts a fresh check_run on each PR's head SHA via the Checks
+    # API. Required-check resolution keys on (head_sha, name), so the
+    # new check supersedes the stale red one. Idempotent: no-op when
+    # the gate result is unchanged.
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo (default branch — trusted scripts)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+
+      - name: Find open PRs
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # List ALL open PRs. The gate script itself short-circuits
+          # when codex.p1_gate.enabled=false, so we don't filter by
+          # label here. `--limit 500` mirrors auto-clear-blocking-
+          # labels.yml's bound (well above any realistic open-PR
+          # count for a single repo).
+          if ! prs_raw=$(gh pr list --repo "$REPO" --state open \
+            --limit 500 --json number --jq '.[].number'); then
+            echo "::error::Failed to list open PRs on $REPO"
+            exit 1
+          fi
+          if [ -z "$prs_raw" ]; then
+            echo "No open PRs on $REPO; sweep is a no-op."
+            echo "prs=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo 'prs<<EOF'
+            printf '%s\n' "$prs_raw"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Re-evaluate gate per PR and post check_run
+        if: steps.find.outputs.prs != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRS: ${{ steps.find.outputs.prs }}
+          REPO: ${{ github.repository }}
+          # Check name MUST match the event-driven job name above so
+          # branch protection's required-check entry resolves either
+          # source as the same gate. GitHub keys required checks on
+          # (head_sha, name); a fresh check_run with the same name
+          # supersedes the stale one.
+          CHECK_NAME: "Codex P1 unresolved threads"
+        run: |
+          set -euo pipefail
+          had_infra_error=0
+          while IFS= read -r PR; do
+            [ -z "$PR" ] && continue
+            echo "::group::Sweep PR #$PR"
+
+            # Look up the PR's head SHA so the check_run lands on the
+            # branch-protection-relevant commit (NOT the schedule's
+            # default-branch HEAD).
+            head_sha=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')
+            if [ -z "$head_sha" ] || [ "$head_sha" = "null" ]; then
+              echo "::warning::Could not resolve head SHA for PR #$PR; skipping"
+              echo "::endgroup::"
+              continue
+            fi
+
+            set +e
+            output=$(scripts/codex-p1-gate.sh "$PR" "$REPO" 2>&1)
+            rc=$?
+            set -e
+            echo "$output"
+
+            case "$rc" in
+              0) conclusion="success" ;;
+              1) conclusion="failure" ;;
+              *)
+                echo "::error::codex-p1-gate.sh rc=$rc on PR #$PR (config/usage error)"
+                had_infra_error=1
+                echo "::endgroup::"
+                continue
+                ;;
+            esac
+
+            # Truncate the summary to ~60KB to stay well under
+            # GitHub's 65535-char limit on check_run.output.summary.
+            summary=$(printf '%s\n' "$output" | head -c 60000)
+
+            gh api -X POST "repos/$REPO/check-runs" \
+              -f name="$CHECK_NAME" \
+              -f head_sha="$head_sha" \
+              -f status="completed" \
+              -f conclusion="$conclusion" \
+              -f "output[title]=Codex P1 gate (scheduled re-evaluation)" \
+              -f "output[summary]=$summary" \
+              >/dev/null \
+              || echo "::warning::Failed to post check_run for PR #$PR"
+            echo "::endgroup::"
+          done <<<"$PRS"
+          if [ "$had_infra_error" -ne 0 ]; then
+            echo "::error::Sweep finished with one or more infra errors"
+            exit 1
+          fi

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,6 +18,22 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
+      # Check out the BASE ref (the target branch's tip), NOT the PR
+      # HEAD. This workflow runs under pull_request_target which has
+      # write permissions and access to secrets — checking out PR-author-
+      # controlled code (HEAD) and reading config from it would be a
+      # privilege escalation surface. We only need the BASE's
+      # .github/review-policy.yml for the available_reviewers
+      # validation in the next step. github.event.pull_request.base.sha
+      # is the merge target's tip at the moment the PR opened.
+      # codex r2 on PR #179 caught the missing checkout.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          # Don't persist the checkout token — we use REVIEWER_ASSIGNMENT_TOKEN
+          # for the gh calls below, not the default GITHUB_TOKEN.
+          persist-credentials: false
+
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
@@ -27,8 +43,104 @@ jobs:
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: |
+          set -euo pipefail
+
+          # Verify GH_TOKEN is set and resolves to a reviewer identity.
+          # The 2026-04-27 weekly PR audit caught 17 of 21 violations
+          # across 6 repos where Dependabot PRs merged without a
+          # reviewer-identity approval recorded — root cause was either
+          # an empty REVIEWER_ASSIGNMENT_TOKEN secret (the approve call
+          # silently no-op'd while the merge proceeded) or the token
+          # resolving to nathanjohnpayne, which GitHub rejects with
+          # "can't approve own pull request". Both modes left the PR
+          # merged with no approval audit trail.
+          # Closes nathanjohnpayne/mergepath#160 from the template side.
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::GH_TOKEN is empty. REVIEWER_ASSIGNMENT_TOKEN secret is not set in this repo."
+            echo "::error::Add a reviewer-identity PAT to repo Settings → Secrets and variables → Actions → REVIEWER_ASSIGNMENT_TOKEN."
+            exit 1
+          fi
+
+          ACTING_AS=$(gh api user --jq .login 2>/dev/null || true)
+          if [ -z "$ACTING_AS" ]; then
+            echo "::error::gh api user returned empty — REVIEWER_ASSIGNMENT_TOKEN may be invalid, expired, or lacks the user scope."
+            exit 1
+          fi
+          echo "::notice::Approving $PR_URL as $ACTING_AS"
+
+          if [ "$ACTING_AS" = "nathanjohnpayne" ]; then
+            echo "::error::REVIEWER_ASSIGNMENT_TOKEN resolves to nathanjohnpayne (the author identity)."
+            echo "::error::GitHub blocks self-approval, so the approve call would silently fail and the merge would proceed without an approval recorded."
+            echo "::error::Replace the secret with a reviewer-identity PAT (nathanpayne-claude / -cursor / -codex)."
+            exit 1
+          fi
+
+          # Validate ACTING_AS against available_reviewers in
+          # .github/review-policy.yml. Codex r1 (Phase 4b) on PR #179:
+          # without this check, any non-author write-collaborator
+          # token (e.g., a contractor's PAT, github-actions[bot]) could
+          # approve+merge and the workflow would exit 0 — but the next
+          # weekly audit would still flag the PR as "not approved by a
+          # known reviewer identity," same audit trail problem #160 set
+          # out to fix.
+          POLICY=".github/review-policy.yml"
+          if [ ! -f "$POLICY" ]; then
+            echo "::error::$POLICY not found — cannot validate $ACTING_AS against available_reviewers."
+            exit 1
+          fi
+          # Same awk extractor used by scripts/codex-review-check.sh
+          # (in-block list parser; sed strips list-marker + optional
+          # quotes). Outputs one reviewer login per line.
+          ALLOWED=$(awk '
+            /^available_reviewers:/ {in_block=1; next}
+            in_block && /^[^[:space:]#]/ {in_block=0}
+            in_block && /^ *-/ {print}
+          ' "$POLICY" | sed -E 's/^[[:space:]]*-[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')
+          if [ -z "$ALLOWED" ]; then
+            echo "::error::$POLICY has no available_reviewers list. Add reviewer identities under available_reviewers: before this workflow can approve."
+            exit 1
+          fi
+          if ! printf '%s\n' "$ALLOWED" | grep -Fxq "$ACTING_AS"; then
+            echo "::error::REVIEWER_ASSIGNMENT_TOKEN resolves to '$ACTING_AS', which is NOT in $POLICY available_reviewers:"
+            printf '%s\n' "$ALLOWED" | sed 's/^/::error::  - /'
+            echo "::error::Even if this identity has write access to the repo, an approval from it would fail the next weekly audit ('approval not from a recognized reviewer identity')."
+            echo "::error::Replace the secret with a PAT for one of the listed reviewers."
+            exit 1
+          fi
+
+          # Approve. set -e ensures we abort on failure rather than
+          # continuing to the merge step with no approval on record.
           gh pr review --approve "$PR_URL"
-          gh pr merge --squash --auto "$PR_URL" || gh pr merge --squash "$PR_URL" || true
+
+          # Try GitHub-side auto-merge first (fires when required
+          # checks pass). Fall back to an immediate squash ONLY when
+          # the failure cause is "auto-merge unavailable" — i.e., the
+          # repo doesn't have branch protection / auto-merge enabled
+          # in settings. Other failures (network, permissions, race,
+          # invalid token) propagate so the audit sees them.
+          #
+          # CodeRabbit on PR #179 caught that the prior bare-`||`
+          # fallback would silently retry on ANY failure mode,
+          # including transient errors that should bubble up. gh CLI
+          # returns exit 1 for all merge failures without a
+          # distinguishing exit code, so we pattern-match stderr for
+          # the documented auto-merge-unavailable GraphQL messages.
+          set +e
+          AUTO_STDERR=$(gh pr merge --squash --auto "$PR_URL" 2>&1 1>/dev/null)
+          AUTO_RC=$?
+          set -e
+          if [ "$AUTO_RC" -eq 0 ]; then
+            echo "$AUTO_STDERR"
+            exit 0
+          fi
+          echo "$AUTO_STDERR" >&2
+          if echo "$AUTO_STDERR" | grep -qiE 'auto[- ]?merge is not available|not in the correct state to enable auto[- ]?merge|auto[- ]?merge.*disabled|enablePullRequestAutoMerge'; then
+            echo "::notice::--auto unavailable on this repo (likely no branch protection); falling back to immediate squash."
+            gh pr merge --squash "$PR_URL"
+          else
+            echo "::error::gh pr merge --auto failed for a non-auto-merge-unavailable reason. See stderr above. Not falling back to immediate squash; surface to audit."
+            exit "$AUTO_RC"
+          fi
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -72,9 +72,24 @@ jobs:
             // unioning them into a single allow-list. See the
             // Check 2 block for the full rationale; the short
             // version is that CLI identities still require
-            // state === 'APPROVED', and the Codex bot's clearance
-            // signal is a +1 reaction on the PR issue (the GitHub
-            // app never emits APPROVED — see #29 + #354).
+            // state === 'APPROVED' but the Codex bot can clear
+            // with a COMMENTED review on the current HEAD that
+            // carries no unaddressed P0/P1 inline findings, because
+            // the GitHub app never emits APPROVED (see #29 for
+            // observational evidence).
+            //
+            // Codex clearance is state-aware (#249): a Codex review
+            // that is present but flags P0/P1 findings does NOT
+            // clear the audit gate. The clearance definition is the
+            // same one `scripts/codex-review-check.sh` enforces at
+            // merge time — a COMMENTED review from the Codex bot on
+            // the current HEAD SHA with zero unresolved P0/P1 inline
+            // findings (P0/P1 detected via the `![P0 Badge]` /
+            // `![P1 Badge]` markdown markers Codex inlines into its
+            // findings). When the merge-gate helper for P0/P1
+            // counting from #235 lands, refactor the inline JS below
+            // to shell out to that shared helper so the two gates
+            // cannot drift. See #249.
 
             const since = new Date();
             since.setDate(since.getDate() - 7);
@@ -110,14 +125,18 @@ jobs:
               // of this script fetched twice. CodeRabbit caught the
               // duplicate on PR #68.
               //
-              // Paginated — `pulls.listReviews` defaults to 30 per
-              // page and returns in chronological order, so a PR
-              // with many review rounds can hide the *latest* Codex
-              // review beyond the first page. The Check 2 logic below
-              // selects the latest Codex review by `submitted_at` to
-              // anchor the clearance gate, so a stale-history slice
-              // would silently misclassify clearance (Codex P2 catch
-              // on PR #359).
+              // Paginate via `github.paginate` (PR #255 round 2 Codex
+              // P2): the unpaginated `listReviews` call returns at
+              // most 30 items in chronological order, so on a PR with
+              // a long review history the latest Codex review on
+              // `pr.head.sha` can sit on a later page and never reach
+              // the HEAD-scoped filter below. The result was a
+              // false-positive policy violation even when Codex had
+              // genuinely cleared on HEAD. `per_page: 100 +
+              // page traversal` is the standard GitHub-API fix and
+              // matches the patterns already used at the
+              // `pulls.list` and `pulls.listReviewComments` call
+              // sites in this file.
               const reviews = await github.paginate(
                 github.rest.pulls.listReviews,
                 {
@@ -158,183 +177,199 @@ jobs:
               );
               const dependabotNeedsApproval = isDependabot;
 
+              // Exemption (#229): PRs opened by `scripts/sync-to-downstream.sh`
+              // propagate already-reviewed mergepath commits to downstream
+              // consumers. Re-reviewing a propagation PR on each consumer
+              // is redundant (the upstream commit was reviewed in mergepath
+              // itself), so the audit's external-review violation check is
+              // skipped for these PRs. Dependabot's separate rule
+              // (cliApprovedReviews) is unaffected.
+              //
+              // Four guards, all required, defending against spoofing
+              // (CodeRabbit ⚠️ Major on PR #230 round 1 — naming alone is
+              // not a trusted-provenance signal):
+              //
+              //   1. PR author == author_identity from review-policy.yml
+              //      (typically `nathanjohnpayne`). The propagation script
+              //      runs under that identity per CLAUDE.md's active-account
+              //      convention; a PR from any other login isn't from the
+              //      sync flow.
+              //   2. Head ref comes from the same repo (not a fork). Forks
+              //      can't impersonate the propagation flow because the
+              //      sync script pushes directly to the consumer repo's
+              //      own `mergepath-sync/*` namespace.
+              //   3. Head branch namespace `mergepath-sync/*` — owned by
+              //      the sync script's branch-naming convention
+              //      (`mergepath-sync/<short-sha>`) and never used for
+              //      hand-authored work.
+              //   4. PR title matches `(mergepath@[0-9a-f]{7,40})` — the
+              //      canonical title format the sync script emits,
+              //      identifying the upstream commit.
+              //
+              // Hand-creating all four signals at once is possible but is
+              // an explicit, traceable action that would surface during
+              // self-review.
+              const isTrustedSyncAuthor =
+                pr.user && pr.user.login === authorIdentity;
+              const isSameRepoHead =
+                pr.head && pr.head.repo &&
+                pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
+              const hasSyncBranchName =
+                pr.head && pr.head.ref &&
+                pr.head.ref.startsWith('mergepath-sync/');
+              const hasMergepathMarker =
+                /\(mergepath@[0-9a-f]{7,40}\)/.test(pr.title || '');
+              const isMergepathSyncPR =
+                isTrustedSyncAuthor &&
+                isSameRepoHead &&
+                hasSyncBranchName &&
+                hasMergepathMarker;
+
               if (hadExternalLabel || dependabotNeedsApproval) {
                 // For the external-review path we accept either:
                 //   - an APPROVED review from a CLI reviewer identity
                 //     (nathanpayne-claude / nathanpayne-codex / etc.), OR
-                //   - a Codex GitHub app bot clearance — via EITHER
-                //     a +1 reaction on the PR issue, OR a COMMENTED
-                //     Codex review whose latest inline comments have
-                //     zero unaddressed P0/P1 findings on the merged
-                //     HEAD.
+                //   - a CLEARED review from the Codex GitHub app bot,
+                //     where "cleared" is the same two-condition
+                //     definition the merge gate uses (#249):
+                //       1. a COMMENTED review from the Codex bot on
+                //          the PR's HEAD SHA, AND
+                //       2. zero unresolved P0/P1 inline findings on
+                //          that review (P0/P1 markers are the
+                //          `![P0 Badge]` / `![P1 Badge]` images Codex
+                //          embeds in its inline finding bodies).
                 //
-                // CLI reviewer identities still require state ===
-                // 'APPROVED' because a non-opinionated COMMENTED review
-                // from a CLI reviewer is not a clearance signal under
+                // The state-agnostic exception is intentionally
+                // SCOPED to the Codex bot only. CLI reviewer
+                // identities still require state === 'APPROVED'
+                // because a non-opinionated COMMENTED review from
+                // a CLI reviewer is not a clearance signal under
                 // policy. nathanpayne-codex caught this on PR #68
                 // round 1 — earlier draft accepted any review from
                 // any external approver, which would have let a
                 // Phase 4b fallback PR with only a COMMENTED CLI
                 // review pass the audit.
                 //
-                // The Codex two-path clearance shape mirrors the
-                // merge-time gate in `scripts/codex-review-check.sh`
-                // (gate (c)). An earlier draft of this audit accepted
-                // "any review from the Codex bot, regardless of state"
-                // as clearance — but that includes Codex reviews that
-                // posted P0/P1 findings and were never cleared, a
-                // non-clearance signal masquerading as one (#354).
-                // A subsequent draft tightened to "+1 reaction only,"
-                // which fixed the false-negative but introduced a
-                // false-positive: PRs cleared via the review-only
-                // path (Codex commented, no P0/P1 findings, no
-                // reaction) would be falsely flagged. The check below
-                // accepts both paths so the audit matches the merge
-                // gate exactly. Codex caught the false-positive on
-                // PR #359.
+                // Codex P0/P1 gating (#249): the prior version used
+                // `codexBotReviews.length === 0` as the block
+                // condition — so any Codex review (even one actively
+                // raising P0/P1 findings) satisfied the gate. The
+                // tightened gate mirrors `scripts/codex-review-check.sh`'s
+                // gate (c) two-condition shape on the PR's HEAD SHA.
+                // TODO(#235): once the merge-gate ships a shared
+                // `codex-p1-gate` helper (or equivalent extraction
+                // from codex-review-check.sh), refactor the inline
+                // computation below to call it so the audit gate and
+                // merge gate cannot drift.
                 const cliApprovedReviews = reviews.filter(
                   r => r.state === 'APPROVED' &&
                        reviewerAccounts.includes(r.user.login)
                 );
 
-                const mergedAt = new Date(pr.merged_at);
-                const mergedHeadSha = pr.head && pr.head.sha;
+                const headSha = pr.head && pr.head.sha;
 
-                // Anchor: latest Codex review by submitted_at,
-                // scoped to the merge-time review set. Used to gate
-                // reaction-freshness AND to identify the review whose
-                // inline comments determine the Path 2 gate.
-                //
-                // Three constraints on the candidate set, matching the
-                // merge-time gate in `scripts/codex-review-check.sh`:
-                //
-                //   1. `state === 'COMMENTED'` — Codex's GitHub app
-                //      only emits COMMENTED reviews; an APPROVED or
-                //      CHANGES_REQUESTED review by something else
-                //      mis-attributed to the bot login (or a future
-                //      GitHub app behavior change) shouldn't satisfy
-                //      the gate.
-                //   2. `submitted_at <= mergedAt` — exclude post-merge
-                //      Codex reruns (someone manually triggered
-                //      `@codex review` after the merge to audit the
-                //      diff). Those say nothing about whether the PR
-                //      was cleared *before* it merged.
-                //   3. `commit_id === pr.head.sha` — exclude reviews
-                //      on prior commits in the branch's history. The
-                //      audit's clearance question is "did Codex
-                //      clear the commit that actually merged", not
-                //      "did Codex ever review anything on this PR".
-                //
-                // Without these, a stale +1 reaction from an earlier
-                // round could satisfy clearance even when a newer
-                // Codex review (still before merge) posted
-                // unaddressed P0/P1 findings (Codex P1 catch on
-                // round 2 of PR #359), AND `latestCodexReview` could
-                // drift to a post-merge or wrong-head review
-                // (CodeRabbit Major catch on round 3 of PR #359).
-                const codexBotReviews = reviews.filter(
-                  r => r.user &&
-                       r.user.login === codexBotLogin &&
-                       r.state === 'COMMENTED' &&
-                       new Date(r.submitted_at) <= mergedAt &&
-                       r.commit_id === mergedHeadSha
+                // Codex reviews on the PR's HEAD SHA. The merge-time
+                // gate uses commit_id == HEAD_SHA to scope findings
+                // to the latest review round; the audit applies the
+                // same scope. If the audit's notion of HEAD ever
+                // drifts (e.g. force-pushes post-merge), tighten
+                // here — but post-merge HEAD is immutable in
+                // practice.
+                const codexReviewsOnHead = reviews.filter(
+                  r => r.user.login === codexBotLogin &&
+                       headSha &&
+                       r.commit_id === headSha
                 );
-                const latestCodexReview =
-                  codexBotReviews.length > 0
-                    ? codexBotReviews.reduce(
-                        (latest, r) =>
-                          new Date(r.submitted_at) > new Date(latest.submitted_at)
-                            ? r
-                            : latest,
-                        codexBotReviews[0]
-                      )
-                    : null;
-                const latestCodexReviewAt = latestCodexReview
-                  ? new Date(latestCodexReview.submitted_at)
-                  : null;
 
-                // Path 1: +1 reaction on the PR issue from Codex,
-                // dated on or before the merge AND on or after the
-                // latest head-scoped Codex review.
-                //
-                // The anchor is ONLY the latest head-scoped Codex
-                // review's submitted_at. There is no fallback
-                // anchor: if no head-scoped Codex review exists,
-                // the reaction path stays closed and the audit
-                // falls through to require an APPROVED CLI
-                // reviewer.
-                //
-                // An earlier draft (round 5) used the merged HEAD
-                // commit's committer date as a fallback anchor when
-                // no head-scoped review existed. nathanpayne-codex's
-                // round-6 CHANGES_REQUESTED on PR #359 caught the
-                // hole: committer date can predate when the SHA
-                // actually became the PR head (cherry-pick, rebase
-                // with `--committer-date-is-author-date`, an old
-                // local commit pushed today). An older Codex +1 from
-                // before the merged commit became HEAD could still
-                // satisfy the audit. There's no robust push-time
-                // signal we can derive from the post-merge state
-                // alone, so the cleaner resolution is to close the
-                // path entirely: a PR with `needs-external-review`
-                // and no head-scoped Codex review on the merged
-                // commit must have an APPROVED CLI reviewer to
-                // clear the audit, regardless of how many +1s the
-                // Codex bot ever left.
-                const reactions = await github.paginate(
-                  github.rest.reactions.listForIssue,
-                  {
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: pr.number,
-                    per_page: 100,
+                const codexCommentedOnHead = codexReviewsOnHead.filter(
+                  r => r.state === 'COMMENTED'
+                );
+
+                // Two-condition Codex clearance: at least one
+                // COMMENTED review on HEAD, AND no unresolved
+                // P0/P1 inline findings on the latest round.
+                // Findings are scoped to the latest Codex review's
+                // pull_request_review_id (same as merge gate (c))
+                // so an earlier round's already-addressed findings
+                // don't keep the audit failing.
+                let codexCleared = false;
+                if (codexCommentedOnHead.length > 0) {
+                  // Latest Codex review on HEAD (max by submitted_at).
+                  const latestCodexReview = codexCommentedOnHead.reduce(
+                    (latest, r) => {
+                      if (!latest) return r;
+                      return (r.submitted_at > latest.submitted_at) ? r : latest;
+                    },
+                    null
+                  );
+
+                  // Fetch inline review comments for this PR. The
+                  // outer review-fetch (listReviews) returns review
+                  // metadata only — inline P0/P1 findings live on
+                  // the /pulls/{pr}/comments endpoint, keyed back
+                  // to a review via pull_request_review_id.
+                  let inlineComments = [];
+                  try {
+                    inlineComments = await github.paginate(
+                      github.rest.pulls.listReviewComments,
+                      {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: pr.number,
+                        per_page: 100,
+                      }
+                    );
+                  } catch (e) {
+                    console.log(
+                      `WARNING: could not fetch inline comments for PR #${pr.number}; ` +
+                      `treating Codex clearance as NOT met for safety. Error: ${e.message}`
+                    );
+                    inlineComments = null;
                   }
-                );
-                const codexClearanceReactions = reactions.filter(
-                  r => r.user &&
-                       r.user.login === codexBotLogin &&
-                       r.content === '+1' &&
-                       new Date(r.created_at) <= mergedAt &&
-                       latestCodexReviewAt !== null &&
-                       new Date(r.created_at) >= latestCodexReviewAt
-                );
 
-                // Path 2: latest Codex review on the PR has no
-                // unaddressed P0/P1 inline comments tied to it.
-                // Mirrors `scripts/codex-review-check.sh:548-561`.
-                // The badge regex matches the canonical markdown
-                // shape `![P0 Badge]…` / `![P1 Badge]…` Codex emits
-                // in inline finding bodies — see codex-review-check.sh
-                // for the source of truth.
-                let codexReviewCleared = false;
-                if (latestCodexReview) {
-                  const inlineComments = await github.paginate(
-                    github.rest.pulls.listReviewComments,
-                    {
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      pull_number: pr.number,
-                      per_page: 100,
+                  if (inlineComments !== null && latestCodexReview) {
+                    // P0/P1 finding heuristic — same regex used by
+                    // scripts/codex-review-check.sh gate (c):
+                    // Codex inlines `![P0 Badge]` / `![P1 Badge]`
+                    // markdown images into each finding body.
+                    // Filter on bot author too — review-thread
+                    // replies (e.g., a quote-reply from the PR
+                    // author addressing a Codex finding) inherit
+                    // the same pull_request_review_id and would
+                    // otherwise be misclassified as unaddressed
+                    // findings (see codex-review-check.sh § P0/P1
+                    // for the nathanpaynedotcom #180 round 3
+                    // history on that filter).
+                    const p01Regex = /!\[P[01] Badge\]/;
+                    const unresolvedP01 = inlineComments.filter(
+                      c => c.user && c.user.login === codexBotLogin &&
+                           c.pull_request_review_id === latestCodexReview.id &&
+                           p01Regex.test(c.body || '')
+                    );
+
+                    if (unresolvedP01.length === 0) {
+                      codexCleared = true;
                     }
-                  );
-                  const unaddressedP01 = inlineComments.filter(
-                    c => c.user &&
-                         c.user.login === codexBotLogin &&
-                         c.pull_request_review_id === latestCodexReview.id &&
-                         /!\[P[01] Badge\]/.test(c.body || '')
-                  );
-                  codexReviewCleared = unaddressedP01.length === 0;
+                  }
                 }
-
-                const codexCleared =
-                  codexClearanceReactions.length > 0 || codexReviewCleared;
 
                 if (hadExternalLabel &&
                     cliApprovedReviews.length === 0 &&
-                    !codexCleared) {
-                  prViolations.push(
-                    'External-review PR merged with no APPROVED review from a CLI reviewer identity and no Codex clearance signal (+1 reaction or COMMENTED review with no unaddressed P0/P1)'
-                  );
+                    !codexCleared &&
+                    !isMergepathSyncPR) {
+                  // Distinguish the two failure modes so the audit
+                  // issue points at the right diagnosis: no Codex
+                  // review at all vs. a Codex review with
+                  // unresolved P0/P1 findings.
+                  if (codexReviewsOnHead.length === 0) {
+                    prViolations.push(
+                      'External-review PR merged with no APPROVED review from a CLI reviewer identity and no Codex bot review on the merge HEAD'
+                    );
+                  } else {
+                    prViolations.push(
+                      'External-review PR merged with a Codex bot review on HEAD that did not clear (no COMMENTED state on HEAD, or unresolved P0/P1 inline findings); see #249'
+                    );
+                  }
                 }
 
                 // Dependabot PRs use a strictly narrower rule: only

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -1,0 +1,30 @@
+# scripts/ci/
+
+CI enforcement scripts for this repository.
+
+The checks defined here mirror the steps in `.github/workflows/repo_lint.yml`
+and can also be run locally before pushing.
+
+Local scripts:
+
+- `check_required_root_files`
+- `check_no_tool_folder_instructions`
+- `check_no_forbidden_top_level_dirs`
+- `check_dist_not_modified`
+- `check_spec_test_alignment`
+- `check_duplicate_docs`
+- `check_codex_scripts` — verifies `scripts/codex-review-request.sh` and `scripts/codex-review-check.sh` exist and are executable (Phase 4a helper-script presence check)
+- `check_codex_p1_gate` — verifies `scripts/codex-p1-gate.sh` + `.github/workflows/codex-p1-gate.yml` + `tests/test_codex_p1_gate.sh` exist, then runs the fixture-driven test suite (Codex P1 unresolved-thread merge gate, #235)
+- `check_sync_manifest` — validates `.mergepath-sync.yml` (manifest read by `scripts/sync-to-downstream.sh`): schema version, consumer shape, every referenced path exists, every path type is recognized. Requires `yq` (mikefarah/yq v4+) on the runner. See #168.
+- `check_coderabbit_config` — validates `.coderabbit.yml` parses as YAML and (in the Mergepath template repo only) stays on `reviews.profile: chill` (the nit-suppressing profile per CodeRabbit's docs). Consumer repos inheriting this workflow via the template-mirror bootstrap get the parse + existence checks but may override `profile: assertive` locally without failing CI. Template detection prefers `GITHUB_REPOSITORY` (CI) and falls back to the `origin` remote URL for local runs; override via `MERGEPATH_TEMPLATE_CHECK=force|skip`. Requires `yq` (mikefarah/yq v4+) on the runner. See #237 and #256 P2.
+- `check_coderabbit_config_tests` — unit tests for `check_coderabbit_config` itself. Drives the template-vs-consumer detection via fixture repos under `tests/test_check_coderabbit_config.sh`. See #256 P2.
+- `check_eslint_config_present` — enforces the ESLint flat-config policy (`rules/repo_rules.md` § ESLint policy). If a root `package.json` exists, `eslint.config.js` must exist at the repo root and parse under `node --check`. Repos without a root `package.json` (mergepath itself) pass via an early-out. See #250.
+- `check_eslint_config_policy` — runs `tests/test_eslint_policy_check.sh` (unit tests for the policy check).
+- `check_sweep_unresolved_feedback` — runs unit tests for the #236 weekly feedback sweep pipeline (`scripts/sweep-unresolved-feedback/enumerate.sh`, `render.sh`). PATH-shims `gh` against synthetic fixtures; hermetic.
+- `check_disagreement_detector` — runs `tests/test_disagreement_detector.sh` against fixtures under `scripts/ci/fixtures/disagreement-detector/`. Exercises `scripts/disagreement-detector.js`, the decision function extracted from `.github/workflows/agent-review.yml`'s `detect-disagreement` job so the workflow and the test share one implementation. Asserts the workflow still `require()`s the module. See #259.
+
+Inline in `repo_lint.yml` (no local script):
+
+- `check_review_policy_exists` — verifies `.github/review-policy.yml` and `REVIEW_POLICY.md` both exist
+
+See `rules/repo_rules.md` for the full list of enforced checks.

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+# check_auto_clear_workflow — smoke tests for auto-clear-blocking-labels.yml
+#
+# The workflow itself runs in GitHub Actions; what we test here is the
+# YAML structure (parses, has the right triggers, has the self-fire
+# guard) and the PR-number resolution dispatch logic (which is bash
+# inside the workflow). Mirrors the integration-test gap that #195's
+# implementation plan flagged.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WORKFLOW="$ROOT/.github/workflows/auto-clear-blocking-labels.yml"
+
+pass=0
+fail=0
+
+# ── Test 1: workflow file exists and is valid YAML
+echo "auto-clear-blocking-labels.yml structural tests"
+
+if [ ! -f "$WORKFLOW" ]; then
+  echo "  FAIL: $WORKFLOW does not exist" >&2
+  exit 1
+fi
+
+# Parse via yq (preferred — no extra deps needed in GitHub-hosted
+# runner) → python3+PyYAML → grep fallback. Graceful skip when no
+# YAML parser is available rather than treating absence as failure.
+if command -v yq >/dev/null 2>&1; then
+  if yq eval '.' "$WORKFLOW" >/dev/null 2>&1; then
+    pass=$((pass + 1))
+    echo "  PASS: workflow YAML parses (via yq)"
+  else
+    fail=$((fail + 1))
+    echo "  FAIL: workflow YAML invalid (per yq)" >&2
+  fi
+elif python3 -c "import yaml" >/dev/null 2>&1; then
+  if python3 -c "import yaml; yaml.safe_load(open('$WORKFLOW'))" 2>/dev/null; then
+    pass=$((pass + 1))
+    echo "  PASS: workflow YAML parses (via python+PyYAML)"
+  else
+    fail=$((fail + 1))
+    echo "  FAIL: workflow YAML invalid (per python+PyYAML)" >&2
+  fi
+else
+  echo "  SKIP: no YAML parser available (install yq or PyYAML for this check)"
+fi
+
+# ── Test 2: required triggers present
+# Codex P1 on PR #202 r1: workflow_run replaces check_suite (which
+# doesn't fire for Actions-created suites).
+for trig in 'pull_request_target' 'pull_request_review' 'workflow_run'; do
+  if grep -qE "^[[:space:]]+${trig}:" "$WORKFLOW"; then
+    pass=$((pass + 1))
+    echo "  PASS: trigger '$trig' configured"
+  else
+    fail=$((fail + 1))
+    echo "  FAIL: missing required trigger '$trig'" >&2
+  fi
+done
+
+# Negative: workflow_run is the canonical post-CI signal. check_suite
+# would silently fail to fire for GitHub-Actions-created suites.
+if grep -qE "^[[:space:]]+check_suite:" "$WORKFLOW"; then
+  fail=$((fail + 1))
+  echo "  FAIL: check_suite trigger should NOT be present (codex P1 on #202 — doesn't fire for Actions suites)" >&2
+else
+  pass=$((pass + 1))
+  echo "  PASS: check_suite trigger absent (regression closed for codex P1 on #202)"
+fi
+
+# Schedule trigger present (#197 sub-C of #191) — catches the
+# 👍-after-last-push case where no event-driven trigger fires.
+# CR Minor on PR #213: anchor to the actual cron entry (not just
+# any `schedule:` / `cron:` text anywhere) so a comment couldn't
+# satisfy the assertion.
+if grep -qE "^[[:space:]]+schedule:" "$WORKFLOW" && \
+   grep -qF -- "- cron: '*/15 * * * *'" "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: schedule trigger configured with 15-min cron (#197)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: missing schedule trigger or expected cron entry (#197 sub-C of #191)" >&2
+fi
+
+# scheduled-sweep job exists and is gated to schedule-only events.
+# Anchor to the executable `if:` line so a string in a comment
+# couldn't satisfy the assertion. CR Minor on PR #213.
+if grep -qE "^[[:space:]]+scheduled-sweep:" "$WORKFLOW" && \
+   grep -qE "^[[:space:]]+if:[[:space:]]+github\.event_name == 'schedule'" "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: scheduled-sweep job gated by executable 'if: ... schedule' line"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: scheduled-sweep job missing or not gated to schedule events (executable line)" >&2
+fi
+
+# CR Major on PR #213: gh pr list defaults to --limit 30. The sweep
+# must use a higher limit so repos with many open needs-external-review
+# PRs get them ALL processed, not just the first 30.
+# `gh pr list` is split across multiple lines via shell continuation,
+# so the assertion is split too: `gh pr list` exists AND `--limit
+# <≥100>` appears within 5 lines after it.
+if grep -qE -- 'gh pr list' "$WORKFLOW" && \
+   awk '/gh pr list/,/[^\\\\]$/' "$WORKFLOW" | grep -qE -- '--limit [1-9][0-9]{2,}'; then
+  pass=$((pass + 1))
+  echo "  PASS: gh pr list uses --limit ≥100 (handles >30-PR repos)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: gh pr list must use --limit ≥100 to override default of 30 (CR Major on PR #213)" >&2
+fi
+
+# CR Major on PR #213: opt-out parser must strip trailing YAML
+# comments. `scheduled_sweep_enabled: false  # opt out` was being
+# parsed as `false#optout`. The fix is `sub(/#.*/, "")` before the
+# value extraction.
+if grep -qE 'sub\(/#\.\*/, ""\)' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: opt-out parser strips trailing YAML comments"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: opt-out parser must strip trailing YAML comments (CR Major on PR #213)" >&2
+fi
+
+# CR Major on PR #213 r2: evaluate-and-clear must skip on cron runs.
+# Without this guard, every 15-min sweep paid for a checkout-only
+# no-op job before the event resolver decided 'schedule' was
+# unsupported.
+if grep -qE -- "github\.event_name != 'schedule'" "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: evaluate-and-clear skips schedule events (cron runs only the sweep job)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: evaluate-and-clear must skip schedule events (CR Major on PR #213 r2)" >&2
+fi
+
+# CR Major on PR #213 r2: sweep must capture `gh pr list` exit
+# status separately, not via process substitution into mapfile (which
+# swallows the producer's exit code, silently turning a gh failure
+# into "0 PRs found").
+if grep -qE -- 'if ! prs_raw=\$\(gh pr list' "$WORKFLOW" && \
+   grep -qE -- 'echo "::error::Failed to list open PRs' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: sweep captures gh pr list exit status (no silent failure on gh error)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: sweep must capture gh pr list status separately, not via mapfile <(...) (CR Major on PR #213 r2)" >&2
+fi
+
+# workflow_run must listen to the EXACT upstream workflow names. A
+# rename or typo on either side would silently break the auto-clear
+# without this test catching it. CR Trivial on PR #202 r2.
+for wf in 'PR Review Policy' 'Agent Review Pipeline' 'repo-lint'; do
+  if grep -qF -- "- \"$wf\"" "$WORKFLOW"; then
+    pass=$((pass + 1))
+    echo "  PASS: workflow_run listens to '$wf'"
+  else
+    fail=$((fail + 1))
+    echo "  FAIL: workflow_run missing '$wf'" >&2
+  fi
+done
+
+# SECURITY: checkout MUST pin to default branch ref for
+# pull_request_review safety. CR Critical on PR #202 r2 — without
+# the explicit ref, a malicious PR could supply its own version of
+# scripts/codex-review-check.sh and have it run with this workflow's
+# pull-requests:write permissions.
+if grep -qF "ref: \${{ github.event.repository.default_branch }}" "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: checkout pinned to default_branch (security: blocks PR-controlled gate-script execution)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: checkout MUST pin ref to default_branch (CR Critical on #202 r2)" >&2
+fi
+
+# Least-privilege permissions: parse the permissions block and
+# compare against the EXACT expected set, not a denylist. Codifies
+# the expected permission shape so any drift (added scope, changed
+# read↔write) is surfaced as a CI failure. CR Major on PR #202 r4
+# (denylist approach was incomplete — missed artifact-metadata,
+# repository-projects, vulnerability-alerts).
+perm_block=$(
+  awk '
+    /^permissions:/ {in_block=1; next}
+    in_block && /^[^[:space:]]/ {exit}
+    in_block && NF { sub(/^[[:space:]]+/, "", $0); print }
+  ' "$WORKFLOW" | sort
+)
+expected_perms=$'checks: read\ncontents: read\npull-requests: write'
+if [ "$perm_block" = "$expected_perms" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: workflow permissions exactly match the least-privilege set"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: workflow permissions drifted from expected least-privilege set" >&2
+  echo "      expected:" >&2; echo "$expected_perms" | sed 's/^/        /' >&2
+  echo "      got:" >&2; echo "$perm_block" | sed 's/^/        /' >&2
+fi
+
+# Sentinel: rc=3 from codex-review-check.sh sets had_infra_error and
+# the job exits non-zero at the end. Without this, gate-evaluation
+# infrastructure failures would silently leave the workflow green.
+# CR Major on PR #202 r2.
+# CR Major on PR #202 r5: anchored to start-of-line + word boundary
+# so commented-out occurrences don't satisfy the assertion.
+if grep -qE '^[[:space:]]*had_infra_error=1([[:space:]]|$)' "$WORKFLOW" && \
+   grep -qE '^[[:space:]]*exit[[:space:]]+"?\$had_infra_error"?([[:space:]]|$)' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: rc=3 sets infra-error sentinel + job exits non-zero on it (executable lines)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: rc=3 from codex-review-check.sh must surface as job failure (sentinel + final exit)" >&2
+fi
+
+# ── Test 3: self-fire loop guard present
+if grep -qE "github\.event\.action == 'unlabeled'" "$WORKFLOW" && \
+   grep -qE "github\.event\.label\.name == 'needs-external-review'" "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: self-fire loop guard for unlabeled+needs-external-review present"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: self-fire loop guard missing or malformed" >&2
+fi
+
+# ── Test 4: scope discipline — only needs-external-review is removed
+# CR Major on PR #202 r3: tighten the positive grep to the actual
+# `gh pr edit ... --remove-label` executable line, not anywhere in
+# the file (header comments/attribution-message would otherwise
+# satisfy the match even if the executable line regressed).
+if grep -qE 'gh pr edit .+--remove-label needs-external-review' "$WORKFLOW" && \
+   ! grep -qE 'gh pr edit .+--remove-label needs-human-review' "$WORKFLOW" && \
+   ! grep -qE 'gh pr edit .+--remove-label policy-violation' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: scope discipline — only needs-external-review is auto-removed (executable line)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: workflow either misses the target label or auto-removes a forbidden one" >&2
+fi
+
+# ── Test 4c: bash syntax check on every `run:` block
+# Extract each `run: |` block to a temp file and feed to `bash -n`.
+# Catches heredoc/subshell errors that only surface at runtime.
+# Real bug from PR #202 r5: `gh pr comment ... --body "$(cat <<'COMMENT'
+# ... COMMENT )"` had the closing `COMMENT` indented, which is
+# invalid heredoc syntax — this test would have caught it pre-merge.
+echo
+echo "auto-clear-blocking-labels.yml bash syntax test"
+
+block_dir=$(mktemp -d)
+# awk extracts each `run: |` block to a separate file in $block_dir.
+# Exit a run block when ANY non-empty line drops to indent <= base
+# (the `run:` line's own indent), not just column-0. This catches
+# job/step transitions like `  scheduled-sweep:` (under `jobs:`) and
+# `      - name: Foo` (under steps:) which would otherwise be
+# treated as continuations of the prior bash block.
+awk -v outdir="$block_dir" '
+  /^[[:space:]]+run:[[:space:]]+\|[[:space:]]*$/ {
+    if (in_run) { close(outfile) }
+    n++; outfile = outdir "/block-" n ".sh"
+    match($0, /^[[:space:]]+/); base_indent = RLENGTH
+    in_run = 1; next
+  }
+  in_run && NF == 0 { print > outfile; next }
+  in_run {
+    match($0, /^[[:space:]]*/); cur_indent = RLENGTH
+    if (cur_indent <= base_indent) {
+      close(outfile); in_run = 0; next
+    }
+    # Strip the YAML run-block indentation (base_indent + 2 spaces).
+    sub("^[[:space:]]{" (base_indent + 2) "}", "")
+    print > outfile
+  }
+  END { if (in_run) close(outfile) }
+' "$WORKFLOW"
+
+extracted_count=$(ls -1 "$block_dir" 2>/dev/null | wc -l | tr -d ' ')
+syntax_errors=0
+for f in "$block_dir"/block-*.sh; do
+  [ -f "$f" ] || continue
+  if ! err=$(bash -n "$f" 2>&1); then
+    fail=$((fail + 1))
+    syntax_errors=$((syntax_errors + 1))
+    echo "  FAIL: bash syntax error in $(basename "$f")" >&2
+    echo "$err" | sed 's/^/    /' >&2
+  fi
+done
+rm -rf "$block_dir"
+
+if [ "$syntax_errors" -eq 0 ] && [ "$extracted_count" -gt 0 ]; then
+  pass=$((pass + 1))
+  echo "  PASS: all $extracted_count run blocks have valid bash syntax"
+elif [ "$extracted_count" = "0" ]; then
+  fail=$((fail + 1))
+  echo "  FAIL: extracted 0 run blocks (extraction logic broken?)" >&2
+fi
+
+# ── Test 5: PR-number resolution dispatch (extracted bash logic)
+# The workflow embeds this dispatch as inline bash. Extract the logic
+# pattern and exercise the three event shapes against canned
+# github.event payloads.
+echo
+echo "auto-clear-blocking-labels.yml PR-number resolution tests"
+
+dispatch() {
+  # Mirrors the workflow's case statement. Args: event_name,
+  # event_json. Unsupported events return 0 (matching the workflow's
+  # `exit 0  # don't fail; just skip` semantics — CR Minor on PR #202).
+  local event_name="$1"
+  local event_json="$2"
+  case "$event_name" in
+    pull_request_target|pull_request_review)
+      jq -r '.pull_request.number' <<<"$event_json"
+      ;;
+    workflow_run)
+      local conclusion
+      conclusion=$(jq -r '.workflow_run.conclusion' <<<"$event_json")
+      if [ "$conclusion" != "success" ]; then
+        return 0  # workflow's "skip on non-success" path
+      fi
+      jq -r '.workflow_run.pull_requests[].number' <<<"$event_json"
+      ;;
+    *)
+      echo "Unsupported event: $event_name" >&2
+      return 0  # workflow exit 0 on unsupported (don't fail; just skip)
+      ;;
+  esac
+}
+
+# pull_request_target → 1 PR
+out=$(dispatch pull_request_target '{"pull_request":{"number":42}}')
+if [ "$out" = "42" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: pull_request_target resolves to PR number"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: pull_request_target dispatch (got: $out)" >&2
+fi
+
+# pull_request_review → 1 PR
+out=$(dispatch pull_request_review '{"pull_request":{"number":99}}')
+if [ "$out" = "99" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: pull_request_review resolves to PR number"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: pull_request_review dispatch (got: $out)" >&2
+fi
+
+# workflow_run success → multiple PRs
+out=$(dispatch workflow_run '{"workflow_run":{"conclusion":"success","pull_requests":[{"number":7},{"number":8}]}}')
+expected=$'7\n8'
+if [ "$out" = "$expected" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: workflow_run (success) enumerates multiple PRs"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: workflow_run (success) dispatch (got: $out)" >&2
+fi
+
+# workflow_run failure → empty (don't bother re-evaluating gate when
+# the upstream workflow itself failed)
+out=$(dispatch workflow_run '{"workflow_run":{"conclusion":"failure","pull_requests":[{"number":7}]}}')
+if [ -z "$out" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: workflow_run (failure conclusion) skips re-evaluation"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: workflow_run failure should produce empty (got: $out)" >&2
+fi
+
+# workflow_run with empty pull_requests → empty (script then skips
+# per the `if [ -z "$prs" ]` guard upstream)
+out=$(dispatch workflow_run '{"workflow_run":{"conclusion":"success","pull_requests":[]}}')
+if [ -z "$out" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: workflow_run with no PRs produces empty output (will be skipped)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: workflow_run empty PRs should yield empty (got: $out)" >&2
+fi
+
+# Unsupported event → exit 0 with stderr message (matches workflow
+# behavior; CR Minor on PR #202 r1 fixed the prior return-1 mismatch)
+set +e
+out=$(dispatch wat '{}' 2>&1)
+rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "Unsupported event"; then
+  pass=$((pass + 1))
+  echo "  PASS: unsupported event returns 0 with clear stderr (matches workflow)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: unsupported event handling (rc=$rc, out=$out)" >&2
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "check_auto_clear_workflow: PASS ($pass tests)"
+  exit 0
+else
+  echo "check_auto_clear_workflow: FAIL ($fail of $((pass + fail)) tests)" >&2
+  exit 1
+fi

--- a/scripts/ci/check_bootstrap_board_and_summary
+++ b/scripts/ci/check_bootstrap_board_and_summary
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# scripts/ci/check_bootstrap_board_and_summary — CI entry point for
+# #156 sub-E / #207 tests.
+#
+# Wraps tests/test_bootstrap_board_and_summary.sh so the repo_lint
+# workflow's "run all scripts/ci/check_*" loop picks it up. Mirrors
+# the pattern used by check_bootstrap_github_infra. Missing test
+# script is a hard error (matches the tightening applied to
+# check_sync_overrides in #228 round 5).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_bootstrap_board_and_summary.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  echo "check_bootstrap_board_and_summary: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"

--- a/scripts/ci/check_bootstrap_firebase_and_codereview
+++ b/scripts/ci/check_bootstrap_firebase_and_codereview
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# scripts/ci/check_bootstrap_firebase_and_codereview — CI entry point
+# for #156 sub-D / #206 tests.
+#
+# Wraps tests/test_bootstrap_firebase_and_codereview.sh so the
+# repo_lint workflow's "run all scripts/ci/check_*" loop picks it up.
+# Mirrors the pattern used by check_bootstrap_github_infra and the
+# other check_* scripts. Missing test script is a hard error (matches
+# the tightening applied to check_sync_overrides in #228 round 5).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_bootstrap_firebase_and_codereview.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  echo "check_bootstrap_firebase_and_codereview: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"

--- a/scripts/ci/check_bootstrap_github_infra
+++ b/scripts/ci/check_bootstrap_github_infra
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# scripts/ci/check_bootstrap_github_infra — CI entry point for
+# #156 sub-C / #205 tests.
+#
+# Wraps tests/test_bootstrap_github_infra.sh so the repo_lint
+# workflow's "run all scripts/ci/check_*" loop picks it up. Mirrors
+# the pattern used by check_bootstrap_template_mirror and the other
+# check_* scripts. Missing test script is a hard error (matches the
+# tightening applied to check_sync_overrides in #228 round 5).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_bootstrap_github_infra.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  echo "check_bootstrap_github_infra: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"

--- a/scripts/ci/check_bootstrap_template_mirror
+++ b/scripts/ci/check_bootstrap_template_mirror
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# scripts/ci/check_bootstrap_template_mirror — CI entry point for
+# #156 sub-B / #204 tests.
+#
+# Wraps tests/test_bootstrap_template_mirror.sh so the repo_lint
+# workflow's "run all scripts/ci/check_*" loop picks it up. Mirrors
+# the pattern used by check_bootstrap_wizard and the other check_*
+# scripts. Missing test script is a hard error (matches the tightening
+# applied to check_sync_overrides in #228 round 5).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_bootstrap_template_mirror.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  echo "check_bootstrap_template_mirror: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"

--- a/scripts/ci/check_bootstrap_wizard
+++ b/scripts/ci/check_bootstrap_wizard
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# scripts/ci/check_bootstrap_wizard — CI entry point for #156 sub-A tests.
+#
+# Wraps tests/test_bootstrap_wizard.sh so the repo_lint workflow's
+# "run all scripts/ci/check_*" loop picks it up. Mirrors the
+# pattern used by check_sync_overrides and the other check_*
+# scripts.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_bootstrap_wizard.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  # Missing test script is a hard error (silent skip would let an
+  # accidental delete/rename disable this check). Matches the
+  # tightening applied to check_sync_overrides in #228 round 5.
+  echo "check_bootstrap_wizard: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"

--- a/scripts/ci/check_coderabbit_config
+++ b/scripts/ci/check_coderabbit_config
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# check_coderabbit_config
+#
+# Validates .coderabbit.yml — the CodeRabbit configuration shipped
+# with the Mergepath template and propagated to consumer repos via
+# the wizard's template-mirror bootstrap (scripts/bootstrap/
+# template-mirror.sh). See #237 for the nit-collapse change this
+# check enforces.
+#
+# Scoping (per Codex P2 on #256 round 1, then CR on round 2):
+#
+#   Round 1 scoped the profile-value gate to the Mergepath template
+#   repo so consumers may run reviews.profile: assertive locally
+#   without their CI failing.
+#
+#   Round 2 (this revision) further scopes the existence requirement
+#   to repos that actually have CodeRabbit enabled. The sub-D
+#   wizard (PR #248) intentionally deletes .coderabbit.yml when a
+#   private consumer repo is bootstrapped — CodeRabbit's free tier is
+#   public-only, so the wizard flips `coderabbit.enabled: false` in
+#   `.github/review-policy.yml` AND removes the now-pointless file.
+#   The previous "must exist" hard requirement therefore fired on
+#   every private consumer and reported FAIL on an intentional state.
+#
+# Existence behavior:
+#
+#   File present:
+#     parse the YAML; if this is the Mergepath template repo,
+#     enforce reviews.profile == "chill".
+#
+#   File absent + review-policy.yml's `coderabbit.enabled` is false:
+#     PASS (intentional disable per sub-D's private-repo bootstrap;
+#     see #248).
+#
+#   File absent + `coderabbit.enabled` is true / unset / no policy
+#   file:
+#     FAIL (config drift on a repo that says it wants CodeRabbit;
+#     the template itself also lands here when its .coderabbit.yml
+#     has wandered off).
+#
+# The profile gate (`reviews.profile == "chill"`) only fires when
+# .coderabbit.yml exists AND this is the Mergepath template repo.
+#
+# Template-repo detection prefers CI signals (GITHUB_REPOSITORY,
+# which Actions always sets, matched against `*/mergepath`) and
+# falls back to the origin remote URL for local runs. An override
+# env var (MERGEPATH_TEMPLATE_CHECK=force|skip) is provided for
+# tests and edge cases.
+#
+# This check is read-only and does not contact CodeRabbit's API.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONFIG="$REPO_ROOT/.coderabbit.yml"
+REVIEW_POLICY="$REPO_ROOT/.github/review-policy.yml"
+EXPECTED_PROFILE="chill"
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "FAIL: yq is required (mikefarah/yq v4+). Install via 'brew install yq' or apt."
+  exit 2
+fi
+
+# Reject non-mikefarah yq (kislyuk/yq is a Python wrapper around jq with a
+# completely different syntax — its `//` and `-r` semantics don't match the
+# patterns this script relies on; accepting it surfaces as cryptic downstream
+# parse errors). Mirrors the same check in scripts/sync-to-downstream.sh and
+# scripts/bootstrap-new-repo.sh's preflight. CodeRabbit round-2 minor on #256.
+if ! yq --version 2>&1 | grep -q "mikefarah/yq"; then
+  echo "FAIL: unsupported yq implementation (got: $(yq --version 2>&1 | head -1)); expected mikefarah/yq v4+. Install via 'brew install yq'."
+  exit 2
+fi
+
+# Resolve whether this repo expects CodeRabbit to be active. The
+# canonical signal is `.github/review-policy.yml`'s `coderabbit.enabled`
+# field — sub-D (#248) flips this to `false` and deletes .coderabbit.yml
+# in one transaction when bootstrapping a private repo. Treat the
+# absence of the policy file (or the absence of the coderabbit key)
+# as "enabled" so the template's own CI keeps catching a missing
+# .coderabbit.yml.
+#
+# Note: `yq -r '.x // "unset"' …` treats the YAML literal `false` as
+# a missing value and substitutes the default — exactly the wrong
+# behavior here. Read the key directly (yq emits `null` for missing
+# keys, `false`/`true` for the literal booleans) and pattern-match
+# the raw output instead.
+coderabbit_enabled="true"
+if [ -f "$REVIEW_POLICY" ]; then
+  raw=$(yq -r '.coderabbit.enabled' "$REVIEW_POLICY" 2>/dev/null || echo "null")
+  case "$raw" in
+    false) coderabbit_enabled="false" ;;
+    *)     coderabbit_enabled="true"  ;;
+  esac
+fi
+
+if [ ! -f "$CONFIG" ]; then
+  if [ "$coderabbit_enabled" = "false" ]; then
+    echo "check_coderabbit_config: PASS (.coderabbit.yml absent; coderabbit.enabled=false in review-policy.yml — private-repo bootstrap path per #248)"
+    exit 0
+  fi
+  echo "FAIL: .coderabbit.yml is missing at repo root (coderabbit.enabled is not false in $REVIEW_POLICY)"
+  echo "      If this repo intentionally disables CodeRabbit, set 'coderabbit.enabled: false' in .github/review-policy.yml."
+  exit 1
+fi
+
+if ! yq '.' "$CONFIG" >/dev/null 2>&1; then
+  echo "FAIL: .coderabbit.yml does not parse as YAML"
+  yq '.' "$CONFIG" || true
+  exit 1
+fi
+
+# --- template-repo detection ------------------------------------------------
+#
+# Returns 0 if this repo is the Mergepath template (where the profile
+# gate applies), 1 otherwise. Order of precedence:
+#
+#   1. MERGEPATH_TEMPLATE_CHECK=force  → treat as template (run gate)
+#   2. MERGEPATH_TEMPLATE_CHECK=skip   → treat as consumer (skip gate)
+#   3. GITHUB_REPOSITORY (CI)          → match *.mergepath suffix
+#   4. git remote get-url origin       → match mergepath repo basename
+#   5. unknown                         → skip the gate (fail-open for
+#                                        the override-friendly direction)
+#
+# The basename match accepts both `mergepath` and `mergepath.git` so
+# SSH-style remotes (`git@github.com:OWNER/mergepath.git`) work.
+is_mergepath_template() {
+  case "${MERGEPATH_TEMPLATE_CHECK:-}" in
+    force) return 0 ;;
+    skip)  return 1 ;;
+  esac
+
+  if [ -n "${GITHUB_REPOSITORY:-}" ]; then
+    case "$GITHUB_REPOSITORY" in
+      */mergepath) return 0 ;;
+      *)           return 1 ;;
+    esac
+  fi
+
+  local remote_url
+  if remote_url=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null); then
+    # Strip a trailing .git, then take the last path component. Works
+    # for both https://host/owner/mergepath.git and
+    # git@host:owner/mergepath.git.
+    local basename_no_git="${remote_url%.git}"
+    basename_no_git="${basename_no_git##*/}"
+    basename_no_git="${basename_no_git##*:}"
+    case "$basename_no_git" in
+      mergepath) return 0 ;;
+      *)         return 1 ;;
+    esac
+  fi
+
+  # No CI env var, no origin remote. Fail-open: skip the gate. A
+  # malformed YAML or missing file still failed the earlier checks;
+  # only the profile-value enforcement is template-scoped.
+  return 1
+}
+
+if ! is_mergepath_template; then
+  echo "check_coderabbit_config: PASS (parse OK; profile gate skipped — not the Mergepath template repo)"
+  exit 0
+fi
+
+profile=$(yq -r '.reviews.profile // ""' "$CONFIG")
+if [ "$profile" != "$EXPECTED_PROFILE" ]; then
+  echo "FAIL: reviews.profile is '$profile', expected '$EXPECTED_PROFILE' (#237 nit-collapse)"
+  echo "      'assertive' re-enables 🧹 Nitpick comments per CodeRabbit's docs."
+  echo "      Keep the template on '$EXPECTED_PROFILE'; consumer repos may override locally."
+  exit 1
+fi
+
+echo "check_coderabbit_config: PASS (reviews.profile=$profile)"
+exit 0

--- a/scripts/ci/check_coderabbit_config_tests
+++ b/scripts/ci/check_coderabbit_config_tests
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# scripts/ci/check_coderabbit_config_tests — CI entry point for the
+# check_coderabbit_config unit tests (#256 P2 follow-up to #237).
+#
+# Wraps tests/test_check_coderabbit_config.sh so the repo_lint workflow
+# picks it up alongside the other check_* scripts. Missing test script
+# is a hard error (matches the tightening applied to other check_* CI
+# entry points in #228 round 5).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_check_coderabbit_config.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  echo "check_coderabbit_config_tests: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"

--- a/scripts/ci/check_codex_p1_gate
+++ b/scripts/ci/check_codex_p1_gate
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# check_codex_p1_gate
+#
+# CI wrapper for scripts/codex-p1-gate.sh — the Codex P1 unresolved-
+# thread merge gate (nathanjohnpayne/mergepath#235).
+#
+# Two concerns:
+#   1. The script and its workflow must exist on disk and be executable
+#      (consistent with check_codex_scripts for the Phase 4a helpers).
+#   2. The script's parsing + decision logic must work against fixture
+#      review-comment payloads. We delegate this to
+#      tests/test_codex_p1_gate.sh which PATH-shims `gh` and walks the
+#      script through 11 cases (enabled/disabled, P1 present/absent,
+#      resolved/unresolved, SHA scoping, non-bot authors, mixed
+#      thread state, malformed input, pagination overflow).
+#
+# Invoked by .github/workflows/repo_lint.yml alongside the other
+# scripts/ci/check_* scripts.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+SCRIPT="scripts/codex-p1-gate.sh"
+WORKFLOW=".github/workflows/codex-p1-gate.yml"
+TEST="tests/test_codex_p1_gate.sh"
+
+FAILED=0
+
+# Existence + executability checks.
+for rel in "$SCRIPT" "$TEST"; do
+  if [ ! -f "$rel" ]; then
+    echo "FAIL: Missing required file: $rel"
+    FAILED=1
+    continue
+  fi
+  if [ ! -x "$rel" ]; then
+    echo "FAIL: File is not executable: $rel"
+    echo "      Fix with: chmod +x $rel"
+    FAILED=1
+  fi
+done
+
+# Workflow file exists (not executable; YAML is not a shell script).
+if [ ! -f "$WORKFLOW" ]; then
+  echo "FAIL: Missing required workflow: $WORKFLOW"
+  FAILED=1
+fi
+
+# Workflow trigger shape (#257 codex CR). GitHub Actions does NOT
+# document `pull_request_review_thread` as a workflow trigger — it
+# exists as a webhook event for Apps, but the Actions
+# events-that-trigger-workflows reference omits it, and adding it to
+# `on:` is a no-op (the gate would NEVER re-fire on UI resolves).
+# The corrected shape is:
+#   - pull_request + pull_request_review + pull_request_review_comment
+#     for the event-driven path.
+#   - schedule (cron) as the safety net for UI "Resolve conversation"
+#     clicks, which produce no Actions event.
+# Additionally, the workflow MUST NOT list pull_request_review_thread —
+# its presence is misleading (suggests we have UI-resolve coverage
+# when we don't) and is the regression this PR closes.
+if [ -f "$WORKFLOW" ]; then
+  for trigger in pull_request pull_request_review pull_request_review_comment schedule; do
+    if ! grep -qE "^[[:space:]]*${trigger}:" "$WORKFLOW"; then
+      echo "FAIL: $WORKFLOW missing required trigger: $trigger"
+      echo "      The gate must fire on push, review submission, inline-comment, AND on a periodic schedule (UI-resolve safety net)."
+      FAILED=1
+    fi
+  done
+
+  # Forbid the misleading pull_request_review_thread trigger.
+  if grep -qE "^[[:space:]]*pull_request_review_thread:" "$WORKFLOW"; then
+    echo "FAIL: $WORKFLOW lists pull_request_review_thread as a workflow trigger."
+    echo "      That event is a webhook payload for GitHub Apps, NOT a documented Actions workflow trigger."
+    echo "      See https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows"
+    echo "      Use schedule (cron) for the UI-resolve safety net instead. See PR #257."
+    FAILED=1
+  fi
+
+  # Schedule cron must be present in the on: block. Loose check —
+  # the value just has to mention */N or a cron string under
+  # schedule:.
+  if ! awk '
+    /^on:/ {in_on=1; next}
+    in_on && /^[^[:space:]#]/ {in_on=0}
+    in_on && /^[[:space:]]+schedule:/ {in_sched=1; next}
+    in_sched && /^[[:space:]]+- cron:/ {found=1; exit}
+    in_sched && /^[[:space:]]+[a-z]/ {in_sched=0}
+    END {exit (found ? 0 : 1)}
+  ' "$WORKFLOW"; then
+    echo "FAIL: $WORKFLOW schedule: block missing a 'cron:' entry."
+    echo "      The schedule trigger needs a cron expression (e.g. '*/15 * * * *')."
+    FAILED=1
+  fi
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "check_codex_p1_gate: FAIL (pre-flight)"
+  exit 1
+fi
+
+# Run the fixture-driven test suite.
+if ! bash "$TEST"; then
+  echo "check_codex_p1_gate: FAIL (test suite)"
+  exit 1
+fi
+
+echo "check_codex_p1_gate: PASS"
+exit 0

--- a/scripts/ci/check_disagreement_detector
+++ b/scripts/ci/check_disagreement_detector
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# check_disagreement_detector — CI wrapper for the disagreement
+# detector test suite (#259).
+#
+# `.github/workflows/agent-review.yml`'s `detect-disagreement` job
+# applies / removes the `needs-human-review` label. Its decision
+# logic was factored into `scripts/disagreement-detector.js` so the
+# workflow and this test exercise the same code (the lockstep
+# pattern documented for pr-audit.yml's P0/P1 detection — except
+# here the JS is a real module both sides `require()`, not an
+# inline literal copied twice).
+#
+# This wrapper hard-fails if the detector module, the fixture
+# directory, or the test script are missing, then runs
+# `tests/test_disagreement_detector.sh`.
+#
+# Also asserts the workflow still wires the extracted module in —
+# the long-pole canary if someone re-inlines the logic and the
+# module drifts.
+#
+# Issue: #259. Cross-reference: scripts/codex-review-check.sh
+# gates (b)/(c), #170 + #218.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+DETECTOR="scripts/disagreement-detector.js"
+FIXTURES_DIR="scripts/ci/fixtures/disagreement-detector"
+TEST_SCRIPT="tests/test_disagreement_detector.sh"
+WORKFLOW=".github/workflows/agent-review.yml"
+
+for f in "$DETECTOR" "$FIXTURES_DIR" "$TEST_SCRIPT" "$WORKFLOW"; do
+  if [ ! -e "$f" ]; then
+    echo "check_disagreement_detector: missing required path: $f" >&2
+    exit 1
+  fi
+done
+
+if [ ! -x "$TEST_SCRIPT" ]; then
+  echo "check_disagreement_detector: $TEST_SCRIPT is not executable" >&2
+  exit 1
+fi
+
+# Structural assertion: the workflow requires the extracted module.
+# If detect-disagreement is re-inlined, the module can rot silently
+# while this test still passes against the stale file. This canary
+# fails first.
+if ! grep -qF 'scripts/disagreement-detector.js' "$WORKFLOW"; then
+  echo "check_disagreement_detector: $WORKFLOW no longer require()s scripts/disagreement-detector.js — the detect-disagreement job and its test may have drifted" >&2
+  exit 1
+fi
+
+# Structural assertion: the workflow references #259 for traceability.
+if ! grep -qF '#259' "$WORKFLOW"; then
+  echo "check_disagreement_detector: $WORKFLOW must reference #259 in a comment for traceability" >&2
+  exit 1
+fi
+
+# Run the fixture-driven suite.
+bash "$TEST_SCRIPT"
+
+echo "check_disagreement_detector: PASS"

--- a/scripts/ci/check_eslint_config_policy
+++ b/scripts/ci/check_eslint_config_policy
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# scripts/ci/check_eslint_config_policy
+#
+# CI wrapper that runs the unit tests for the ESLint flat-config
+# policy check (scripts/ci/check_eslint_config_present). Mirrors the
+# scripts/ci/check_gh_as_author pattern: hard-fail (exit 1) when the
+# test file is missing so an accidental delete/rename can't silently
+# disable the policy.
+#
+# This is the "tests" wrapper; the actual policy check that runs
+# against the repo tree is `check_eslint_config_present`. Both are
+# wired into .github/workflows/repo_lint.yml — see issue #250.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+TESTS=(
+  "tests/test_eslint_policy_check.sh"
+)
+
+FAILED=0
+for rel in "${TESTS[@]}"; do
+  full="$REPO_ROOT/$rel"
+  if [ ! -f "$full" ]; then
+    echo "check_eslint_config_policy: ERROR (missing $rel)" >&2
+    FAILED=1
+    continue
+  fi
+  echo "check_eslint_config_policy: running $rel"
+  if ! bash "$full"; then
+    echo "check_eslint_config_policy: FAIL ($rel)" >&2
+    FAILED=1
+  fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "check_eslint_config_policy: FAIL"
+  exit 1
+fi
+
+echo "check_eslint_config_policy: PASS"
+exit 0

--- a/scripts/ci/check_eslint_config_present
+++ b/scripts/ci/check_eslint_config_present
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# scripts/ci/check_eslint_config_present
+#
+# Enforces the ESLint flat-config policy from `rules/repo_rules.md`:
+# any repo with a root `package.json` MUST ship an `eslint.config.js`
+# flat config at the repo root, and the file must be syntactically
+# valid JavaScript.
+#
+# Repos without a root `package.json` (mergepath itself is shell-only,
+# for example) are exempt — the check logs a not-applicable note and
+# exits 0.
+#
+# Contract (load-bearing — referenced by docs/agents/code-review-
+# requirements.md and the rule in rules/repo_rules.md):
+#
+#   exit 0 — pass:
+#            (a) no root package.json (policy not applicable), OR
+#            (b) root package.json present AND eslint.config.js
+#                present at root AND `node --check` parses it.
+#   exit 1 — fail:
+#            root package.json present AND either eslint.config.js
+#            missing at root, OR present but fails `node --check`.
+#   exit 2 — environment error (Node not available when we needed it
+#            to parse-check). Treated as fail by the workflow so the
+#            check can't silently degrade to "skip".
+#
+# Bash 3.2 portable (macOS default shell). Mirrors the style of
+# scripts/ci/check_codex_scripts and scripts/ci/check_required_root_files.
+#
+# Synced to consumer repos via the `scripts/ci/` kit entry in
+# .mergepath-sync.yml — the file is canonical at this path everywhere.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+PKG_JSON="$REPO_ROOT/package.json"
+ESLINT_CONFIG="$REPO_ROOT/eslint.config.js"
+
+if [ ! -f "$PKG_JSON" ]; then
+  echo "check_eslint_config_present: no package.json — ESLint policy not applicable to this repo."
+  echo "check_eslint_config_present: PASS"
+  exit 0
+fi
+
+FAILED=0
+
+if [ ! -f "$ESLINT_CONFIG" ]; then
+  echo "FAIL: package.json is present at repo root but eslint.config.js is missing."
+  echo "      Mergepath policy requires a flat ESLint config in every Node-bearing repo."
+  echo "      See rules/repo_rules.md § ESLint policy and examples/eslint.config.js for"
+  echo "      a starting point you can copy."
+  FAILED=1
+fi
+
+if [ "$FAILED" -eq 0 ]; then
+  if ! command -v node >/dev/null 2>&1; then
+    echo "ERROR: node is not on PATH — cannot parse-check eslint.config.js."
+    echo "       Install Node.js >= 18 on the runner."
+    echo "check_eslint_config_present: ERROR"
+    exit 2
+  fi
+  # Use a unique temp file rather than a fixed `/tmp/...` path so two
+  # concurrent runners (CI matrix, multiple worktrees on a dev box)
+  # can't clobber each other's parse output.
+  ERR_FILE="$(mktemp "${TMPDIR:-/tmp}/eslint-config-parse.XXXXXX")"
+  trap 'rm -f "$ERR_FILE"' EXIT
+  if ! node --check "$ESLINT_CONFIG" 2>"$ERR_FILE"; then
+    echo "FAIL: eslint.config.js failed Node syntax check:"
+    sed 's/^/      /' <"$ERR_FILE"
+    FAILED=1
+  fi
+  rm -f "$ERR_FILE"
+  trap - EXIT
+
+  # Enforce the policy floor from rules/repo_rules.md § ESLint policy:
+  # the config must include `@eslint/js`'s `recommended` ruleset. We
+  # match on both the package import and a `*.configs.recommended`
+  # reference — either alone is a common partial-config mistake (e.g.
+  # importing `@eslint/js` but forgetting to spread `js.configs.recommended`).
+  # Skipped if the parse step already failed — no point re-reporting
+  # on a syntactically-broken file.
+  #
+  # Comment-bypass guard (codex CR on #253): a config that only
+  # references `@eslint/js` or `.configs.recommended` from within a
+  # JS comment must NOT satisfy the check. nathanpayne-codex
+  # reproduced the bypass on the prior HEAD: a config that imports
+  # `@eslint/js` but exports only a local rules object, with a stray
+  # `// ...tseslint.configs.recommended` comment, passed CI. We strip
+  # `//` and `/* */` comments before grepping. Strings are preserved
+  # so a `//` literal inside a quoted value can't confuse the
+  # stripper (theoretical — ESLint configs rarely contain `//` in
+  # strings, but the stripper handles it correctly).
+  if [ "$FAILED" -eq 0 ]; then
+    STRIPPED="$(node -e '
+      const fs = require("fs");
+      const src = fs.readFileSync(process.argv[1], "utf8");
+      let out = "", i = 0, n = src.length;
+      while (i < n) {
+        const c = src[i], nx = src[i+1];
+        if (c === "/" && nx === "/") {
+          while (i < n && src[i] !== "\n") i++;
+        } else if (c === "/" && nx === "*") {
+          i += 2;
+          while (i < n && !(src[i] === "*" && src[i+1] === "/")) i++;
+          i += 2;
+        } else if (c === "\"" || c === "\x27" || c === "`") {
+          const q = c; out += c; i++;
+          while (i < n) {
+            const ch = src[i]; out += ch;
+            if (ch === "\\") { out += src[i+1] || ""; i += 2; continue; }
+            i++;
+            if (ch === q) break;
+          }
+        } else { out += c; i++; }
+      }
+      process.stdout.write(out);
+    ' "$ESLINT_CONFIG")"
+    if ! printf '%s' "$STRIPPED" | grep -Eq '["'\'']@eslint/js["'\'']' \
+       || ! printf '%s' "$STRIPPED" | grep -Eq '\.configs\.recommended\b'; then
+      echo "FAIL: eslint.config.js must include the @eslint/js recommended ruleset."
+      echo "      Mergepath policy floor (rules/repo_rules.md § ESLint policy)"
+      echo "      requires at least:"
+      echo "        import js from \"@eslint/js\";"
+      echo "        export default [ js.configs.recommended, ... ];"
+      echo "      See examples/eslint.config.js for a starting point."
+      echo "      (Comments are stripped before this check — a"
+      echo "      // @eslint/js .configs.recommended line in a comment"
+      echo "      cannot satisfy the policy floor.)"
+      FAILED=1
+    fi
+  fi
+fi
+
+if [ "$FAILED" -eq 1 ]; then
+  echo "check_eslint_config_present: FAIL"
+  exit 1
+fi
+
+echo "check_eslint_config_present: PASS"
+exit 0

--- a/scripts/ci/check_gh_as_author
+++ b/scripts/ci/check_gh_as_author
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# scripts/ci/check_gh_as_author — CI entry point for #241 tests.
+#
+# Runs the unit tests for scripts/gh-as-author.sh AND for the
+# identity-check addition to scripts/hooks/gh-pr-guard.sh. Both test
+# files are under tests/; this wrapper invokes them in sequence and
+# fails on the first failure. Hard-fails (exit 1, not skip) when
+# either test script is missing, so an accidental delete/rename
+# can't silently disable this check.
+#
+# Mirrors the pattern used by scripts/ci/check_sync_overrides.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+TESTS=(
+  "tests/test_gh_as_author.sh"
+  "tests/test_gh_as_reviewer.sh"
+  "tests/test_gh_pr_guard.sh"
+)
+
+FAILED=0
+for rel in "${TESTS[@]}"; do
+  full="$REPO_ROOT/$rel"
+  if [ ! -f "$full" ]; then
+    echo "check_gh_as_author: ERROR (missing $rel)" >&2
+    FAILED=1
+    continue
+  fi
+  echo "check_gh_as_author: running $rel"
+  if ! bash "$full"; then
+    echo "check_gh_as_author: FAIL ($rel)" >&2
+    FAILED=1
+  fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "check_gh_as_author: FAIL"
+  exit 1
+fi
+
+echo "check_gh_as_author: PASS"
+exit 0

--- a/scripts/ci/check_phase_4b_classifier
+++ b/scripts/ci/check_phase_4b_classifier
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Unit-level coverage for scripts/phase-4b-classifier.sh.
+#
+# Runs the classifier against six fixture PRs (one per trigger class
+# plus a no-trigger negative case) and asserts the output triggers
+# array. Fixture inputs live in scripts/ci/fixtures/phase-4b/.
+#
+# Each fixture is a JSON object: {body: string, files: [{filename,
+# patch}, ...]}. The classifier's --fixture flag reads this shape
+# directly (mirroring gh's pulls/{pr}/files response with an optional
+# body field for triggers that scan PR text).
+#
+# Runs from the repo root. Invoked by .github/workflows/repo_lint.yml
+# (alongside the other scripts/ci/check_* scripts).
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+CLASSIFIER="scripts/phase-4b-classifier.sh"
+FIXTURES_DIR="scripts/ci/fixtures/phase-4b"
+
+for f in "$CLASSIFIER" "$FIXTURES_DIR"; do
+  if [ ! -e "$f" ]; then
+    echo "check_phase_4b_classifier: missing required path: $f" >&2
+    exit 1
+  fi
+done
+
+pass=0
+fail=0
+
+# Run the classifier against a fixture and compare the triggers array
+# (sorted, comma-joined) to the expected list. The classifier reads
+# phase_4b_default from cwd's .github/review-policy.yml — to keep
+# fixture tests self-contained (and not depend on whatever the live
+# policy is on the branch where the test runs), set up a per-call
+# scratch dir with phase_4b_default: complex-changes and cd into it.
+SCRATCH_TRIGGERS=$(mktemp -d)
+mkdir -p "$SCRATCH_TRIGGERS/.github"
+echo "phase_4b_default: complex-changes" > "$SCRATCH_TRIGGERS/.github/review-policy.yml"
+
+assert_triggers() {
+  local desc="$1" fixture="$2" expected="$3" expected_exit="$4"
+  local out actual_triggers actual_exit
+
+  set +e
+  out=$(cd "$SCRATCH_TRIGGERS" && bash "$ROOT/$CLASSIFIER" 99999 --fixture "$ROOT/$FIXTURES_DIR/$fixture" 2>/dev/null)
+  actual_exit=$?
+  set -e
+
+  # Guard the jq parse so a malformed classifier output (which would
+  # be a bug we want to SEE in test output, not a script-aborting
+  # surprise) is reported as an assertion failure with the raw output
+  # printed. CodeRabbit Major on PR #190.
+  set +e
+  actual_triggers=$(echo "$out" | jq -r '.triggers | sort | join(",")' 2>/dev/null)
+  jq_rc=$?
+  set -e
+  if [ "$jq_rc" -ne 0 ]; then
+    fail=$((fail + 1))
+    echo "  FAIL: $desc" >&2
+    echo "    fixture:        $fixture" >&2
+    echo "    classifier output is not valid JSON or .triggers is missing" >&2
+    echo "    full output:" >&2
+    echo "$out" | sed 's/^/      /' >&2
+    return
+  fi
+
+  if [ "$expected" = "$actual_triggers" ] && [ "$expected_exit" = "$actual_exit" ]; then
+    pass=$((pass + 1))
+    echo "  PASS: $desc"
+  else
+    fail=$((fail + 1))
+    echo "  FAIL: $desc" >&2
+    echo "    fixture:        $fixture" >&2
+    echo "    expected (e=$expected_exit): $expected" >&2
+    echo "    actual   (e=$actual_exit): $actual_triggers" >&2
+    echo "    full output:" >&2
+    echo "$out" | sed 's/^/      /' >&2
+  fi
+}
+
+echo "phase-4b-classifier.sh fixture tests"
+
+assert_triggers "state-machine fixture matches state-machine-change" \
+  "state-machine.json" "state-machine-change" "1"
+
+assert_triggers "concurrency fixture matches concurrency (paths + keywords)" \
+  "concurrency.json" "concurrency" "1"
+
+assert_triggers "prompt-design fixture matches prompt-design (path glob)" \
+  "prompt-design.json" "prompt-design" "1"
+
+# Cross-cutting fixture spans 4 distinct top-level dirs (src, src+, tests)
+# AND has both types/ + services/ — either heuristic alone matches.
+assert_triggers "cross-cutting fixture matches cross-cutting-refactor" \
+  "cross-cutting.json" "cross-cutting-refactor" "1"
+
+assert_triggers "invariant fixture matches invariant-enforcement (path + body)" \
+  "invariant.json" "invariant-enforcement" "1"
+
+assert_triggers "no-trigger fixture (README + LICENSE only) matches nothing" \
+  "no-trigger.json" "" "0"
+
+# Regression: 3 root files (README + LICENSE + CONTRIBUTING) must NOT
+# trigger cross-cutting-refactor. Codex P2 + CR Minor on PR #190 caught
+# the prior `awk -F/ '{print $1}'` over-counting each root filename as
+# a distinct top-level dir, spuriously triggering 4b on docs-only PRs.
+assert_triggers "3 root-only files do not trigger cross-cutting-refactor (regression)" \
+  "root-files-only.json" "" "0"
+
+echo
+echo "phase-4b-classifier.sh policy short-circuit tests"
+
+# fallback-only short-circuit: the test harness uses a temp config to
+# avoid mutating the real .github/review-policy.yml. We swap the
+# config in via a temp dir + cd, since the script reads CONFIG=
+# "$.github/review-policy.yml" relative to cwd.
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "$SCRATCH" "$SCRATCH_TRIGGERS"' EXIT
+mkdir -p "$SCRATCH/.github"
+
+# Helper: extract a single jq field from $out without aborting under
+# `set -e` on a parse error. Sets `got_VAL` and `got_rc`. CodeRabbit
+# Major on PR #190 — jq parse failures shouldn't terminate the harness.
+jq_get() {
+  local field=$1
+  set +e
+  got_VAL=$(echo "$out" | jq -r ".$field" 2>/dev/null)
+  got_rc=$?
+  set -e
+}
+
+# fallback-only short-circuits without inspecting any diff.
+echo "phase_4b_default: fallback-only" > "$SCRATCH/.github/review-policy.yml"
+set +e
+out=$(cd "$SCRATCH" && bash "$ROOT/$CLASSIFIER" 99999 --fixture "$ROOT/$FIXTURES_DIR/state-machine.json" 2>/dev/null)
+rc=$?
+set -e
+jq_get recommendation; got_rec=$got_VAL; rec_rc=$got_rc
+jq_get files_inspected; got_files=$got_VAL; files_rc=$got_rc
+if [ "$rec_rc" = 0 ] && [ "$files_rc" = 0 ] && [ "$rc" = "0" ] && [ "$got_rec" = "fallback-only" ] && [ "$got_files" = "0" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: fallback-only short-circuits to recommendation=fallback-only, exit 0, no files inspected"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: fallback-only short-circuit (rc=$rc, rec=$got_rec [jq_rc=$rec_rc], files=$got_files [jq_rc=$files_rc])" >&2
+  echo "$out" | sed 's/^/      /' >&2
+fi
+
+# always short-circuits to invoke-4b regardless of fixture content.
+echo "phase_4b_default: always" > "$SCRATCH/.github/review-policy.yml"
+set +e
+out=$(cd "$SCRATCH" && bash "$ROOT/$CLASSIFIER" 99999 --fixture "$ROOT/$FIXTURES_DIR/no-trigger.json" 2>/dev/null)
+rc=$?
+set -e
+jq_get recommendation; got_rec=$got_VAL; rec_rc=$got_rc
+if [ "$rec_rc" = 0 ] && [ "$rc" = "1" ] && [ "$got_rec" = "invoke-4b" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: always short-circuits to recommendation=invoke-4b, exit 1 (even with no-trigger fixture)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: always short-circuit (rc=$rc, rec=$got_rec [jq_rc=$rec_rc])" >&2
+  echo "$out" | sed 's/^/      /' >&2
+fi
+
+# Unknown phase_4b_default value rejected with exit 2.
+echo "phase_4b_default: bogus-mode" > "$SCRATCH/.github/review-policy.yml"
+set +e
+err=$(cd "$SCRATCH" && bash "$ROOT/$CLASSIFIER" 99999 --fixture "$ROOT/$FIXTURES_DIR/no-trigger.json" 2>&1 >/dev/null)
+rc=$?
+set -e
+if [ "$rc" = "2" ] && echo "$err" | grep -q "phase_4b_default must be one of"; then
+  pass=$((pass + 1))
+  echo "  PASS: unknown phase_4b_default value rejected with exit 2 + clear error"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: unknown phase_4b_default rejection (rc=$rc, stderr: $err)" >&2
+fi
+
+echo
+echo "phase-4b-classifier.sh PR-body fetch failure tests (codex r1 Phase 4b on #190)"
+
+# Regression: when gh PR body fetch fails (network, missing PR, auth),
+# the classifier must hard-fail with exit 2 — NOT silently fall through
+# to PR_BODY="" and run trigger detectors with body-only signals
+# missing. The stub is *selective*: it succeeds for the /files endpoint
+# (so the script reaches the body fetch) and fails ONLY on the bare
+# pulls/{n} endpoint. CR Major on PR #190 r1 reproduced the prior
+# stub's flaw — failing on every call meant the script aborted at the
+# /files fetch and never exercised the body-fetch guard the test was
+# meant to cover.
+SCRATCH_GH=$(mktemp -d)
+cat > "$SCRATCH_GH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+# Selective fake gh. Endpoint dispatch on the joined argv. The /files
+# endpoint succeeds with a single-file array (so the classifier proceeds
+# to the body fetch); the bare pulls/{n} endpoint exits non-zero so the
+# classifier's || guard fires on the body fetch specifically.
+case " $* " in
+  *" repos/"*"/pulls/"*"/files "*|*" repos/"*"/pulls/"*"/files")
+    printf '%s\n' '[{"filename":"src/foo.ts","patch":"+const x = 1;\n"}]'
+    exit 0
+    ;;
+  *" repos/"*"/pulls/"*)
+    echo "Error: stubbed gh PR-body fetch failure" >&2
+    exit 1
+    ;;
+  *)
+    echo "Error: unstubbed gh call: $*" >&2
+    exit 1
+    ;;
+esac
+GH_STUB
+chmod +x "$SCRATCH_GH/gh"
+
+# Use a scratch policy to force complex-changes (so the script doesn't
+# short-circuit before reaching the body fetch).
+mkdir -p "$SCRATCH_GH/.github"
+echo "phase_4b_default: complex-changes" > "$SCRATCH_GH/.github/review-policy.yml"
+
+set +e
+# Drop --fixture so the script actually goes through the live API path
+# (which is what hits the PR body fetch). Set GH_TOKEN so the script
+# passes its empty-token guard before reaching the body fetch.
+out=$(cd "$SCRATCH_GH" && PATH="$SCRATCH_GH:$PATH" GH_TOKEN=stub-token bash "$ROOT/$CLASSIFIER" 99999 --repo nathanjohnpayne/mergepath 2>&1)
+rc=$?
+set -e
+# Tightened assertion: must specifically be the BODY-fetch error, not
+# the files-fetch or flatten error. If the script aborts earlier, the
+# body-fetch guard isn't being exercised and codex r1's required
+# coverage isn't met.
+if [ "$rc" = "2" ] && echo "$out" | grep -q "failed to fetch PR body"; then
+  pass=$((pass + 1))
+  echo "  PASS: PR body-fetch failure → exit 2 with body-specific error (no silent mask)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: PR body-fetch failure should exit 2 with body-specific error (rc=$rc)" >&2
+  echo "$out" | sed 's/^/      /' >&2
+fi
+rm -rf "$SCRATCH_GH"
+
+echo
+echo "phase-4b-classifier.sh argument-validation tests"
+
+# Bad PR# (non-integer) → exit 3
+set +e
+err=$(bash "$CLASSIFIER" "abc" 2>&1 >/dev/null); rc=$?
+set -e
+if [ "$rc" = "3" ] && echo "$err" | grep -q "PR# must be a positive integer"; then
+  pass=$((pass + 1))
+  echo "  PASS: non-integer PR# rejected with exit 3"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: non-integer PR# rejection (rc=$rc): $err" >&2
+fi
+
+# Bad --repo → exit 3
+set +e
+err=$(bash "$CLASSIFIER" 99999 --repo "not-valid" 2>&1 >/dev/null); rc=$?
+set -e
+if [ "$rc" = "3" ] && echo "$err" | grep -q "invalid --repo value"; then
+  pass=$((pass + 1))
+  echo "  PASS: invalid --repo value rejected with exit 3"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: invalid --repo rejection (rc=$rc): $err" >&2
+fi
+
+# Missing --fixture file → exit 3
+set +e
+err=$(bash "$CLASSIFIER" 99999 --fixture /nonexistent/path 2>&1 >/dev/null); rc=$?
+set -e
+if [ "$rc" = "3" ] && echo "$err" | grep -q "fixture file not readable"; then
+  pass=$((pass + 1))
+  echo "  PASS: missing --fixture file rejected with exit 3"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: missing fixture rejection (rc=$rc): $err" >&2
+fi
+
+echo
+if [ "$fail" -gt 0 ]; then
+  echo "check_phase_4b_classifier: $fail FAIL / $pass PASS" >&2
+  exit 1
+fi
+echo "check_phase_4b_classifier: PASS ($pass tests)"

--- a/scripts/ci/check_pr_audit_codex_clearance
+++ b/scripts/ci/check_pr_audit_codex_clearance
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# check_pr_audit_codex_clearance — unit coverage for the Codex
+# clearance branch of `.github/workflows/pr-audit.yml`.
+#
+# The audit workflow runs in GitHub Actions under `actions/github-
+# script`, so the gate logic itself is JavaScript embedded in YAML.
+# This check extracts the clearance algorithm into a small Node
+# script that mirrors the workflow's logic verbatim, then runs it
+# against six fixture payloads under
+# `scripts/ci/fixtures/pr-audit-codex-clearance/` covering:
+#
+#   - clean-clear.json            — COMMENTED on HEAD, zero P0/P1 → cleared
+#   - p1-flagged.json             — COMMENTED on HEAD with P1 finding → NOT cleared (#249 case)
+#   - p0-flagged.json             — COMMENTED on HEAD with P0 finding → NOT cleared
+#   - wrong-sha.json              — COMMENTED on an older SHA → NOT cleared
+#   - p2-only.json                — only P2/P3 inline findings → cleared (P2/P3 advisory)
+#   - quote-reply-from-author.json — author quote-reply containing `![P1 Badge]` text →
+#                                     cleared (filter scopes to bot author only)
+#
+# Inline-literal pattern: the algorithm under test is duplicated
+# from the workflow YAML into the Node script below, the same way
+# `check_workflow_parsers` carries an inline copy of the awk
+# `policy_field_awk` literal it tests. If the workflow's clearance
+# logic changes, this script must be updated in lockstep — that
+# coupling is intentional, since extracting to a separate .js file
+# would force the sync manifest to ship two files and complicate
+# downstream propagation.
+#
+# Issue: #249. Cross-reference: scripts/codex-review-check.sh
+# gate (c) and (when it lands) #235's merge-gate P1 helper.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+FIXTURES_DIR="scripts/ci/fixtures/pr-audit-codex-clearance"
+WORKFLOW=".github/workflows/pr-audit.yml"
+
+for f in "$FIXTURES_DIR" "$WORKFLOW"; do
+  if [ ! -e "$f" ]; then
+    echo "check_pr_audit_codex_clearance: missing required path: $f" >&2
+    exit 1
+  fi
+done
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "check_pr_audit_codex_clearance: SKIP — node not on PATH" >&2
+  exit 0
+fi
+
+# The mirrored algorithm. Keep this in sync with the
+# `codexCleared` computation in .github/workflows/pr-audit.yml.
+RUNNER=$(cat <<'NODE_EOF'
+const fs = require('fs');
+// With `node -e`, process.argv[1] is the first user-supplied arg
+// (there is no script-path slot to consume argv[1]).
+const fixturePath = process.argv[1];
+const fx = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+
+const codexBotLogin = fx.codex_bot_login;
+const headSha = fx.head_sha;
+const reviews = fx.reviews || [];
+const inlineComments = fx.inline_comments || [];
+
+// --- mirrored from .github/workflows/pr-audit.yml (#249) ----------
+const codexReviewsOnHead = reviews.filter(
+  r => r.user.login === codexBotLogin &&
+       headSha &&
+       r.commit_id === headSha
+);
+const codexCommentedOnHead = codexReviewsOnHead.filter(
+  r => r.state === 'COMMENTED'
+);
+
+let codexCleared = false;
+if (codexCommentedOnHead.length > 0) {
+  const latestCodexReview = codexCommentedOnHead.reduce(
+    (latest, r) => {
+      if (!latest) return r;
+      return (r.submitted_at > latest.submitted_at) ? r : latest;
+    },
+    null
+  );
+
+  const p01Regex = /!\[P[01] Badge\]/;
+  const unresolvedP01 = inlineComments.filter(
+    c => c.user && c.user.login === codexBotLogin &&
+         c.pull_request_review_id === latestCodexReview.id &&
+         p01Regex.test(c.body || '')
+  );
+
+  if (unresolvedP01.length === 0) {
+    codexCleared = true;
+  }
+}
+// --- end mirrored algorithm --------------------------------------
+
+const result = {
+  fixture: fixturePath,
+  expected_cleared: fx.expected_cleared,
+  actual_cleared: codexCleared,
+  pass: codexCleared === fx.expected_cleared,
+  description: fx.description,
+};
+process.stdout.write(JSON.stringify(result));
+NODE_EOF
+)
+
+pass=0
+fail=0
+
+for fixture in "$FIXTURES_DIR"/*.json; do
+  name=$(basename "$fixture")
+  result=$(node -e "$RUNNER" "$fixture")
+  ok=$(echo "$result" | node -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8"));console.log(d.pass?"yes":"no")')
+  desc=$(echo "$result" | node -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8"));console.log(d.description)')
+  expected=$(echo "$result" | node -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8"));console.log(d.expected_cleared)')
+  actual=$(echo "$result" | node -e 'const d=JSON.parse(require("fs").readFileSync("/dev/stdin","utf8"));console.log(d.actual_cleared)')
+
+  if [ "$ok" = "yes" ]; then
+    pass=$((pass + 1))
+    echo "  PASS: $name — $desc (expected=$expected, actual=$actual)"
+  else
+    fail=$((fail + 1))
+    echo "  FAIL: $name — $desc (expected=$expected, actual=$actual)" >&2
+  fi
+done
+
+# Structural assertion: the workflow contains the load-bearing
+# `p01Regex` literal. If someone refactors the workflow to drop the
+# P0/P1 check entirely, this assertion is the long-pole canary.
+if grep -qF '!\[P[01] Badge\]' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW carries the !\[P[01] Badge\] regex literal (clearance gate present)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW is missing the !\[P[01] Badge\] regex literal — the #249 gate may have regressed" >&2
+fi
+
+# Structural assertion: the workflow cross-references #249 in a
+# comment, anchoring the regression to the issue if grep/blame
+# leads someone here later.
+if grep -qF '#249' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW references #249 (audit-side Codex clearance issue)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW must reference #249 in a comment for traceability" >&2
+fi
+
+# Structural assertion: the per-PR review fetch is paginated. PRs
+# with a long review history would otherwise truncate at 30 items
+# and silently miss the latest Codex review on HEAD, producing a
+# false-positive policy violation (PR #255 round 2 Codex P2). The
+# fix is to use `github.paginate(github.rest.pulls.listReviews, ...)`
+# with `per_page: 100`. This assertion is structural rather than
+# algorithmic because the fixture-based tests above consume already-
+# materialised review arrays — they can't catch a pagination bug at
+# the API call site. If the workflow regresses to the unpaginated
+# `github.rest.pulls.listReviews({...})` form, this canary fails.
+if grep -qE 'github\.paginate\(\s*$' "$WORKFLOW" && \
+   grep -A1 'github\.paginate(' "$WORKFLOW" | grep -qF 'github.rest.pulls.listReviews,'; then
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW paginates pulls.listReviews via github.paginate (PR #255 P2)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW must call pulls.listReviews via github.paginate with per_page:100 (PR #255 P2)" >&2
+fi
+
+echo
+if [ "$fail" -gt 0 ]; then
+  echo "check_pr_audit_codex_clearance: $fail FAIL / $pass PASS" >&2
+  exit 1
+fi
+echo "check_pr_audit_codex_clearance: PASS ($pass tests)"

--- a/scripts/ci/check_resolve_pr_threads
+++ b/scripts/ci/check_resolve_pr_threads
@@ -1,0 +1,455 @@
+#!/usr/bin/env bash
+# check_resolve_pr_threads — regression tests for scripts/resolve-pr-threads.sh
+#
+# Closes the test gap that let PR #189's silent-undercount bug ship
+# (cursor passed as `-f cursor=null` → string "null" → API silently
+# returned wrong thread set). See #192 for the post-mortem.
+#
+# Tests stub `gh` via PATH-prepend so they exercise the script's
+# argument construction and exit-code paths without live API calls.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/resolve-pr-threads.sh"
+
+pass=0
+fail=0
+
+# ── Test 1: cursor-null typing
+# The script must send `-F cursor=null` (typed null) on the first
+# call, NOT `-f cursor=null` (string "null"). The stub captures
+# the gh argv to a side file so we can inspect what was actually sent.
+echo "resolve-pr-threads.sh cursor-null typing test (#192 regression)"
+
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "$SCRATCH"' EXIT
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+# Capture all argv to a file the test harness reads. Then return a
+# minimal valid GraphQL response so the script doesn't bail.
+echo "$@" >> "$GH_ARGV_LOG"
+case "$1" in
+  api)
+    case "$2" in
+      graphql)
+        # Match how the script's GraphQL response is shaped: empty
+        # threads list with totalCount=0 → script reports "no
+        # unresolved threads" and exits 0.
+        cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":0,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}
+JSON
+        exit 0
+        ;;
+      "repos/"*"/pulls/"*)
+        # HEAD oid fetch
+        echo "abc123def"
+        exit 0
+        ;;
+    esac
+    ;;
+  repo)
+    # `gh repo view --json nameWithOwner` fallback
+    printf '{"nameWithOwner":"test/repo"}\n'
+    exit 0
+    ;;
+esac
+exit 0
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+GH_ARGV_LOG="$SCRATCH/gh-argv.log"
+: > "$GH_ARGV_LOG"
+
+set +e
+out=$(GH_ARGV_LOG="$GH_ARGV_LOG" PATH="$SCRATCH:$PATH" bash "$SCRIPT" 99999 --repo test/repo 2>&1)
+rc=$?
+set -e
+
+# The first GraphQL call (cursor=null path) must use `-F cursor=null`
+# not `-f cursor=null`. Grep the captured argv for the typed flag.
+if grep -qE -- '-F cursor=null' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: first call uses -F cursor=null (typed null)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: expected -F cursor=null in first GraphQL call argv" >&2
+  echo "      argv log:" >&2
+  sed 's/^/        /' "$GH_ARGV_LOG" >&2
+fi
+
+# Negative assertion: must NOT use `-f cursor=null` (string "null")
+# anywhere — the prior bug.
+if grep -qE -- '-f cursor=null' "$GH_ARGV_LOG"; then
+  fail=$((fail + 1))
+  echo "  FAIL: regression — -f cursor=null (string 'null') was sent" >&2
+else
+  pass=$((pass + 1))
+  echo "  PASS: no -f cursor=null anywhere in argv (regression closed)"
+fi
+
+# ── Test 2: totalCount cross-validation catches undercount
+echo
+echo "resolve-pr-threads.sh totalCount cross-validation test"
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+case "$1" in
+  api)
+    case "$2" in
+      graphql)
+        # Simulate the bug condition: totalCount=3 but only 2 nodes
+        # returned. Script must exit 2 with the undercount-detected
+        # error (not silently report "no unresolved threads").
+        # Stub uses the new commentsFirst/commentsLast alias shape.
+        cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":3,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"T1","isResolved":true,"isOutdated":false,"commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"a","body":"x","createdAt":"2026-01-01T00:00:00Z"}]},"commentsLast":{"nodes":[{"commit":{"oid":"abc"}}]}},
+  {"id":"T2","isResolved":true,"isOutdated":false,"commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"b","body":"y","createdAt":"2026-01-01T00:00:00Z"}]},"commentsLast":{"nodes":[{"commit":{"oid":"abc"}}]}}
+]}}}}}
+JSON
+        exit 0
+        ;;
+      "repos/"*"/pulls/"*)
+        echo "abc123def"; exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+set +e
+out=$(PATH="$SCRATCH:$PATH" bash "$SCRIPT" 99999 --repo test/repo 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" = "2" ] && echo "$out" | grep -q "GraphQL count mismatch"; then
+  pass=$((pass + 1))
+  echo "  PASS: totalCount > returned → exit 2 with count-mismatch error"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: undercount should exit 2 (rc=$rc)" >&2
+  echo "$out" | sed 's/^/      /' >&2
+fi
+
+# ── Test 3: equal totalCount and returned → no undercount error
+echo
+echo "resolve-pr-threads.sh equal-count happy-path test"
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+case "$1" in
+  api)
+    case "$2" in
+      graphql)
+        cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":2,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"T1","isResolved":true,"isOutdated":false,"commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"a","body":"x","createdAt":"2026-01-01T00:00:00Z"}]},"commentsLast":{"nodes":[{"commit":{"oid":"abc"}}]}},
+  {"id":"T2","isResolved":true,"isOutdated":false,"commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"b","body":"y","createdAt":"2026-01-01T00:00:00Z"}]},"commentsLast":{"nodes":[{"commit":{"oid":"abc"}}]}}
+]}}}}}
+JSON
+        exit 0
+        ;;
+      "repos/"*"/pulls/"*)
+        echo "abc123def"; exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+set +e
+out=$(PATH="$SCRATCH:$PATH" bash "$SCRIPT" 99999 --repo test/repo 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" = "0" ] && echo "$out" | grep -q "No unresolved threads"; then
+  pass=$((pass + 1))
+  echo "  PASS: totalCount == returned (all resolved) → exit 0 + clean message"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: equal counts + all resolved should exit 0 (rc=$rc)" >&2
+  echo "$out" | sed 's/^/      /' >&2
+fi
+
+# ── Test 4: defensive isResolved != true catches null
+echo
+echo "resolve-pr-threads.sh defensive isResolved-null test"
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+case "$1" in
+  api)
+    case "$2" in
+      graphql)
+        # isResolved is null on one thread — defensive `!= true`
+        # filter must treat it as unresolved and surface it.
+        cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"T1","isResolved":null,"isOutdated":false,"commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"a","body":"x","createdAt":"2026-01-01T00:00:00Z"}]},"commentsLast":{"nodes":[{"commit":{"oid":"abc"}}]}}
+]}}}}}
+JSON
+        exit 0
+        ;;
+      "repos/"*"/pulls/"*)
+        echo "abc123def"; exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+set +e
+out=$(PATH="$SCRATCH:$PATH" bash "$SCRIPT" 99999 --repo test/repo 2>&1)
+rc=$?
+set -e
+
+# In list mode (default), unresolved threads exit 3 with the listing.
+if [ "$rc" = "3" ] && echo "$out" | grep -q "Unresolved threads on test/repo#99999"; then
+  pass=$((pass + 1))
+  echo "  PASS: null isResolved treated as unresolved (defensive)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: null isResolved should be treated as unresolved (rc=$rc)" >&2
+  echo "$out" | sed 's/^/      /' >&2
+fi
+
+# ── Test 4b: totalCount cross-validation also fails on over-count
+# CR Major on PR #194 r2 — a duplicate-page / cursor-reset regression
+# in the pagination loop would produce returned > totalCount; the
+# equality check must fail on that case too, not just under-count.
+echo
+echo "resolve-pr-threads.sh totalCount over-count detection (CR Major on #194)"
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+case "$1" in
+  api)
+    case "$2" in
+      graphql)
+        # totalCount=1 but 2 nodes returned (simulated duplicate page).
+        cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"T1","isResolved":true,"isOutdated":false,"commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"a","body":"x","createdAt":"2026-01-01T00:00:00Z"}]},"commentsLast":{"nodes":[{"commit":{"oid":"abc"}}]}},
+  {"id":"T1","isResolved":true,"isOutdated":false,"commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"a","body":"x","createdAt":"2026-01-01T00:00:00Z"}]},"commentsLast":{"nodes":[{"commit":{"oid":"abc"}}]}}
+]}}}}}
+JSON
+        exit 0
+        ;;
+      "repos/"*"/pulls/"*)
+        echo "abc123def"; exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+set +e
+out=$(PATH="$SCRATCH:$PATH" bash "$SCRIPT" 99999 --repo test/repo 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" = "2" ] && echo "$out" | grep -q "GraphQL count mismatch"; then
+  pass=$((pass + 1))
+  echo "  PASS: returned > totalCount → exit 2 with count-mismatch error"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: over-count should exit 2 (rc=$rc)" >&2
+  echo "$out" | sed 's/^/      /' >&2
+fi
+
+# ── Test 5: HEAD-anchor uses commentsLast (codex P2 #194 regression)
+# A thread where commentsFirst points at an old commit and commentsLast
+# points at the truly-latest one. The script must surface the
+# commentsLast oid as the thread's commit_oid for the HEAD-anchor
+# check, NOT commentsFirst's. Prior shape (`comments(first: 50)` +
+# `[-1]`) would silently return the wrong oid for >50-comment threads.
+echo
+echo "resolve-pr-threads.sh HEAD-anchor uses commentsLast (codex P2 on #194)"
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+case "$1" in
+  api)
+    case "$2" in
+      graphql)
+        # commentsFirst.commit.oid would be "OLDOID" (anchored to
+        # original review commit), commentsLast.commit.oid is "NEWOID"
+        # (truly-latest comment from a much later push). The script
+        # must read commit_oid from commentsLast.
+        cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"T1","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"src/foo.ts","body":"original review","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"NEWOIDcurrent"}}]}}
+]}}}}}
+JSON
+        exit 0
+        ;;
+      "repos/"*"/pulls/"*)
+        echo "NEWOIDcurrent"; exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+set +e
+out=$(PATH="$SCRATCH:$PATH" bash "$SCRIPT" 99999 --repo test/repo --auto-resolve-bots --dry-run 2>&1)
+rc=$?
+set -e
+
+# With --dry-run --auto-resolve-bots, the script reports "would resolve"
+# only when commit_oid matches HEAD_OID. If it correctly picked
+# commentsLast's "NEWOIDcurrent" (matching HEAD_OID), the output
+# includes "would resolve". If it picked commentsFirst's commit (which
+# we don't even populate here), it would skip-as-stale.
+if echo "$out" | grep -qE "WOULD RESOLVE|would-resolve: [1-9]"; then
+  pass=$((pass + 1))
+  echo "  PASS: HEAD anchor read from commentsLast (current-HEAD bot thread is auto-resolvable)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: expected would-resolve output (rc=$rc)" >&2
+  echo "$out" | sed 's/^/      /' >&2
+fi
+
+# ── Test 6: two-page pagination + cursor accumulation
+# CR Major on PR #194 r3 — without exercising the multi-page path,
+# a paginator regression on the happy path stays green. Stub returns
+# page 1 with hasNextPage=true + endCursor="CURSOR1", page 2 with
+# hasNextPage=false. Final state: 2 nodes accumulated, totalCount=2,
+# script exits 0. Also asserts the 2nd call's argv contains
+# `-f cursor=CURSOR1` (the post-first-call branch is exercised).
+echo
+echo "resolve-pr-threads.sh two-page pagination test (CR Major on #194)"
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+echo "$@" >> "$GH_ARGV_LOG"
+case "$1" in
+  api)
+    case "$2" in
+      graphql)
+        # Determine page from whether `cursor=CURSOR1` is in argv.
+        if [[ " $* " == *" cursor=CURSOR1 "* ]]; then
+          # Page 2: remaining node, no next page.
+          cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":2,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"T2","isResolved":true,"isOutdated":false,"commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"b","body":"y","createdAt":"2026-01-01T00:00:00Z"}]},"commentsLast":{"nodes":[{"commit":{"oid":"abc"}}]}}
+]}}}}}
+JSON
+        else
+          # Page 1: first node, hasNextPage=true.
+          cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":2,"pageInfo":{"hasNextPage":true,"endCursor":"CURSOR1"},"nodes":[
+  {"id":"T1","isResolved":true,"isOutdated":false,"commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"a","body":"x","createdAt":"2026-01-01T00:00:00Z"}]},"commentsLast":{"nodes":[{"commit":{"oid":"abc"}}]}}
+]}}}}}
+JSON
+        fi
+        exit 0
+        ;;
+      "repos/"*"/pulls/"*)
+        echo "abc123def"; exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+GH_ARGV_LOG="$SCRATCH/gh-argv-page.log"
+: > "$GH_ARGV_LOG"
+
+set +e
+out=$(GH_ARGV_LOG="$GH_ARGV_LOG" PATH="$SCRATCH:$PATH" bash "$SCRIPT" 99999 --repo test/repo 2>&1)
+rc=$?
+set -e
+
+# Must (a) exit 0 with "no unresolved threads" (both nodes are
+# isResolved=true and totalCount=2 matches accumulated), (b) include
+# `-f cursor=CURSOR1` in the second-page call argv.
+if [ "$rc" = "0" ] && echo "$out" | grep -q "No unresolved threads" && grep -qE -- '-f cursor=CURSOR1' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: page 2 fetched with -f cursor=CURSOR1; accumulated count matches totalCount"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: pagination regression (rc=$rc)" >&2
+  echo "      output:" >&2; echo "$out" | sed 's/^/        /' >&2
+  echo "      argv log:" >&2; sed 's/^/        /' "$GH_ARGV_LOG" >&2
+fi
+
+# ── Test 7: keyring fallback when neither preflight nor GH_TOKEN set
+# CR Major on PR #194 r3 — the prior `GH_TOKEN="${VAR:-${OTHER:-}}"`
+# pattern set GH_TOKEN to empty when both unset, blocking gh's
+# keyring fallback. The conditional gh_read wrapper must NOT pass
+# GH_TOKEN= (empty) when no PAT is available.
+echo
+echo "resolve-pr-threads.sh keyring fallback (no empty GH_TOKEN trap)"
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+echo "ENV_GH_TOKEN_PRESENT=${GH_TOKEN+yes}" >> "$GH_ARGV_LOG"
+echo "ENV_GH_TOKEN_VALUE=${GH_TOKEN:-<unset>}" >> "$GH_ARGV_LOG"
+case "$1" in
+  api)
+    case "$2" in
+      graphql)
+        cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":0,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}
+JSON
+        exit 0
+        ;;
+      "repos/"*"/pulls/"*)
+        echo "abc123def"; exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+GH_ARGV_LOG="$SCRATCH/gh-argv-keyring.log"
+: > "$GH_ARGV_LOG"
+
+# Crucially: unset both PAT vars in the subshell environment.
+set +e
+out=$(GH_ARGV_LOG="$GH_ARGV_LOG" PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$SCRIPT" 99999 --repo test/repo 2>&1)
+rc=$?
+set -e
+
+# Stub captured env state. Assert GH_TOKEN was NOT set (or NOT empty).
+# An empty GH_TOKEN would show ENV_GH_TOKEN_PRESENT=yes + ENV_GH_TOKEN_VALUE=<unset>
+# (which renders as just the unset placeholder). Need to confirm absence
+# of the "ENV_GH_TOKEN_PRESENT=yes" line on graphql calls.
+if [ "$rc" = "0" ] && ! grep -q "^ENV_GH_TOKEN_PRESENT=yes$" "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: GH_TOKEN unset (not empty) when no PAT available — keyring fallback engaged"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: GH_TOKEN was set (possibly empty) — keyring fallback would be blocked (rc=$rc)" >&2
+  echo "      env capture:" >&2; sed 's/^/        /' "$GH_ARGV_LOG" >&2
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "check_resolve_pr_threads: PASS ($pass tests)"
+  exit 0
+else
+  echo "check_resolve_pr_threads: FAIL ($fail of $((pass + fail)) tests)" >&2
+  exit 1
+fi

--- a/scripts/ci/check_sweep_unresolved_feedback
+++ b/scripts/ci/check_sweep_unresolved_feedback
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# scripts/ci/check_sweep_unresolved_feedback
+#
+# Runs unit tests for the #236 weekly feedback sweep pipeline:
+#
+#   scripts/sweep-unresolved-feedback/enumerate.sh
+#   scripts/sweep-unresolved-feedback/render.sh
+#
+# The tests stub `gh` via a PATH shim, so this check is hermetic: no
+# network, no real auth. Mirrors the pattern of check_gh_as_author /
+# check_sync_overrides.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+REQUIRED_FILES=(
+  "scripts/sweep-unresolved-feedback/enumerate.sh"
+  "scripts/sweep-unresolved-feedback/render.sh"
+  "scripts/sweep-unresolved-feedback/target-repos.txt"
+  ".github/workflows/weekly-feedback-sweep.yml"
+  "tests/test_sweep_unresolved_feedback.sh"
+)
+
+FAILED=0
+for rel in "${REQUIRED_FILES[@]}"; do
+  full="$REPO_ROOT/$rel"
+  if [ ! -f "$full" ]; then
+    echo "check_sweep_unresolved_feedback: ERROR missing $rel" >&2
+    FAILED=1
+  fi
+done
+
+# Exec bit on the scripts.
+for rel in scripts/sweep-unresolved-feedback/enumerate.sh scripts/sweep-unresolved-feedback/render.sh; do
+  full="$REPO_ROOT/$rel"
+  if [ -f "$full" ] && [ ! -x "$full" ]; then
+    echo "check_sweep_unresolved_feedback: ERROR $rel not executable (chmod +x)" >&2
+    FAILED=1
+  fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "check_sweep_unresolved_feedback: FAIL (file presence)"
+  exit 1
+fi
+
+TEST="$REPO_ROOT/tests/test_sweep_unresolved_feedback.sh"
+echo "check_sweep_unresolved_feedback: running $TEST"
+if ! bash "$TEST"; then
+  echo "check_sweep_unresolved_feedback: FAIL (tests)" >&2
+  exit 1
+fi
+
+echo "check_sweep_unresolved_feedback: PASS"
+exit 0

--- a/scripts/ci/check_sync_manifest
+++ b/scripts/ci/check_sync_manifest
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# check_sync_manifest
+#
+# Validates .mergepath-sync.yml — the propagation manifest read by
+# scripts/sync-to-downstream.sh. See #168 for the design.
+#
+# Checks (CI must run on a runner with yq installed; the workflow
+# step installs it via Homebrew/apt before invoking this script):
+#
+#   1. Manifest file exists and parses as YAML.
+#   2. Schema version matches what sync-to-downstream.sh supports.
+#   3. Every consumer has a non-empty name and repo.
+#   4. Every path entry's `path` field exists on disk in this repo
+#      (catches typos and removed files before they cause silent
+#      audit misses on every consumer).
+#   5. Every path entry's `type` is one of: canonical, kit, templated.
+#   6. Every path's `consumers` is either the literal "all" or a list
+#      of consumer names that exist in the consumers block.
+#
+# This check is read-only and does NOT contact downstream repos —
+# that's the audit script's job and is too slow for CI.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MANIFEST="$REPO_ROOT/.mergepath-sync.yml"
+SUPPORTED_VERSION=1
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "FAIL: yq is required (mikefarah/yq v4+). Install via 'brew install yq' or apt."
+  exit 2
+fi
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "FAIL: .mergepath-sync.yml is missing at repo root"
+  exit 1
+fi
+
+# Parse-check: yq exits non-zero on a malformed YAML.
+if ! yq '.' "$MANIFEST" >/dev/null 2>&1; then
+  echo "FAIL: .mergepath-sync.yml does not parse as YAML"
+  yq '.' "$MANIFEST" || true
+  exit 1
+fi
+
+FAILED=0
+
+# 2. version
+version=$(yq '.version' "$MANIFEST")
+if [ "$version" != "$SUPPORTED_VERSION" ]; then
+  echo "FAIL: manifest version is '$version', expected $SUPPORTED_VERSION"
+  FAILED=1
+fi
+
+# 3. consumers shape
+consumer_count=$(yq '.consumers | length' "$MANIFEST")
+if [ "$consumer_count" -lt 1 ]; then
+  echo "FAIL: consumers list is empty"
+  FAILED=1
+fi
+
+while IFS=$'\t' read -r name repo; do
+  if [ -z "$name" ] || [ "$name" = "null" ]; then
+    echo "FAIL: a consumer entry has no name (repo=$repo)"
+    FAILED=1
+  fi
+  if [ -z "$repo" ] || [ "$repo" = "null" ]; then
+    echo "FAIL: consumer '$name' has no repo"
+    FAILED=1
+  fi
+done < <(yq -r '.consumers[] | (.name + "\t" + .repo)' "$MANIFEST")
+
+# Build a set of valid consumer names for cross-check
+valid_consumers=$(yq -r '.consumers[].name' "$MANIFEST" | tr '\n' ',')
+
+# 4-6. path entries
+while IFS=$'\t' read -r path type consumers; do
+  [ -z "$path" ] && continue
+
+  # 4: path exists on disk
+  case "$type" in
+    kit)
+      target="$REPO_ROOT/${path%/}"
+      if [ ! -d "$target" ]; then
+        echo "FAIL: kit path '$path' is not a directory in this repo"
+        FAILED=1
+      fi
+      ;;
+    canonical|templated)
+      target="$REPO_ROOT/$path"
+      if [ ! -f "$target" ]; then
+        echo "FAIL: $type path '$path' does not exist as a file in this repo"
+        FAILED=1
+      fi
+      ;;
+    *)
+      echo "FAIL: path '$path' has unknown type '$type' (must be canonical, kit, or templated)"
+      FAILED=1
+      ;;
+  esac
+
+  # 6: consumers field
+  if [ "$consumers" = "all" ]; then
+    :
+  else
+    IFS=',' read -ra consumer_arr <<< "$consumers"
+    for c in "${consumer_arr[@]}"; do
+      if [[ ",$valid_consumers," != *",$c,"* ]]; then
+        echo "FAIL: path '$path' references unknown consumer '$c'"
+        FAILED=1
+      fi
+    done
+  fi
+done < <(yq -r '
+  .paths[]
+  | (.path + "\t" + .type + "\t"
+     + (.consumers | (select(tag == "!!str") // (join(","))) | tostring))
+' "$MANIFEST")
+
+if [ "$FAILED" -eq 1 ]; then
+  echo "check_sync_manifest: FAIL"
+  exit 1
+fi
+
+echo "check_sync_manifest: PASS ($consumer_count consumer(s), $(yq '.paths | length' "$MANIFEST") path entry/entries)"
+exit 0

--- a/scripts/ci/check_sync_overrides
+++ b/scripts/ci/check_sync_overrides
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# scripts/ci/check_sync_overrides — CI entry point for #200 tests.
+#
+# Wraps tests/test_sync_overrides.sh so the repo_lint workflow's
+# "run all scripts/ci/check_*" loop picks it up. Mirrors the
+# pattern used by the other check_* scripts in this directory.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_sync_overrides.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  # Missing test script is a hard error, not a skip — silent-skip
+  # would let an accidental delete/rename disable this check
+  # without surfacing in CI. CodeRabbit ⚠️ Major on PR #228 round 4.
+  echo "check_sync_overrides: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"

--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -131,6 +131,75 @@ src/auth/login.ts'
 assert_eq "end-to-end: parse output piped into matcher" "$want" "$got"
 
 echo
+echo "policy_field (top-level scalar) tests — for phase_4b_default (#185)"
+
+# Inline copy of the same awk policy_field uses inside
+# scripts/codex-review-check.sh. Keeping the test in lockstep with the
+# parser shape — if the parser changes, this awk literal needs the same
+# update. Documented inline rather than sourced from the script because
+# sourcing codex-review-check.sh runs its full top-level logic.
+policy_field_awk='
+  /^[^[:space:]]/ && $1 == field":" {
+    sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+    gsub(/^"/, "", $0)
+    gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+    gsub(/[[:space:]]*#.*$/, "", $0)
+    sub(/[[:space:]]+$/, "", $0)
+    print
+    exit
+  }
+'
+
+# Fixture: field present at top level, no comments.
+got=$(printf '%s\n' "phase_4b_default: complex-changes" | awk -v field="phase_4b_default" "$policy_field_awk")
+assert_eq "policy_field reads phase_4b_default (bare value)" "complex-changes" "$got"
+
+# Fixture: field with a trailing inline comment.
+got=$(printf '%s\n' "phase_4b_default: always   # opt in to strict mode" | awk -v field="phase_4b_default" "$policy_field_awk")
+assert_eq "policy_field strips trailing inline comment" "always" "$got"
+
+# Fixture: field missing entirely (existing-consumer migration path).
+got=$(printf 'codex:\n  enabled: true\n' | awk -v field="phase_4b_default" "$policy_field_awk")
+assert_eq "policy_field returns empty when field absent (default falls to fallback-only)" "" "$got"
+
+# Fixture: field at top level surrounded by other top-level fields.
+mixed=$(printf 'external_review_threshold: 300\nphase_4b_default: fallback-only\ncoderabbit:\n  enabled: false\n')
+got=$(echo "$mixed" | awk -v field="phase_4b_default" "$policy_field_awk")
+assert_eq "policy_field reads field amid other top-level fields" "fallback-only" "$got"
+
+# Fixture: field with double quotes (matches the parser's quote-stripping).
+got=$(printf '%s\n' 'phase_4b_default: "complex-changes"' | awk -v field="phase_4b_default" "$policy_field_awk")
+assert_eq "policy_field strips surrounding quotes" "complex-changes" "$got"
+
+# Regression: nested same-named key under a parent block must NOT match
+# (Codex P2 on PR #189 — top-level lookup should be anchored to the
+# document root, not match indented occurrences of the same field name).
+nested=$(printf 'codex:\n  phase_4b_default: should-not-match\nphase_4b_default: complex-changes\n')
+got=$(echo "$nested" | awk -v field="phase_4b_default" "$policy_field_awk")
+assert_eq "policy_field ignores nested same-named keys; reads only top-level" "complex-changes" "$got"
+
+# Regression: nested key with NO top-level twin must return empty
+# (the parser shouldn't fall through to the indented match).
+nested_only=$(printf 'codex:\n  phase_4b_default: nested-only\n')
+got=$(echo "$nested_only" | awk -v field="phase_4b_default" "$policy_field_awk")
+assert_eq "policy_field returns empty when only a nested same-named key exists" "" "$got"
+
+# Fixture: real mergepath review-policy.yml has the field set; verify
+# end-to-end against the actual file so a typo in the schema-doc
+# example doesn't pass the unit fixtures while breaking the real read.
+got=$(awk -v field="phase_4b_default" "$policy_field_awk" "$ROOT/.github/review-policy.yml")
+case "$got" in
+  fallback-only|complex-changes|always)
+    pass=$((pass + 1))
+    echo "  PASS: real .github/review-policy.yml has a valid phase_4b_default value ('$got')"
+    ;;
+  *)
+    fail=$((fail + 1))
+    echo "  FAIL: real .github/review-policy.yml phase_4b_default is missing or invalid (got '$got'; expected one of fallback-only / complex-changes / always)"
+    ;;
+esac
+
+echo
 if [ "$fail" -gt 0 ]; then
   echo "check_workflow_parsers: $fail FAIL / $pass PASS" >&2
   exit 1

--- a/scripts/ci/fixtures/disagreement-detector/dismissed-approved.json
+++ b/scripts/ci/fixtures/disagreement-detector/dismissed-approved.json
@@ -1,0 +1,34 @@
+{
+  "description": "DISMISSED APPROVED from reviewer A on HEAD + live CHANGES_REQUESTED from reviewer B on HEAD. DISMISSED must not satisfy hasApproval, so this is NOT a disagreement (one-sided CHANGES_REQUESTED only).",
+  "headSha": "feedfacebeef000000000000000000000000feed",
+  "hasLabel": false,
+  "reviewerAccounts": [
+    "nathanpayne-claude",
+    "nathanpayne-codex",
+    "nathanpayne-cursor"
+  ],
+  "expected_decision": "noop",
+  "reviews": [
+    {
+      "id": 30,
+      "state": "APPROVED",
+      "commit_id": "feedfacebeef000000000000000000000000feed",
+      "submitted_at": "2026-05-12T08:00:00Z",
+      "user": { "login": "nathanpayne-cursor" }
+    },
+    {
+      "id": 31,
+      "state": "DISMISSED",
+      "commit_id": "feedfacebeef000000000000000000000000feed",
+      "submitted_at": "2026-05-12T08:30:00Z",
+      "user": { "login": "nathanpayne-cursor" }
+    },
+    {
+      "id": 32,
+      "state": "CHANGES_REQUESTED",
+      "commit_id": "feedfacebeef000000000000000000000000feed",
+      "submitted_at": "2026-05-12T09:00:00Z",
+      "user": { "login": "nathanpayne-codex" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/disagreement-detector/live-disagreement.json
+++ b/scripts/ci/fixtures/disagreement-detector/live-disagreement.json
@@ -1,0 +1,27 @@
+{
+  "description": "Two different reviewers BOTH on current HEAD with conflicting states — the real disagreement case, regression-net. Should apply.",
+  "headSha": "abc333liveheadsha333333333333333333333333",
+  "hasLabel": false,
+  "reviewerAccounts": [
+    "nathanpayne-claude",
+    "nathanpayne-codex",
+    "nathanpayne-cursor"
+  ],
+  "expected_decision": "apply",
+  "reviews": [
+    {
+      "id": 20,
+      "state": "APPROVED",
+      "commit_id": "abc333liveheadsha333333333333333333333333",
+      "submitted_at": "2026-05-12T09:00:00Z",
+      "user": { "login": "nathanpayne-cursor" }
+    },
+    {
+      "id": 21,
+      "state": "CHANGES_REQUESTED",
+      "commit_id": "abc333liveheadsha333333333333333333333333",
+      "submitted_at": "2026-05-12T10:00:00Z",
+      "user": { "login": "nathanpayne-codex" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/disagreement-detector/same-reviewer-reversal.json
+++ b/scripts/ci/fixtures/disagreement-detector/same-reviewer-reversal.json
@@ -1,0 +1,27 @@
+{
+  "description": "Same reviewer reversed CHANGES_REQUESTED to APPROVED on HEAD. Latest-per-reviewer collapses to APPROVED; no disagreement.",
+  "headSha": "deafbeef00headsha00000000000000000000dead",
+  "hasLabel": false,
+  "reviewerAccounts": [
+    "nathanpayne-claude",
+    "nathanpayne-codex",
+    "nathanpayne-cursor"
+  ],
+  "expected_decision": "noop",
+  "reviews": [
+    {
+      "id": 10,
+      "state": "CHANGES_REQUESTED",
+      "commit_id": "old111staleshastaleshastalesha111111111",
+      "submitted_at": "2026-05-09T08:00:00Z",
+      "user": { "login": "nathanpayne-codex" }
+    },
+    {
+      "id": 11,
+      "state": "APPROVED",
+      "commit_id": "deafbeef00headsha00000000000000000000dead",
+      "submitted_at": "2026-05-12T15:00:00Z",
+      "user": { "login": "nathanpayne-codex" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/disagreement-detector/stale-changes-then-fresh-approval-with-label.json
+++ b/scripts/ci/fixtures/disagreement-detector/stale-changes-then-fresh-approval-with-label.json
@@ -1,0 +1,27 @@
+{
+  "description": "Same as stale-changes-then-fresh-approval but label was previously applied — should remove (auto-clear after the disagreement is resolved on a fresher HEAD).",
+  "headSha": "abc222headcurrentsha22222222222222222222",
+  "hasLabel": true,
+  "reviewerAccounts": [
+    "nathanpayne-claude",
+    "nathanpayne-codex",
+    "nathanpayne-cursor"
+  ],
+  "expected_decision": "remove",
+  "reviews": [
+    {
+      "id": 1,
+      "state": "CHANGES_REQUESTED",
+      "commit_id": "fb0821000000000000000000000000000000fb08",
+      "submitted_at": "2026-05-10T10:00:00Z",
+      "user": { "login": "nathanpayne-codex" }
+    },
+    {
+      "id": 2,
+      "state": "APPROVED",
+      "commit_id": "abc222headcurrentsha22222222222222222222",
+      "submitted_at": "2026-05-12T11:00:00Z",
+      "user": { "login": "nathanpayne-cursor" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/disagreement-detector/stale-changes-then-fresh-approval.json
+++ b/scripts/ci/fixtures/disagreement-detector/stale-changes-then-fresh-approval.json
@@ -1,0 +1,27 @@
+{
+  "description": "Round-1 CHANGES_REQUESTED on stale SHA from reviewer A + round-2 APPROVED on HEAD from reviewer B (the PR #256 scenario from #259). No live disagreement.",
+  "headSha": "abc222headcurrentsha22222222222222222222",
+  "hasLabel": false,
+  "reviewerAccounts": [
+    "nathanpayne-claude",
+    "nathanpayne-codex",
+    "nathanpayne-cursor"
+  ],
+  "expected_decision": "noop",
+  "reviews": [
+    {
+      "id": 1,
+      "state": "CHANGES_REQUESTED",
+      "commit_id": "fb0821000000000000000000000000000000fb08",
+      "submitted_at": "2026-05-10T10:00:00Z",
+      "user": { "login": "nathanpayne-codex" }
+    },
+    {
+      "id": 2,
+      "state": "APPROVED",
+      "commit_id": "abc222headcurrentsha22222222222222222222",
+      "submitted_at": "2026-05-12T11:00:00Z",
+      "user": { "login": "nathanpayne-cursor" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/phase-4b/concurrency.json
+++ b/scripts/ci/fixtures/phase-4b/concurrency.json
@@ -1,0 +1,13 @@
+{
+  "body": "Wraps the application-claim flow in a Firestore transaction with a tombstone re-check.",
+  "files": [
+    {
+      "filename": "src/services/applications/claim.ts",
+      "patch": "@@ -10,5 +10,15 @@\n export async function claim(id: string, owner: string) {\n-  const ref = db.doc(`applications/${id}`);\n-  await ref.update({ owner });\n+  const ref = db.doc(`applications/${id}`);\n+  return runTransaction(db, async (tx) => {\n+    const snap = await tx.get(ref);\n+    if (!snap.exists()) throw new Error(\"gone\");\n+    if (snap.data().owner_uid !== owner) throw new Error(\"already claimed\");\n+    tx.update(ref, { owner, claimedAt: Date.now() });\n+  });\n }"
+    },
+    {
+      "filename": "src/transactions/index.ts",
+      "patch": "@@ -1 +1,2 @@\n+export { claim } from \"../services/applications/claim\";"
+    }
+  ]
+}

--- a/scripts/ci/fixtures/phase-4b/cross-cutting.json
+++ b/scripts/ci/fixtures/phase-4b/cross-cutting.json
@@ -1,0 +1,9 @@
+{
+  "body": "Renames `Application.status` to `Application.lifecycle_state` across types + service layer + UI.",
+  "files": [
+    {"filename": "src/types/application.ts", "patch": "@@ -1,3 +1,3 @@\n-export type Application = { id: string, status: string };\n+export type Application = { id: string, lifecycle_state: string };"},
+    {"filename": "src/services/applications/get.ts", "patch": "@@ -3,3 +3,3 @@\n-  return { id, status };\n+  return { id, lifecycle_state };"},
+    {"filename": "src/components/ApplicationCard.tsx", "patch": "@@ -2,3 +2,3 @@\n-  <span>{app.status}</span>\n+  <span>{app.lifecycle_state}</span>"},
+    {"filename": "tests/applications.test.ts", "patch": "@@ -1,3 +1,3 @@\n-expect(app.status).toBe(\"draft\");\n+expect(app.lifecycle_state).toBe(\"draft\");"}
+  ]
+}

--- a/scripts/ci/fixtures/phase-4b/invariant.json
+++ b/scripts/ci/fixtures/phase-4b/invariant.json
@@ -1,0 +1,9 @@
+{
+  "body": "Tightens the owner_uid invariant check on application updates: now also verified inside the transaction body, not just the upfront ownership check.",
+  "files": [
+    {
+      "filename": "src/validation/owner-uid.ts",
+      "patch": "@@ -5,3 +5,8 @@\n+export function assertOwnerUid(snap: DocumentSnapshot, expected: string) {\n+  const actual = snap.data()?.owner_uid;\n+  if (actual !== expected) throw new OwnerMismatchError({ expected, actual });\n+}"
+    }
+  ]
+}

--- a/scripts/ci/fixtures/phase-4b/no-trigger.json
+++ b/scripts/ci/fixtures/phase-4b/no-trigger.json
@@ -1,0 +1,7 @@
+{
+  "body": "Bumps the README copyright year. No code changes.",
+  "files": [
+    {"filename": "README.md", "patch": "@@ -1,3 +1,3 @@\n-© 2025 Nathan Payne.\n+© 2026 Nathan Payne."},
+    {"filename": "LICENSE", "patch": "@@ -1,3 +1,3 @@\n-Copyright 2025\n+Copyright 2026"}
+  ]
+}

--- a/scripts/ci/fixtures/phase-4b/prompt-design.json
+++ b/scripts/ci/fixtures/phase-4b/prompt-design.json
@@ -1,0 +1,9 @@
+{
+  "body": "Adds an `experience-extraction.v3.md` system prompt + extends the few-shot examples for industry-tag normalization.",
+  "files": [
+    {
+      "filename": "src/prompts/experience-extraction.v3.md",
+      "patch": "@@ -0,0 +1,40 @@\n+# Experience Extraction Prompt v3\n+\n+You normalize free-text resume bullets into structured experience records.\n+\n+## Few-shot examples\n+\n+Input: \"Led a 5-person team in launching a new product, AND owned the GTM motion.\"\n+Output: { team_size: 5, scope: [\"product launch\", \"GTM\"] }"
+    }
+  ]
+}

--- a/scripts/ci/fixtures/phase-4b/root-files-only.json
+++ b/scripts/ci/fixtures/phase-4b/root-files-only.json
@@ -1,0 +1,8 @@
+{
+  "body": "Bumps the year on three root docs.",
+  "files": [
+    {"filename": "README.md", "patch": "@@ -1,3 +1,3 @@\n-© 2025 Nathan Payne.\n+© 2026 Nathan Payne."},
+    {"filename": "LICENSE", "patch": "@@ -1,3 +1,3 @@\n-Copyright 2025\n+Copyright 2026"},
+    {"filename": "CONTRIBUTING.md", "patch": "@@ -1,3 +1,3 @@\n-In 2025\n+In 2026"}
+  ]
+}

--- a/scripts/ci/fixtures/phase-4b/state-machine.json
+++ b/scripts/ci/fixtures/phase-4b/state-machine.json
@@ -1,0 +1,9 @@
+{
+  "body": "Adds the application discriminated union to the route reducer.",
+  "files": [
+    {
+      "filename": "src/routes/application.ts",
+      "patch": "@@ -1,3 +1,8 @@\n+type ApplicationState =\n+  | { kind: \"draft\", id: string }\n+  | { kind: \"submitted\", id: string, submittedAt: number }\n+  | { kind: \"reviewed\", id: string, reviewedBy: string };\n+\n export function reduce(s: ApplicationState, event: AppEvent) {"
+    }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/clean-clear.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/clean-clear.json
@@ -1,0 +1,23 @@
+{
+  "description": "Codex COMMENTED on HEAD with zero P0/P1 inline findings → cleared",
+  "expected_cleared": true,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "reviews": [
+    {
+      "id": 1001,
+      "state": "COMMENTED",
+      "commit_id": "deadbeefcafe1234567890abcdef1234567890ab",
+      "submitted_at": "2026-05-12T10:00:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ],
+  "inline_comments": [
+    {
+      "id": 5001,
+      "pull_request_review_id": 1001,
+      "body": "Nice work here — looks clean.",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/p0-flagged.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/p0-flagged.json
@@ -1,0 +1,23 @@
+{
+  "description": "Codex COMMENTED on HEAD with a P0 inline finding → NOT cleared (parity with P1 case)",
+  "expected_cleared": false,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "reviews": [
+    {
+      "id": 1001,
+      "state": "COMMENTED",
+      "commit_id": "deadbeefcafe1234567890abcdef1234567890ab",
+      "submitted_at": "2026-05-12T10:00:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ],
+  "inline_comments": [
+    {
+      "id": 5001,
+      "pull_request_review_id": 1001,
+      "body": "![P0 Badge](https://example.com/p0.svg) Credential leak: this prints the API key to stdout.",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/p1-flagged.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/p1-flagged.json
@@ -1,0 +1,23 @@
+{
+  "description": "Codex COMMENTED on HEAD but with an unresolved P1 inline finding → NOT cleared (the #249 regression case)",
+  "expected_cleared": false,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "reviews": [
+    {
+      "id": 1001,
+      "state": "COMMENTED",
+      "commit_id": "deadbeefcafe1234567890abcdef1234567890ab",
+      "submitted_at": "2026-05-12T10:00:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ],
+  "inline_comments": [
+    {
+      "id": 5001,
+      "pull_request_review_id": 1001,
+      "body": "![P1 Badge](https://example.com/p1.svg) This call site can retry endlessly when the upstream returns 5xx.",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/p2-only.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/p2-only.json
@@ -1,0 +1,29 @@
+{
+  "description": "Codex COMMENTED on HEAD with only P2/P3 findings (no P0/P1) → cleared (matches merge-gate semantics: P2/P3 are advisory)",
+  "expected_cleared": true,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "reviews": [
+    {
+      "id": 1001,
+      "state": "COMMENTED",
+      "commit_id": "deadbeefcafe1234567890abcdef1234567890ab",
+      "submitted_at": "2026-05-12T10:00:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ],
+  "inline_comments": [
+    {
+      "id": 5001,
+      "pull_request_review_id": 1001,
+      "body": "![P2 Badge](https://example.com/p2.svg) Consider extracting this into a helper.",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    },
+    {
+      "id": 5002,
+      "pull_request_review_id": 1001,
+      "body": "![P3 Badge](https://example.com/p3.svg) Nit: trailing whitespace.",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/quote-reply-from-author.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/quote-reply-from-author.json
@@ -1,0 +1,23 @@
+{
+  "description": "Codex COMMENTED on HEAD; the only `![P1 Badge]`-bearing inline is a human quote-reply on a Codex thread → cleared (replies inherit pull_request_review_id but are not bot-authored; matches the nathanpaynedotcom#180 r3 fix in scripts/codex-review-check.sh)",
+  "expected_cleared": true,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "reviews": [
+    {
+      "id": 1001,
+      "state": "COMMENTED",
+      "commit_id": "deadbeefcafe1234567890abcdef1234567890ab",
+      "submitted_at": "2026-05-12T10:00:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ],
+  "inline_comments": [
+    {
+      "id": 5001,
+      "pull_request_review_id": 1001,
+      "body": "Addressed in 0123abc — was previously: `![P1 Badge]` retry loop. Confirming the bound is now 5 attempts.",
+      "user": { "login": "nathanjohnpayne" }
+    }
+  ]
+}

--- a/scripts/ci/fixtures/pr-audit-codex-clearance/wrong-sha.json
+++ b/scripts/ci/fixtures/pr-audit-codex-clearance/wrong-sha.json
@@ -1,0 +1,16 @@
+{
+  "description": "Codex review present but on an older SHA, not on HEAD → NOT cleared",
+  "expected_cleared": false,
+  "head_sha": "deadbeefcafe1234567890abcdef1234567890ab",
+  "codex_bot_login": "chatgpt-codex-connector[bot]",
+  "reviews": [
+    {
+      "id": 1001,
+      "state": "COMMENTED",
+      "commit_id": "00000000staleshathatisnotcurrenthead0000",
+      "submitted_at": "2026-05-10T10:00:00Z",
+      "user": { "login": "chatgpt-codex-connector[bot]" }
+    }
+  ],
+  "inline_comments": []
+}

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -167,10 +167,41 @@ if ! [[ "$MAX_RATE_LIMIT_RETRIES" =~ ^[0-9]+$ ]]; then
   exit 3
 fi
 
+WALLCLOCK_FRESHNESS_WINDOW_SECONDS=$(coderabbit_field wallclock_freshness_window_seconds)
+WALLCLOCK_FRESHNESS_WINDOW_SECONDS=${WALLCLOCK_FRESHNESS_WINDOW_SECONDS:-1800}
+if ! [[ "$WALLCLOCK_FRESHNESS_WINDOW_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: coderabbit.wallclock_freshness_window_seconds must be an integer; got '$WALLCLOCK_FRESHNESS_WINDOW_SECONDS'" >&2
+  exit 3
+fi
+
 BOT_LOGIN=$(coderabbit_field bot_login)
 BOT_LOGIN=${BOT_LOGIN:-"coderabbitai[bot]"}
 POLL_INTERVAL_SECONDS=15
 RATE_LIMIT_BUFFER_SECONDS=30
+
+# CodeRabbit emits two distinct per-SHA signals:
+#   1. Narrative review comment (issue/PR comment + inline diff comments).
+#      The freshness-anchored polling loop watches for this. Posted only
+#      when there's commentary to add — clean re-reviews on fix-up pushes
+#      can skip it entirely.
+#   2. `CodeRabbit` StatusContext check on the commit status API. Always
+#      posted per-SHA, terminal state SUCCESS/FAILURE.
+# The narrative comment alone is the historical terminal-state source,
+# but on a fix-up push that genuinely cleared all prior findings, signal
+# (2) flips to SUCCESS while signal (1) stays silent — and this script
+# would burn its full MAX_WAIT_SECONDS budget waiting for a comment that
+# never comes. Toggle off via `coderabbit.trust_status_context_for_clearance:
+# false` in `.github/review-policy.yml` for repos that prefer the
+# strict comment-driven gate. See nathanjohnpayne/mergepath#221.
+TRUST_STATUS_CONTEXT=$(coderabbit_field trust_status_context_for_clearance)
+TRUST_STATUS_CONTEXT=${TRUST_STATUS_CONTEXT:-true}
+case "$TRUST_STATUS_CONTEXT" in
+  true|false) ;;
+  *)
+    echo "ERROR: coderabbit.trust_status_context_for_clearance must be true|false; got '$TRUST_STATUS_CONTEXT'" >&2
+    exit 3
+    ;;
+esac
 
 # --- logging helpers --------------------------------------------------------
 
@@ -194,6 +225,62 @@ fetch_api_array() {
     || die 3 "failed to flatten $label pagination output"
 }
 
+# Fetch the CodeRabbit `StatusContext` check on the current HEAD SHA.
+# Emits one of: success | failure | pending | error | missing
+# on stdout. `missing` covers both the no-statuses-yet case and any
+# transient API hiccup (network, 5xx, etc.) — caller treats it as
+# "fall through to the existing comment-driven path."
+#
+# Two defensive guards (CodeRabbit ⚠️ Critical on PR #224 round 1):
+#
+# 1. Filter by `creator.login == $BOT_LOGIN` in addition to context.
+#    Anyone with write access to commit statuses can post a status
+#    with the literal context string "CodeRabbit"; without the
+#    creator filter, that's a spoof vector. The configured bot login
+#    is the only signal we trust.
+#
+# 2. Use `sort_by(.created_at) | last` to pick the latest status, not
+#    `head -n 1`. The /statuses endpoint does not guarantee chronological
+#    ordering across calls, so `head` could return a stale status if
+#    multiple have been posted on the same SHA (e.g., re-evaluation
+#    after a CodeRabbit retry).
+#
+# Endpoint choice: `/commits/{sha}/statuses` (plural) returns each
+# status object with full `creator` details. The singular
+# `/commits/{sha}/status` rolls up state but omits per-status creator
+# fields, which would defeat guard 1. Confirmed empirically — see
+# PR #224 round 2.
+check_status_context() {
+  local resp state
+  # Pagination (CodeRabbit ⚠️ Minor @ line 267 on PR #224 round 2):
+  # `/commits/{ref}/statuses` defaults to per_page=30 and returns
+  # statuses in reverse chronological order. Without `--paginate`, a
+  # commit with >30 statuses (e.g., long-running PR with retries)
+  # could miss the latest CodeRabbit entry in the unpaginated first
+  # page if non-CodeRabbit statuses crowd it out. `--paginate` plus
+  # `jq -s 'add // []'` flattens all pages into a single array before
+  # the context+creator filter runs.
+  resp=$(gh api --paginate "repos/$REPO/commits/$HEAD_SHA/statuses" 2>/dev/null \
+    | jq -s 'add // []' 2>/dev/null) || {
+    echo "missing"
+    return
+  }
+  state=$(echo "$resp" | jq -r --arg bot "$BOT_LOGIN" '
+    [ .[]?
+      | select(.context == "CodeRabbit")
+      | select((.creator.login // "") == $bot)
+    ]
+    | sort_by(.created_at)
+    | last
+    | .state // ""
+  ')
+  if [ -z "$state" ]; then
+    echo "missing"
+    return
+  fi
+  echo "$state"
+}
+
 # --- fetch PR metadata ------------------------------------------------------
 
 log "PR $REPO#$PR_NUMBER — fetching HEAD commit metadata"
@@ -208,36 +295,39 @@ fi
 HEAD_COMMITTER_DATE=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date' 2>&1) \
   || die 3 "failed to fetch commit date for $HEAD_SHA: $HEAD_COMMITTER_DATE"
 
-# HEAD freshness anchor. Committer date alone is unreliable — force-push of
-# an older commit, cherry-pick, or rebase with `--committer-date-is-author-date`
-# can produce a HEAD whose committer date predates prior CodeRabbit comments
-# on this PR. Filtering `comments.created_at >= HEAD_COMMITTER_DATE` would
-# then treat stale review-round comments as current and return a false
-# "cleared"/"findings" signal. Mirrors the Layer-1 anchor advance in
-# codex-review-request.sh: advance the anchor past any `head_ref_force_pushed`
-# timeline event. See nathanjohnpayne/mergepath#140 round-2 Codex finding
-# (P1, line 270) for the specific exposure this closes.
+# HEAD freshness anchor. Two stacked guards — committer date alone is
+# unreliable:
 #
-# Push-time anchoring (#342 → #250 P2 follow-up):
-#   The PR timeline's `committed` event for HEAD_SHA carries a `created_at`
-#   field that is the time GitHub *received* the commit (i.e. push time),
-#   independent of the local commit's `committer.date`. When that event
-#   exists, prefer it over the local committer date — it is the only
-#   timestamp guaranteed to be monotonic with the moment HEAD became
-#   visible to CodeRabbit. Falls back to committer date when the timeline
-#   does not yet contain a matching `committed` event (rare, but happens
-#   on very fresh pushes that race the timeline indexer).
+#   Layer 1 (force-push): advance the anchor past any
+#     `head_ref_force_pushed` event on this PR's timeline. Closes the
+#     force-push-with-old-commit false-clear. See #140 round-2 Codex
+#     finding (P1, line 270).
+#
+#   Layer 2 (wallclock floor): max the anchor with NOW - window.
+#     Without this, an ordinary push of a commit with an old committer
+#     date (cherry-pick, rebase with `--committer-date-is-author-date`,
+#     or a commit whose metadata was rewritten) lets CodeRabbit comments
+#     from a prior review round pass the filter and the script exits
+#     cleared/findings without waiting for a real review on the new
+#     HEAD. See #51/#52/#30/#35 round-3 Codex findings ("Anchor
+#     CodeRabbit freshness to push time", "Gate reviews against a
+#     fresh poll anchor", "Tie CodeRabbit freshness to push time",
+#     "Filter CodeRabbit state by current HEAD SHA", "Gate on review
+#     commit rather than comment timestamp").
+#
+# The two layers compose: force-push events get exact timestamps when
+# available, and the wallclock floor bounds residual exposure for the
+# ordinary-push path where the GitHub API does not expose a reliable
+# per-push time for non-force pushes.
+#
+# Mirrors the REACTION_THRESHOLD computation in codex-review-request.sh,
+# which uses `reaction_freshness_window_seconds` as its floor. Here the
+# knob is `coderabbit.wallclock_freshness_window_seconds` (default
+# 1800s / 30min — long enough for a typical Phase 2.5 cycle to land,
+# short enough that cross-cycle staleness is caught).
 HEAD_ANCHOR="$HEAD_COMMITTER_DATE"
 ANCHOR_SOURCE="HEAD committer date"
 TIMELINE_JSON=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/timeline" "PR timeline")
-HEAD_PUSH_TIME=$(echo "$TIMELINE_JSON" | jq -r --arg sha "$HEAD_SHA" '
-  [ .[] | select(.event == "committed" and .sha == $sha) | .created_at ]
-  | max // ""
-')
-if [ -n "$HEAD_PUSH_TIME" ] && [[ "$HEAD_PUSH_TIME" > "$HEAD_ANCHOR" ]]; then
-  HEAD_ANCHOR="$HEAD_PUSH_TIME"
-  ANCHOR_SOURCE="committed event @ $HEAD_PUSH_TIME (push time)"
-fi
 LATEST_FORCE_PUSH_TIME=$(echo "$TIMELINE_JSON" | jq -r '
   [ .[] | select(.event == "head_ref_force_pushed") | .created_at ]
   | max // ""
@@ -247,9 +337,23 @@ if [ -n "$LATEST_FORCE_PUSH_TIME" ] && [[ "$LATEST_FORCE_PUSH_TIME" > "$HEAD_ANC
   ANCHOR_SOURCE="head_ref_force_pushed @ $LATEST_FORCE_PUSH_TIME"
 fi
 
+# Layer 2 — wallclock freshness floor.
+EPOCH_NOW=$(date +%s)
+EPOCH_FLOOR=$((EPOCH_NOW - WALLCLOCK_FRESHNESS_WINDOW_SECONDS))
+if FLOOR_ISO=$(date -u -r "$EPOCH_FLOOR" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null); then
+  :
+else
+  FLOOR_ISO=$(date -u -d "@$EPOCH_FLOOR" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) \
+    || die 3 "could not compute wallclock freshness floor from epoch $EPOCH_FLOOR"
+fi
+if [[ "$FLOOR_ISO" > "$HEAD_ANCHOR" ]]; then
+  HEAD_ANCHOR="$FLOOR_ISO"
+  ANCHOR_SOURCE="wallclock floor (NOW - ${WALLCLOCK_FRESHNESS_WINDOW_SECONDS}s)"
+fi
+
 log "HEAD = $HEAD_SHA committed at $HEAD_COMMITTER_DATE"
 log "anchor = $HEAD_ANCHOR (source: $ANCHOR_SOURCE)"
-log "max_wait = ${MAX_WAIT_SECONDS}s   max_rate_limit_retries = $MAX_RATE_LIMIT_RETRIES"
+log "max_wait = ${MAX_WAIT_SECONDS}s   max_rate_limit_retries = $MAX_RATE_LIMIT_RETRIES   freshness_window = ${WALLCLOCK_FRESHNESS_WINDOW_SECONDS}s"
 
 # --- state machine ----------------------------------------------------------
 
@@ -368,6 +472,46 @@ count_potential_issues() {
   '
 }
 
+# SHA-scoped variant of count_potential_issues, used by the
+# StatusContext fast-path. Counts CodeRabbit inline findings whose
+# `commit_id` (the SHA GitHub considers the comment currently anchored
+# to, after rebases / new commits) equals the given SHA — independent
+# of HEAD_ANCHOR's wallclock floor.
+#
+# Why this is needed (codex CHANGES_REQUESTED on PR #224 round 2 +
+# CodeRabbit ⚠️ Major @ line 581): the freshness-anchored count_potential_
+# issues filters reviews with `submitted_at >= HEAD_ANCHOR`. Once the
+# same unchanged HEAD sits longer than `coderabbit.wallclock_freshness_
+# window_seconds` (default 1800s / 30 min), HEAD_ANCHOR advances past
+# the prior CodeRabbit review's submitted_at, latest_review_id becomes
+# null, and the helper returns 0 — false-clearing the fast-path even
+# while the same SHA still has unresolved Potential issue/⚠️ inline
+# findings. The fast-path is the only caller that has authoritative
+# per-SHA scope (from the StatusContext check) and should leverage it.
+#
+# Filter shape: inline review comments where the bot author posted a
+# comment whose `commit_id == HEAD_SHA` (i.e., GitHub still considers
+# it applicable to HEAD after any rebases) and whose body contains a
+# `Potential issue` / `⚠️` marker. Resolved-thread state is NOT
+# consulted — same scope as count_potential_issues — so an addressed-
+# but-not-resolved finding will still count. That's the conservative
+# interpretation: "if there's any current-HEAD finding I haven't
+# explicitly resolved, hold the gate."
+count_potential_issues_for_sha() {
+  local sha=$1
+  local pulls_comments
+  pulls_comments=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "pulls comments")
+  echo "$pulls_comments" | jq \
+    --arg bot "$BOT_LOGIN" \
+    --arg sha "$sha" '
+    [ .[]
+      | select(.user.login == $bot)
+      | select(.commit_id == $sha)
+      | select((.body // "") | test("Potential issue|⚠️"; "i"))
+    ] | length
+  '
+}
+
 post_retry_trigger() {
   # Strip the `[bot]` suffix that GitHub REST uses for App logins —
   # @-mentions address the user-facing handle (`@coderabbitai`), not
@@ -453,12 +597,80 @@ sleep_or_timeout() {
   sleep "$actual"
 }
 
+emit_status_context_verdict() {
+  local state=$1
+  # CodeRabbit's StatusContext SUCCESS state means "review completed"
+  # — NOT "no findings remain." With CodeRabbit's default
+  # `request_changes_workflow: false`, the status flips to success
+  # whenever the review finishes, even if Potential issue / ⚠️
+  # comments were posted. Codex (chatgpt-codex-connector[bot]) caught
+  # this on PR #224 round 1 (P1 finding, line 546). The fix: scan
+  # inline `Potential issue` / `⚠️` markers anchored on HEAD before
+  # declaring clearance.
+  #
+  # Round 2 sharpening (codex CHANGES_REQUESTED + CodeRabbit ⚠️ Major
+  # @ line 581 on the round 1 fix): use `count_potential_issues_for_sha
+  # "$HEAD_SHA"` rather than `count_potential_issues`. The latter is
+  # filtered by HEAD_ANCHOR (wallclock freshness floor); after 30 min
+  # on the same unchanged HEAD, anchor advances past prior reviews and
+  # the count drops to 0 — false-clearing the fast-path. The
+  # SHA-scoped variant ignores the wallclock anchor entirely and counts
+  # findings whose `commit_id == HEAD_SHA`, which is the right scope
+  # given the fast-path already has authoritative SHA-level evidence
+  # from the StatusContext check.
+  local potential_issues synthetic
+  potential_issues=$(count_potential_issues_for_sha "$HEAD_SHA")
+  synthetic=$(jq -nc \
+    --arg sha "$HEAD_SHA" \
+    --arg state "$state" \
+    --argjson p "$potential_issues" \
+    '{
+      endpoint: "status_context",
+      head_sha: $sha,
+      context_state: $state,
+      potential_issue_count: $p,
+      body_excerpt: ("CodeRabbit StatusContext = " + $state + " on " + $sha + " (potential_issue_count=" + ($p | tostring) + ")")
+    }')
+  if [ "$potential_issues" -gt 0 ]; then
+    log "StatusContext $state but $potential_issues Potential issue/⚠️ marker(s) on HEAD — emitting findings (exit 2)"
+    emit_json_and_exit "findings" 2 "$synthetic" "$potential_issues"
+  fi
+  log "StatusContext $state and 0 Potential issue/⚠️ markers — emitting cleared (exit 0)"
+  emit_json_and_exit "cleared" 0 "$synthetic" 0
+}
+
+# Pre-loop fast-path. If CodeRabbit posted SUCCESS on this SHA before
+# the script started polling, we can short-circuit immediately and
+# avoid the first 15s sleep. See #221 — the historical comment-driven
+# poll burned the full 300s budget on every clean fix-up push because
+# CodeRabbit doesn't re-narrate when there's nothing new to flag.
+if [ "$TRUST_STATUS_CONTEXT" = "true" ]; then
+  INITIAL_CTX=$(check_status_context)
+  log "initial CodeRabbit StatusContext = $INITIAL_CTX on $HEAD_SHA"
+  if [ "$INITIAL_CTX" = "success" ]; then
+    log "StatusContext success — entering fast-path verdict (scans inline findings before clearance)"
+    emit_status_context_verdict "$INITIAL_CTX"
+  fi
+fi
+
 while :; do
   NOW_EPOCH=$(date +%s)
   ELAPSED=$((NOW_EPOCH - START_EPOCH))
   if [ "$ELAPSED" -ge "$MAX_WAIT_SECONDS" ]; then
     log "max_wait_seconds ($MAX_WAIT_SECONDS) exceeded after ${ELAPSED}s — timing out"
     emit_json_and_exit "timeout" 4 "null" 0
+  fi
+
+  # In-loop fast-path — same intent as the pre-loop check, for the case
+  # where CodeRabbit posts SUCCESS while we're already polling. Cheaper
+  # API call than `scan_latest_comment` so it's worth doing first each
+  # iteration; falls through to the comment scan if not success/failure.
+  if [ "$TRUST_STATUS_CONTEXT" = "true" ]; then
+    LOOP_CTX=$(check_status_context)
+    if [ "$LOOP_CTX" = "success" ]; then
+      log "CodeRabbit StatusContext flipped to success mid-loop on $HEAD_SHA — entering fast-path verdict"
+      emit_status_context_verdict "$LOOP_CTX"
+    fi
   fi
 
   LATEST=$(scan_latest_comment)

--- a/scripts/codex-p1-gate.sh
+++ b/scripts/codex-p1-gate.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+# scripts/codex-p1-gate.sh — Codex P1 unresolved-thread merge gate
+#
+# Reports "Codex P1 unresolved: N" for a pull request and fails (exit 1)
+# when N > 0. Read-only. Never merges, labels, or comments.
+#
+# Context: per nathanjohnpayne/mergepath#235, the 2026-05-13 sweep of
+# unresolved reviewer feedback (#234) found 62 Codex P1 items sitting
+# on merged PRs across 9 repos. P1 is Codex's "blocking" severity tag;
+# 62 P1s riding through to closed state is evidence that the label was
+# advisory, not enforced. This script is the v1 enforcement.
+#
+# Usage:
+#   scripts/codex-p1-gate.sh <PR_NUMBER> [REPO]
+#   scripts/codex-p1-gate.sh                       # env-only mode
+#
+# Arguments:
+#   PR_NUMBER  Required (positional or via $PR_NUMBER env). Integer.
+#   REPO       Optional. "owner/repo". Falls back to $REPO env, then
+#              to the current repo via `gh repo view`.
+#
+# Environment:
+#   GH_TOKEN   Required. Needs pull_requests:read.
+#   PR_NUMBER  Optional fallback for the positional arg. The
+#              scheduled-sweep job in .github/workflows/codex-p1-
+#              gate.yml passes PR_NUMBER positionally per iteration,
+#              but other callers (workflow_dispatch, ad-hoc CLI use,
+#              CI matrix jobs) may find it easier to set it as env.
+#   REPO       Optional fallback for the positional REPO arg. Same
+#              motivation as PR_NUMBER above.
+#
+# Algorithm:
+#   1. Read .github/review-policy.yml `codex.p1_gate.enabled`. If false
+#      (the default everywhere except mergepath), exit 0 — clean pass,
+#      gate disabled.
+#   2. Fetch all inline review comments on the PR via
+#      `repos/{repo}/pulls/{pr}/comments`.
+#   3. Filter to comments authored by `chatgpt-codex-connector[bot]`
+#      (or whatever `codex.bot_login` is configured to) that contain a
+#      P1 marker — the badge image pattern `![P1 Badge]` or the text
+#      pattern `**P1` (covers Codex's text-only fallback when image
+#      rendering is suppressed).
+#   4. For each candidate, fetch its review thread state via GraphQL
+#      `reviewThreads` and check `isResolved`. The author or any
+#      collaborator can resolve a thread via the GitHub UI or
+#      `resolveReviewThread` mutation; this script does NOT fight
+#      against a human-or-agent-marked-resolved state.
+#   5. SHA scope: a P1 finding only gates if its comment was attached
+#      to the PR's current HEAD. A P1 from an earlier SHA that is now
+#      either resolved OR no longer on HEAD does not count.
+#   6. Print one line per unresolved P1 to stdout for CI visibility,
+#      then the summary "Codex P1 unresolved: N".
+#
+# Exit codes:
+#   0   No unresolved P1s on current HEAD (or gate disabled).
+#   1   One or more unresolved P1s on current HEAD — gate blocks.
+#   2   Usage / config error. Error message on stderr.
+#
+# Design notes:
+#   - Read-only. Only GETs against the GitHub API.
+#   - bash 3.2 portable (`#!/usr/bin/env bash`, no associative arrays
+#     or [[ ]] regex features beyond what 3.2 supports).
+#   - PATH-shimmable: tests substitute a `gh` stub on PATH that returns
+#     canned payloads. See tests/test_codex_p1_gate.sh.
+#   - The override pattern from #235 (`p1-already-fixed`,
+#     `p1-rejected`, `p1-moot`, `p1-deferred`) is NOT implemented in
+#     v1 — instead, the override path is "mark the thread resolved
+#     via the GitHub UI or GraphQL". The structured taxonomy lands in
+#     a follow-up once we see how the basic gate behaves in practice.
+#
+# References:
+#   - nathanjohnpayne/mergepath#235 — this script
+#   - nathanjohnpayne/mergepath#234 — the sweep that motivated it
+#   - REVIEW_POLICY.md § Phase 4a merge gate — the companion script
+#     `codex-review-check.sh` covers Codex clearance more broadly;
+#     this script is a narrower per-thread enforcement that exists
+#     specifically to catch the "Codex flagged P1 but author shipped
+#     anyway" failure mode.
+
+set -euo pipefail
+
+# --- argument parsing -------------------------------------------------------
+
+if [ $# -gt 2 ]; then
+  echo "Usage: $0 [PR_NUMBER] [REPO]" >&2
+  echo "       PR_NUMBER and REPO may also be set via env." >&2
+  exit 2
+fi
+
+# Positional args take precedence; env fallbacks support the
+# workflow_dispatch / scheduled-sweep paths where it's more
+# ergonomic to set env than to build a positional arg list.
+PR_NUMBER=${1:-${PR_NUMBER:-}}
+if [ -z "$PR_NUMBER" ]; then
+  echo "ERROR: PR_NUMBER required (positional arg or \$PR_NUMBER env)" >&2
+  exit 2
+fi
+if ! echo "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
+  echo "ERROR: PR_NUMBER must be an integer; got '$PR_NUMBER'" >&2
+  exit 2
+fi
+
+REPO=${2:-${REPO:-}}
+if [ -z "$REPO" ]; then
+  REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)
+  if [ -z "$REPO" ]; then
+    echo "ERROR: could not detect current repo via 'gh repo view'. Pass REPO explicitly." >&2
+    exit 2
+  fi
+fi
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "ERROR: GH_TOKEN is required. See REVIEW_POLICY.md § PAT lookup table." >&2
+  exit 2
+fi
+
+# --- config readers ---------------------------------------------------------
+
+CONFIG=".github/review-policy.yml"
+
+# Read a scalar field nested inside `codex:` `<sub_block>:` `<field>:`.
+# Same state-machine awk pattern as codex-review-check.sh, but tracks
+# nesting one level deeper for the `p1_gate` sub-block.
+codex_p1_gate_field() {
+  local field=$1
+  [ -f "$CONFIG" ] || return 0
+  awk -v field="$field" '
+    /^codex:/ { in_codex=1; in_p1_gate=0; next }
+    in_codex && /^[^[:space:]#]/ { in_codex=0; in_p1_gate=0 }
+    in_codex && /^[[:space:]]+p1_gate:/ { in_p1_gate=1; next }
+    in_p1_gate && /^[[:space:]]{0,3}[^[:space:]#]/ { in_p1_gate=0 }
+    in_p1_gate && $1 == field":" {
+      sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+      gsub(/^"/, "", $0)
+      gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+      gsub(/[[:space:]]*#.*$/, "", $0)
+      sub(/[[:space:]]+$/, "", $0)
+      print
+      exit
+    }
+  ' "$CONFIG"
+}
+
+# Read a scalar field from the codex: block. Mirrors codex-review-check.sh.
+codex_field() {
+  local field=$1
+  [ -f "$CONFIG" ] || return 0
+  awk -v field="$field" '
+    /^codex:/ {in_block=1; next}
+    in_block && /^[^[:space:]#]/ {in_block=0}
+    in_block && $1 == field":" {
+      sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+      gsub(/^"/, "", $0)
+      gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+      gsub(/[[:space:]]*#.*$/, "", $0)
+      sub(/[[:space:]]+$/, "", $0)
+      print
+      exit
+    }
+  ' "$CONFIG"
+}
+
+# Gate knob: codex.p1_gate.enabled. Default false everywhere except
+# mergepath itself (which sets it true in .github/review-policy.yml).
+# Off-state is a clean pass — no API calls, no work.
+P1_GATE_ENABLED=$(codex_p1_gate_field enabled)
+P1_GATE_ENABLED=${P1_GATE_ENABLED:-false}
+case "$P1_GATE_ENABLED" in
+  true|false) ;;
+  *)
+    echo "ERROR: codex.p1_gate.enabled must be true|false; got '$P1_GATE_ENABLED'" >&2
+    exit 2
+    ;;
+esac
+
+if [ "$P1_GATE_ENABLED" != "true" ]; then
+  echo "[codex-p1-gate] codex.p1_gate.enabled=false — skipping (clean pass)"
+  echo "Codex P1 unresolved: 0"
+  exit 0
+fi
+
+BOT_LOGIN=$(codex_field bot_login)
+BOT_LOGIN=${BOT_LOGIN:-"chatgpt-codex-connector[bot]"}
+
+# --- logging helpers --------------------------------------------------------
+
+log() {
+  echo "[codex-p1-gate] $*" >&2
+}
+
+die() {
+  local code=$1
+  shift
+  echo "[codex-p1-gate] ERROR: $*" >&2
+  exit "$code"
+}
+
+# Paginated fetch helper — same shape as codex-review-check.sh.
+fetch_api_array() {
+  local endpoint=$1
+  local label=$2
+  local raw
+  raw=$(gh api --paginate "$endpoint" 2>&1) || die 2 "failed to fetch $label: $raw"
+  echo "$raw" | jq -s 'add // []' 2>/dev/null \
+    || die 2 "failed to flatten $label pagination output"
+}
+
+# --- fetch PR metadata ------------------------------------------------------
+
+log "PR $REPO#$PR_NUMBER — fetching metadata"
+
+PR_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER" 2>&1) \
+  || die 2 "failed to fetch PR metadata: $PR_JSON"
+
+HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
+if [ -z "$HEAD_SHA" ] || [ "$HEAD_SHA" = "null" ]; then
+  die 2 "could not determine HEAD sha for PR #$PR_NUMBER"
+fi
+log "HEAD = $HEAD_SHA    bot_login = $BOT_LOGIN"
+
+# --- fetch Codex P1 inline comments ----------------------------------------
+
+COMMENTS_JSON=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "inline comments")
+
+# Filter:
+#   - author == bot_login
+#   - body contains a P1 marker: the badge image (`![P1 Badge]`) OR the
+#     text fallback (`**P1` at any position; covers titles like
+#     `**P1**: Stop retrying endlessly`).
+#   - on the current HEAD: original_commit_id == HEAD or commit_id == HEAD.
+#     A P1 from an earlier SHA that was addressed in a later commit will
+#     have commit_id != HEAD; we treat it as out-of-scope for this gate
+#     regardless of thread state (it's already resolved by virtue of
+#     not being on HEAD).
+#
+# Output: array of {id, path, line, body_snippet}. body_snippet is a
+# trimmed first line for log readability.
+P1_COMMENTS=$(echo "$COMMENTS_JSON" | jq \
+  --arg bot "$BOT_LOGIN" --arg sha "$HEAD_SHA" '
+  [ .[]
+    | select(.user.login == $bot)
+    | select(.body | test("!\\[P1 Badge\\]") or test("\\*\\*P1"))
+    | select((.commit_id == $sha) or (.original_commit_id == $sha))
+    | {
+        id: .id,
+        path: .path,
+        line: (.line // .original_line // 0),
+        body_snippet: ((.body // "") | split("\n")[0] | .[0:120])
+      }
+  ]
+')
+
+P1_COUNT=$(echo "$P1_COMMENTS" | jq 'length')
+log "found $P1_COUNT P1 comment(s) on HEAD"
+
+if [ "$P1_COUNT" -eq 0 ]; then
+  echo "Codex P1 unresolved: 0"
+  exit 0
+fi
+
+# --- fetch review-thread resolution state via GraphQL ----------------------
+
+# GraphQL `reviewThreads(first: N)` returns each thread with `isResolved`
+# and a `comments` connection. We extract a mapping (comment_id →
+# isResolved) keyed on the first comment's databaseId, then look each
+# P1-bearing comment up.
+#
+# A single page of 100 review threads is enough for the typical PR; a
+# PR with >100 review threads is unusual and warrants a hard error
+# rather than a silent truncation (same pattern as the manual GraphQL
+# fallback in CLAUDE.md § Before merging step 7.6 escape hatch).
+
+OWNER=${REPO%/*}
+NAME=${REPO#*/}
+
+GRAPHQL_QUERY=$(cat <<'EOF'
+query($owner: String!, $name: String!, $pr: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        totalCount
+        pageInfo { hasNextPage }
+        nodes {
+          isResolved
+          comments(first: 100) {
+            nodes { databaseId }
+          }
+        }
+      }
+    }
+  }
+}
+EOF
+)
+
+THREADS_JSON=$(gh api graphql \
+  -F owner="$OWNER" \
+  -F name="$NAME" \
+  -F pr="$PR_NUMBER" \
+  -f query="$GRAPHQL_QUERY" 2>&1) \
+  || die 2 "failed to query reviewThreads: $THREADS_JSON"
+
+HAS_NEXT=$(echo "$THREADS_JSON" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+if [ "$HAS_NEXT" = "true" ]; then
+  die 2 "PR has >100 review threads; pagination not yet supported. File a follow-up issue."
+fi
+
+# Build a JSON object: { "<comment_id>": isResolved, ... }
+RESOLUTION_MAP=$(echo "$THREADS_JSON" | jq '
+  .data.repository.pullRequest.reviewThreads.nodes
+  | map(
+      (.isResolved) as $resolved
+      | .comments.nodes
+      | map({ key: (.databaseId | tostring), value: $resolved })
+    )
+  | flatten
+  | from_entries
+')
+
+# --- classify P1 comments by resolution ------------------------------------
+
+UNRESOLVED_P1=$(echo "$P1_COMMENTS" | jq \
+  --argjson map "$RESOLUTION_MAP" '
+  [ .[]
+    | . as $c
+    | ($map[($c.id | tostring)] // false) as $resolved
+    | select($resolved != true)
+  ]
+')
+
+UNRESOLVED_COUNT=$(echo "$UNRESOLVED_P1" | jq 'length')
+
+# --- report ----------------------------------------------------------------
+
+if [ "$UNRESOLVED_COUNT" -gt 0 ]; then
+  echo ""
+  echo "Unresolved Codex P1 findings on current HEAD ($HEAD_SHA):"
+  echo "$UNRESOLVED_P1" | jq -r '
+    .[] | "  - \(.path):\(.line) (comment id \(.id))\n      \(.body_snippet)"
+  '
+  echo ""
+  echo "Resolve each thread via the GitHub UI (or GraphQL"
+  echo "resolveReviewThread mutation) once the finding is addressed."
+  echo ""
+fi
+
+echo "Codex P1 unresolved: $UNRESOLVED_COUNT"
+
+if [ "$UNRESOLVED_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -25,13 +25,25 @@
 #       nathanpayne-cursor, nathanpayne-codex) is present on the PR,
 #       from an account != the PR author.
 #
-#   (c) Codex has cleared on or after the current HEAD commit via one
-#       of two signals:
+#   (c) Codex (or a Phase 4b substitute reviewer) has cleared on or
+#       after the current HEAD commit via one of three signals:
 #
 #         - A COMMENTED review from the Codex bot on the current HEAD
 #           with NO unaddressed P0/P1 inline findings, OR
 #         - A +1 / 👍 reaction from the Codex bot on the PR issue
-#           with created_at >= current HEAD committer date.
+#           with created_at >= current HEAD committer date, OR
+#         - **Phase 4b substitute (#218):** an APPROVED review on the
+#           current HEAD (`commit_id == HEAD_SHA`) from a non-author
+#           identity in `available_reviewers`, gated on
+#           `codex.allow_phase_4b_substitute` (default true). This
+#           handles the case where the Codex App is unavailable
+#           (not review-ready, timeout, agent usage limits) and an
+#           external CLI reviewer (e.g., nathanpayne-cursor or
+#           nathanpayne-codex) carries the cross-agent merge gate
+#           per REVIEW_POLICY.md § Phase 4b. Set the knob to false
+#           for repos that genuinely require Codex bot clearance and
+#           not a substitute Phase 4b reviewer. Mirrors gate (b)
+#           branch 1's filter shape, scoped to HEAD via commit_id.
 #
 #       The merge gate explicitly does NOT require an APPROVED review
 #       state from the Codex bot. The ChatGPT Codex Connector GitHub
@@ -124,6 +136,46 @@ codex_field() {
   ' "$CONFIG"
 }
 
+# Read a top-level (block-less) scalar field. Same shape as codex_field
+# but without the in-block check — used for fields like `phase_4b_default`
+# (#185) that live at the document root rather than inside `codex:` /
+# `coderabbit:`. Outputs the value or empty on miss.
+#
+# Anchored to start-of-line (no leading whitespace) so a same-named
+# nested key under e.g. `codex:` doesn't accidentally match. Codex P2
+# on PR #189 caught the unanchored-match scope-bleed risk.
+policy_field() {
+  local field=$1
+  [ -f "$CONFIG" ] || return 0
+  awk -v field="$field" '
+    /^[^[:space:]]/ && $1 == field":" {
+      sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+      gsub(/^"/, "", $0)
+      gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+      gsub(/[[:space:]]*#.*$/, "", $0)
+      sub(/[[:space:]]+$/, "", $0)
+      print
+      exit
+    }
+  ' "$CONFIG"
+}
+
+# phase_4b_default — controls when Phase 4b fires proactively. Validated
+# against the three known values; reject unknowns with a clear error
+# pointing at REVIEW_POLICY.md § Phase 4b Triggers. Missing field defaults
+# to "fallback-only" (existing-consumer migration semantics per #188).
+PHASE_4B_DEFAULT=$(policy_field phase_4b_default)
+PHASE_4B_DEFAULT=${PHASE_4B_DEFAULT:-fallback-only}
+case "$PHASE_4B_DEFAULT" in
+  fallback-only|complex-changes|always) ;;
+  *)
+    echo "ERROR: phase_4b_default must be one of: fallback-only, complex-changes, always — got '$PHASE_4B_DEFAULT'" >&2
+    echo "       See REVIEW_POLICY.md § Phase 4b Triggers." >&2
+    exit 3
+    ;;
+esac
+export PHASE_4B_DEFAULT
+
 BOT_LOGIN=$(codex_field bot_login)
 BOT_LOGIN=${BOT_LOGIN:-"chatgpt-codex-connector[bot]"}
 
@@ -143,6 +195,27 @@ fi
 # actually consulted by this script).
 REQUIRE_CI_GREEN=$(codex_field require_ci_green)
 REQUIRE_CI_GREEN=${REQUIRE_CI_GREEN:-true}
+
+# Honor codex.allow_phase_4b_substitute. When true (default), gate (c)
+# also accepts an APPROVED review on the current HEAD from an
+# available_reviewers identity != the PR author as a Codex-equivalent
+# clearance signal. This is the merge gate's understanding of Phase 4b
+# clearance per REVIEW_POLICY.md § Phase 4b — without it, PRs that
+# clear via Phase 4b (Codex App not review-ready, App timeout, agent
+# usage limits) leave gate (c) failing forever and the auto-clear
+# workflow stops working until a human removes the
+# `needs-external-review` label by hand. Set to false for repos that
+# genuinely require Codex clearance and not a substitute Phase 4b
+# reviewer. See nathanjohnpayne/mergepath#218.
+ALLOW_PHASE_4B_SUBSTITUTE=$(codex_field allow_phase_4b_substitute)
+ALLOW_PHASE_4B_SUBSTITUTE=${ALLOW_PHASE_4B_SUBSTITUTE:-true}
+case "$ALLOW_PHASE_4B_SUBSTITUTE" in
+  true|false) ;;
+  *)
+    echo "ERROR: codex.allow_phase_4b_substitute must be true|false; got '$ALLOW_PHASE_4B_SUBSTITUTE'" >&2
+    exit 3
+    ;;
+esac
 
 # Read the available_reviewers list (one per line). Same state-machine
 # awk pattern, but collecting list items rather than matching a scalar.
@@ -201,8 +274,21 @@ PR_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER" 2>&1) || die 3 "failed to fetch 
 
 HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
 PR_AUTHOR=$(echo "$PR_JSON" | jq -r '.user.login')
+PR_BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
 if [ -z "$HEAD_SHA" ] || [ "$HEAD_SHA" = "null" ]; then
   die 3 "could not determine HEAD sha for PR #$PR_NUMBER"
+fi
+
+# Extract the Authoring-Agent line and resolve it to the matching reviewer
+# identity (e.g., `Authoring-Agent: claude` → `nathanpayne-claude`). Used
+# by gate (b) branch 2 (#170) to detect the same-agent author/reviewer
+# case where Codex's 👍 reaction can substitute for an APPROVED review.
+AUTHORING_AGENT=$(echo "$PR_BODY" | grep -i -m1 -E '^Authoring-Agent:' | sed -E 's/^[Aa]uthoring-[Aa]gent:[[:space:]]*([A-Za-z0-9_-]+).*/\1/' | tr '[:upper:]' '[:lower:]')
+SAME_AGENT_REVIEWER=""
+if [ -n "$AUTHORING_AGENT" ]; then
+  # Match against available_reviewers via suffix (e.g., "claude" matches
+  # "nathanpayne-claude"). Empty if no match.
+  SAME_AGENT_REVIEWER=$(echo "$REVIEWERS" | awk -v agent="-$AUTHORING_AGENT" '$0 ~ agent"$" { print; exit }')
 fi
 
 HEAD_COMMITTER_DATE=$(gh api "repos/$REPO/commits/$HEAD_SHA" --jq '.commit.committer.date' 2>&1) \
@@ -434,9 +520,16 @@ BAD_CHECKS=$(echo "$ROLLUP_JSON" | jq --argjson required_names "${REQUIRED_JSON:
     # checks block the gate. When the list is empty (no branch
     # protection configured or query failed), fall back to the
     # prior behavior of treating all checks as required.
+    #
+    # Bind `.label` to a variable BEFORE the `$required_names | ...`
+    # sub-pipeline, because inside that sub-pipeline `.` rebinds to
+    # `$required_names` (the array) and `.label` would then try to
+    # index the array, producing the jq error
+    # "Cannot index array with string \"label\"".
+    | (.label) as $label_name
     | select(
         ($required_names | length) == 0
-        or ($required_names | index(.label)) != null
+        or ($required_names | index($label_name)) != null
       )
     # A check passes the gate iff its result is SUCCESS, SKIPPED, or
     # NEUTRAL. Everything else — FAILURE, CANCELLED, TIMED_OUT,
@@ -504,10 +597,56 @@ APPROVING_REVIEWER=$(echo "$REVIEWS_JSON" | jq -r \
 ')
 
 if [ -z "$APPROVING_REVIEWER" ]; then
-  fail_gate "no reviewer identity in available_reviewers has a latest-state APPROVED review (COMMENTED reviews are ignored; later CHANGES_REQUESTED/DISMISSED overrides earlier APPROVED)"
-fi
+  # Branch 2 (#170): same-agent author/reviewer fallback. For Phase 4
+  # PRs, the no-self-approve scoping rule (REVIEW_POLICY.md § No-self-
+  # approve scoping; #220) prohibits the agent that authored the PR from
+  # also approving under its own reviewer identity — that's the case
+  # this branch handles. (Under-threshold PRs don't reach this script;
+  # they self-approve via the reviewer identity per the same scoping
+  # rule.) Same-agent PRs at Phase 4 would otherwise be unable to clear
+  # gate (b) by branch 1 unless a second agent (cursor / codex CLI)
+  # reviews independently. In a single-agent session that's friction
+  # with no policy benefit — Codex's external review IS the cross-agent
+  # signal. Accept a fresh Codex 👍 reaction on the PR issue as a
+  # substitute for branch 1, BUT ONLY when the PR's Authoring-Agent
+  # matches an entry in available_reviewers (otherwise this would
+  # weaken gate (b) for cross-agent PRs that
+  # genuinely need a reviewer-identity APPROVED).
+  #
+  # Freshness: same REACTION_THRESHOLD that gate (c) uses, computed
+  # earlier in the script. Reaction must be at-or-after the threshold,
+  # which is max(HEAD_PUSHED_AT, NOW - reaction_freshness_window).
+  #
+  # If a cross-agent reviewer COULD review (e.g., another agent is in
+  # available_reviewers with no opinionated state on this PR), that's
+  # still permitted — branch 2 is opt-in via the matching Authoring-
+  # Agent header. If you want strict cross-agent enforcement, omit the
+  # Authoring-Agent line; gate (b) then falls back to branch 1 only.
+  if [ -n "$SAME_AGENT_REVIEWER" ]; then
+    log "gate (b): no reviewer-identity APPROVED, but same-agent author/reviewer detected (Authoring-Agent: $AUTHORING_AGENT → $SAME_AGENT_REVIEWER); checking for Codex 👍 fallback per #170"
+    REACTIONS_FOR_GATE_B=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/reactions" "reactions")
+    GATE_B_THUMBS_UP=$(echo "$REACTIONS_FOR_GATE_B" | jq -r \
+      --arg bot "$BOT_LOGIN" --arg after "$REACTION_THRESHOLD" '
+      [ .[]
+        | select(.user.login == $bot)
+        | select(.content == "+1")
+        | select(.created_at >= $after)
+        | .created_at
+      ]
+      | max // ""
+    ')
+    if [ -n "$GATE_B_THUMBS_UP" ]; then
+      log "gate (b): same-agent + Codex 👍 @ $GATE_B_THUMBS_UP (≥ threshold $REACTION_THRESHOLD) — branch 2 cleared"
+      APPROVING_REVIEWER="(branch 2: same-agent + Codex 👍)"
+    fi
+  fi
 
-log "gate (b): latest-state APPROVED by $APPROVING_REVIEWER"
+  if [ -z "$APPROVING_REVIEWER" ]; then
+    fail_gate "no reviewer identity in available_reviewers has a latest-state APPROVED review, and same-agent + Codex 👍 fallback (branch 2) did not apply (Authoring-Agent: ${AUTHORING_AGENT:-not set}; matched reviewer: ${SAME_AGENT_REVIEWER:-none}; threshold: $REACTION_THRESHOLD)"
+  fi
+else
+  log "gate (b): latest-state APPROVED by $APPROVING_REVIEWER"
+fi
 
 # --- gate (c): Codex cleared on current HEAD -------------------------------
 
@@ -631,9 +770,90 @@ elif [ -n "$CODEX_REVIEW_TIME" ]; then
   fi
 fi
 
+# Phase 4b substitute (#218): if Codex hasn't cleared via 👍 or a
+# COMMENTED-on-HEAD review, and the knob is on, accept a fresh APPROVED
+# review on the current HEAD from an available_reviewers identity that
+# is NOT the PR author. This is the merge gate's understanding of
+# Phase 4b clearance per REVIEW_POLICY.md § Phase 4b: when the Codex
+# App is unavailable / times out / hits usage limits, an external CLI
+# reviewer (e.g., nathanpayne-cursor or nathanpayne-codex) is the
+# cross-agent signal. The freshness anchor is a strict commit_id ==
+# HEAD_SHA match — no time-window approximation needed since the
+# review API returns the exact SHA the review was submitted on.
+#
+# Latest-state-per-reviewer filter (Codex P1 round 1 on PR #225):
+# group reviews on HEAD by reviewer identity, take each reviewer's
+# most-recent review on this SHA, then accept ONLY if that latest
+# state is APPROVED. Without this guard, a reviewer who first APPROVED
+# then later submitted CHANGES_REQUESTED on the same HEAD would still
+# satisfy the substitute via the stale APPROVED. Mirrors gate (b)
+# branch 1's same-shaped filter (line 547 above).
+#
+# When this branch fires, the auto-clear-blocking-labels workflow
+# correctly removes `needs-external-review` on the next event-driven
+# trigger or scheduled sweep, instead of stalling on a permanently-
+# failing gate (c) until a human clears the label by hand.
+if [ "$CLEARED" != "true" ] && [ "$ALLOW_PHASE_4B_SUBSTITUTE" = "true" ]; then
+  PHASE_4B_APPROVER=$(echo "$REVIEWS_JSON" | jq -r \
+    --argjson reviewers "$REVIEWERS_JSON" \
+    --arg author "$PR_AUTHOR" \
+    --arg sha "$HEAD_SHA" '
+      [ .[]
+        | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+        | select(.commit_id == $sha)
+        | select(.user.login as $u | $reviewers | index($u))
+        | select(.user.login != $author)
+      ]
+      | group_by(.user.login)
+      | map(max_by(.submitted_at))
+      | map(select(.state == "APPROVED"))
+      | max_by(.submitted_at)
+      | if . == null then "" else .user.login + "|" + .submitted_at end
+  ')
+  if [ -n "$PHASE_4B_APPROVER" ]; then
+    PHASE_4B_LOGIN="${PHASE_4B_APPROVER%|*}"
+    PHASE_4B_TIME="${PHASE_4B_APPROVER#*|}"
+
+    # Latest-signal-wins guard (codex CHANGES_REQUESTED + CodeRabbit ⚠️
+    # Major @ scripts/codex-review-check.sh:811 on PR #225 round 3):
+    # accept the Phase 4b substitute ONLY when its APPROVED is the
+    # newest external clearance signal on HEAD. If a Codex bot review
+    # or 👍 reaction on HEAD is newer than the Phase 4b APPROVED, the
+    # Codex signal carries the verdict — and since the Codex paths
+    # above already failed to clear (CLEARED != true at this point),
+    # that means Codex's newer signal indicated unresolved P0/P1
+    # findings or had no qualifying clearance, and the older Phase 4b
+    # APPROVED must NOT override.
+    #
+    # Edge cases:
+    # - No Codex signals on HEAD (`LATEST_CODEX_SIGNAL_TIME` empty):
+    #   Phase 4b APPROVED is the only external-clearance evidence on
+    #   HEAD; accept it. This is the bare Phase 4b path (Codex App
+    #   not review-ready / timed out / etc.).
+    # - Phase 4b APPROVED newer than Codex review timestamp: the
+    #   reviewer saw Codex's findings and approved anyway (or the
+    #   findings were addressed and Codex's review captured them
+    #   without a 👍). Treat as deliberate; accept.
+    LATEST_CODEX_SIGNAL_TIME="$LATEST_THUMBS_UP_TIME"
+    if [ -n "$CODEX_REVIEW_TIME" ] && { [ -z "$LATEST_CODEX_SIGNAL_TIME" ] || [[ "$CODEX_REVIEW_TIME" > "$LATEST_CODEX_SIGNAL_TIME" ]]; }; then
+      LATEST_CODEX_SIGNAL_TIME="$CODEX_REVIEW_TIME"
+    fi
+    if [ -z "$LATEST_CODEX_SIGNAL_TIME" ] || [[ "$PHASE_4B_TIME" > "$LATEST_CODEX_SIGNAL_TIME" ]]; then
+      CLEARED=true
+      CLEARANCE_REASON="Phase 4b substitute: latest-state APPROVED on HEAD from $PHASE_4B_LOGIN @ $PHASE_4B_TIME (codex.allow_phase_4b_substitute=true; newer than any Codex bot signal on HEAD: ${LATEST_CODEX_SIGNAL_TIME:-none})"
+    else
+      log "gate (c): Phase 4b substitute candidate $PHASE_4B_LOGIN @ $PHASE_4B_TIME is older than newest Codex bot signal @ $LATEST_CODEX_SIGNAL_TIME; latest-signal-wins guard rejects substitute"
+    fi
+  fi
+fi
+
 if [ "$CLEARED" != "true" ]; then
   if [ -z "$LATEST_THUMBS_UP_TIME" ] && [ -z "$CODEX_REVIEW_TIME" ]; then
-    fail_gate "Codex has not cleared current HEAD (no review on $HEAD_SHA and no +1 reaction from $BOT_LOGIN on or after reaction threshold $REACTION_THRESHOLD: $REACTION_THRESHOLD_SOURCE)"
+    if [ "$ALLOW_PHASE_4B_SUBSTITUTE" = "true" ]; then
+      fail_gate "Codex has not cleared current HEAD and no Phase 4b substitute APPROVED on $HEAD_SHA from a non-author identity in available_reviewers (no review on HEAD, no +1 reaction from $BOT_LOGIN on or after reaction threshold $REACTION_THRESHOLD: $REACTION_THRESHOLD_SOURCE)"
+    else
+      fail_gate "Codex has not cleared current HEAD (no review on $HEAD_SHA and no +1 reaction from $BOT_LOGIN on or after reaction threshold $REACTION_THRESHOLD: $REACTION_THRESHOLD_SOURCE)"
+    fi
   else
     PATHS=$(echo "$UNADDRESSED_P01" | jq -r '[.[] | "\(.path):\(.line)"] | join(", ")')
     fail_gate "latest Codex signal is a review on HEAD with $UNADDRESSED_COUNT unaddressed P0/P1 finding(s): $PATHS"

--- a/scripts/disagreement-detector.js
+++ b/scripts/disagreement-detector.js
@@ -1,0 +1,108 @@
+// scripts/disagreement-detector.js
+//
+// Pure decision function for `.github/workflows/agent-review.yml`'s
+// `detect-disagreement` job and its CI test (#259). Given a PR's
+// review list, the configured reviewer accounts, the current HEAD
+// SHA, and whether `needs-human-review` is currently applied,
+// returns one of `apply` / `remove` / `noop`.
+//
+// Live-disagreement semantics (the pre-#259 bug was that all three
+// were absent):
+//
+//   1. Per-reviewer collapse: keep only the LATEST review per
+//      `user.login` (sorted by `submitted_at`), discarding stale
+//      reviews from the same reviewer. A round-1 CHANGES_REQUESTED
+//      followed by a round-2 APPROVED from the same agent is a
+//      reversal, not a disagreement.
+//   2. DISMISSED filtering: a DISMISSED review (state-cleared by
+//      GitHub when branch churn invalidates it, or manually
+//      dismissed) does NOT count toward `hasApproval` or
+//      `hasChangesRequested`. Per-reviewer collapse happens first
+//      so a fresher DISMISSED can't bury an earlier non-DISMISSED
+//      from the same reviewer.
+//   3. HEAD-SHA scoping: only reviews whose `commit_id` matches the
+//      current HEAD count. A CHANGES_REQUESTED on a stale SHA is
+//      superseded by any APPROVED on a fresher SHA from any
+//      reviewer.
+//   4. Reviewer-account allow-list: only listed agent reviewers
+//      contribute. COMMENTED reviews are filtered out — they do
+//      not change a reviewer's effective position.
+//
+// Mirrors the merge-gate's latest-state-per-reviewer pattern from
+// `scripts/codex-review-check.sh` gates (b)/(c) (#170 + #218).
+//
+// Input shape (object):
+//   {
+//     reviews:           Array<{ user:{login}, state, commit_id, submitted_at }>,
+//     reviewerAccounts:  Array<string>,
+//     headSha:           string,
+//     hasLabel:          boolean,
+//   }
+//
+// Output: one of 'apply' | 'remove' | 'noop'.
+//
+// The workflow `require()`s this module after `actions/checkout`
+// and calls `decide(input)`. The CI test under
+// `scripts/ci/check_disagreement_detector` `require()`s the same
+// module and feeds it canned fixtures.
+
+'use strict';
+
+function decide(input) {
+  const reviews = Array.isArray(input && input.reviews) ? input.reviews : [];
+  const reviewerAccounts = Array.isArray(input && input.reviewerAccounts)
+    ? input.reviewerAccounts
+    : [];
+  const headSha = (input && input.headSha) || '';
+  const hasLabel = !!(input && input.hasLabel);
+
+  const allowed = new Set(reviewerAccounts);
+
+  // Step 1: collapse to latest review per reviewer. We collapse
+  // across ALL non-COMMENTED states (APPROVED, CHANGES_REQUESTED,
+  // DISMISSED) so a fresher DISMISSED can supersede an older
+  // APPROVED from the same reviewer (GitHub's dismissal model:
+  // the reviewer's signal is no longer valid). COMMENTED reviews
+  // are dropped here because they never change a reviewer's
+  // effective position.
+  const latestByReviewer = new Map();
+  for (const r of reviews) {
+    if (!r || !r.user || !allowed.has(r.user.login)) continue;
+    if (r.state !== 'APPROVED' &&
+        r.state !== 'CHANGES_REQUESTED' &&
+        r.state !== 'DISMISSED') continue;
+    const existing = latestByReviewer.get(r.user.login);
+    if (!existing) {
+      latestByReviewer.set(r.user.login, r);
+      continue;
+    }
+    const existingTs = Date.parse(existing.submitted_at || '') || 0;
+    const candidateTs = Date.parse(r.submitted_at || '') || 0;
+    if (candidateTs > existingTs) {
+      latestByReviewer.set(r.user.login, r);
+    }
+  }
+
+  // Step 2: filter to reviews on the current HEAD that are not
+  // DISMISSED. The HEAD-SHA filter is what kills the #259
+  // false-positive: a CHANGES_REQUESTED on a stale SHA drops out
+  // here even if the same reviewer hasn't revisited.
+  const liveReviews = [];
+  for (const r of latestByReviewer.values()) {
+    if (!headSha || r.commit_id !== headSha) continue;
+    if (r.state === 'DISMISSED') continue;
+    liveReviews.push(r);
+  }
+
+  const hasApproval = liveReviews.some(r => r.state === 'APPROVED');
+  const hasChangesRequested = liveReviews.some(r => r.state === 'CHANGES_REQUESTED');
+
+  const liveDisagreement = hasApproval && hasChangesRequested;
+
+  if (liveDisagreement) {
+    return hasLabel ? 'noop' : 'apply';
+  }
+  return hasLabel ? 'remove' : 'noop';
+}
+
+module.exports = { decide };

--- a/scripts/gh-as-author.sh
+++ b/scripts/gh-as-author.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# scripts/gh-as-author.sh
+#
+# Run a `gh` command (typically a write — pr create, pr merge, pr
+# edit) under the AUTHOR identity (nathanjohnpayne by default), then
+# restore the previously-active gh keyring account. Switches and
+# switch-back all happen inside one bash process via `trap EXIT`, so
+# even a crash or interrupt between the switch and the wrapped command
+# leaves the keyring in a known-good state.
+#
+# Usage:
+#   scripts/gh-as-author.sh -- gh pr create --title ...
+#   scripts/gh-as-author.sh -- gh pr merge 123 --squash --delete-branch
+#   scripts/gh-as-author.sh -- gh pr edit 123 --add-label foo
+#
+# The leading `--` is conventional but optional; the script strips it
+# before running the wrapped command.
+#
+# Why this exists (#241):
+#
+#   The canonical pattern `gh auth switch -u <author> && gh pr create
+#   && gh auth switch -u <reviewer>` is correct only when all three
+#   commands run inside ONE bash invocation. When an agent splits it
+#   across two Bash tool calls (switch in call A; pr create + switch-
+#   back in call B), the gh keyring's active account can drift between
+#   calls — observed concretely on friends-and-family-billing#262
+#   where a `gh pr create` landed under `nathanpayne-claude` despite
+#   a preceding `gh auth switch -u nathanjohnpayne` in the prior
+#   Bash call. Wrapping the whole sequence in a single script process
+#   eliminates the split-invocation failure mode.
+#
+#   This wrapper is the canonical pattern referenced from CLAUDE.md
+#   and REVIEW_POLICY.md.
+#
+# Verification (#241 mitigation 2):
+#
+#   When the wrapped command is `gh pr create`, the script also runs
+#   a post-create `gh pr view --json author` check on the created PR
+#   and exits non-zero if `author.login` does not match the expected
+#   author identity. This catches the "PR landed under the wrong
+#   identity" failure mode immediately, instead of at the reviewer-
+#   approval step ~10 min later.
+#
+# Environment:
+#   GH_AS_AUTHOR_IDENTITY   author identity to switch to.
+#                           Default: nathanjohnpayne
+#
+# Exit codes:
+#   0    success (wrapped command exited 0 AND, for gh pr create,
+#        author verification passed)
+#   1    setup error (could not determine prior active account, etc.)
+#   2    switch-to-author failed
+#   5    post-create author verification failed (PR landed under
+#        wrong identity) OR verification could not complete (PR URL
+#        not extractable from gh pr create output / gh pr view failed
+#        / empty author.login). Fail-closed: an unverified create
+#        is NOT treated as success, so downstream automation can
+#        distinguish "verified clean" from "verification skipped".
+#   *    propagated from the wrapped command otherwise
+#
+# Bash 3.2 compatible (macOS default).
+
+set -euo pipefail
+
+AUTHOR="${GH_AS_AUTHOR_IDENTITY:-nathanjohnpayne}"
+
+# Capture prior active via `gh config get -h github.com user`, NOT
+# `gh auth status`. `gh auth status` is GH_TOKEN-poisonable — when
+# GH_TOKEN is set it reports the GH_TOKEN entry as Active even though
+# writes still attribute to the keyring entry. CLAUDE.md § Active-
+# account convention is explicit about this.
+PRIOR=$(gh config get -h github.com user 2>/dev/null || echo "")
+if [ -z "$PRIOR" ]; then
+  echo "gh-as-author: could not determine prior active gh account (gh config get -h github.com user returned empty)" >&2
+  echo "gh-as-author: refusing to proceed; running the wrapped command without a recorded prior account would leave the keyring in an unknown state on switch-back." >&2
+  exit 1
+fi
+
+# Install the switch-back trap BEFORE the switch-to-author. That way
+# if the switch-to-author itself partial-fails, we still attempt to
+# restore the prior account. The trap is tolerant of restore failure
+# — a stuck-on-author keyring is a louder problem than the wrapped
+# command's exit code, so we emit a clear diagnostic but don't
+# clobber the exit code.
+restore_prior() {
+  if ! gh auth switch -u "$PRIOR" >/dev/null 2>&1; then
+    echo "gh-as-author: WARNING failed to restore prior active account ($PRIOR). Run 'gh auth switch -u $PRIOR' manually to recover." >&2
+  fi
+}
+trap 'restore_prior' EXIT
+
+if ! gh auth switch -u "$AUTHOR" >/dev/null 2>&1; then
+  echo "gh-as-author: gh auth switch -u $AUTHOR failed. Is $AUTHOR in the keyring? Run 'gh auth login' once for that identity." >&2
+  exit 2
+fi
+
+# Strip leading `--` if present so callers can use the conventional
+# disambiguator `scripts/gh-as-author.sh -- gh pr create ...`.
+[ "${1:-}" = "--" ] && shift
+
+# Detect whether the wrapped command is `gh pr create`. argv[0] must
+# be `gh` and argv[1] must be `pr` and argv[2] must be `create`. We
+# don't try to handle `gh -R foo/bar pr create ...` here — agents
+# should use the subcommand-scoped `--repo` flag with this wrapper
+# (the gh CLI accepts both forms equivalently). Worst case: a global
+# -R/--repo before `pr` slips past the detector, the wrapped command
+# still runs correctly, and we just skip the post-create verification.
+IS_PR_CREATE=0
+if [ "${1:-}" = "gh" ] && [ "${2:-}" = "pr" ] && [ "${3:-}" = "create" ]; then
+  IS_PR_CREATE=1
+fi
+
+if [ "$IS_PR_CREATE" -eq 1 ]; then
+  # Capture stdout so we can extract the PR URL for verification, but
+  # also tee it to the operator's terminal so they see the URL gh
+  # prints. Stderr is left alone (gh emits progress + errors there).
+  TMP_OUT=$(mktemp)
+  # `trap` chains — append to the existing EXIT trap (the restore)
+  # so the tempfile is cleaned up too.
+  trap 'rm -f "$TMP_OUT"; restore_prior' EXIT
+  set +e
+  "$@" | tee "$TMP_OUT"
+  # PIPESTATUS[0] is the wrapped gh's exit code; tee almost always
+  # returns 0 so we ignore PIPESTATUS[1].
+  WRAPPED_RC=${PIPESTATUS[0]}
+  set -e
+  if [ "$WRAPPED_RC" -ne 0 ]; then
+    exit "$WRAPPED_RC"
+  fi
+
+  # Extract the PR URL from the captured output. gh pr create's last
+  # line is the URL (https://github.com/owner/repo/pull/N). `basename`
+  # on the URL yields the PR number. Use `grep -oE` to find the URL
+  # rather than `tail -1` because gh sometimes appends `--web` open
+  # diagnostics or other trailing lines.
+  PR_URL=$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' "$TMP_OUT" | tail -1 || true)
+  if [ -z "$PR_URL" ]; then
+    # Fail closed: a successful `gh pr create` whose URL we cannot
+    # extract is NOT verified. Treating it as verified would let
+    # downstream automation proceed after the safety check was
+    # silently skipped — exactly the #241 footgun this wrapper
+    # exists to close. Operator recovery: verify the new PR's
+    # author.login manually (`gh pr list --author nathanjohnpayne`).
+    echo "gh-as-author: ERROR could not extract PR URL from gh pr create output; refusing to treat the create as verified." >&2
+    echo "gh-as-author: The PR may still have been created — check 'gh pr list --author $AUTHOR' and verify manually." >&2
+    exit 5
+  fi
+  PR_NUM=$(basename "$PR_URL")
+  # Repo slug is the path component between github.com/ and /pull/N.
+  PR_REPO=$(echo "$PR_URL" | sed -E 's|https://github\.com/([^/]+/[^/]+)/pull/[0-9]+|\1|')
+
+  # Use the active keyring (currently $AUTHOR) for the verification
+  # read. We don't pin GH_TOKEN here — the read works under either
+  # identity and avoiding the env-var dependency keeps the wrapper
+  # standalone.
+  ACTUAL_AUTHOR=$(gh pr view "$PR_NUM" --repo "$PR_REPO" --json author --jq .author.login 2>/dev/null || echo "")
+  if [ -z "$ACTUAL_AUTHOR" ]; then
+    # Fail closed: see PR-URL branch above. Network blips and
+    # transient gh errors must NOT be confused with a verified clean
+    # create.
+    echo "gh-as-author: ERROR could not read PR author from gh pr view $PR_NUM --repo $PR_REPO (network? permissions?); refusing to treat the create as verified." >&2
+    echo "gh-as-author: Verify manually: gh pr view $PR_NUM --repo $PR_REPO --json author" >&2
+    exit 5
+  fi
+
+  if [ "$ACTUAL_AUTHOR" != "$AUTHOR" ]; then
+    echo "gh-as-author: ERROR PR #$PR_NUM on $PR_REPO landed under '$ACTUAL_AUTHOR', expected '$AUTHOR'." >&2
+    echo "gh-as-author: This is the #241 footgun — gh keyring active-identity glitch." >&2
+    echo "gh-as-author: Recovery: close the PR and recreate from the same branch." >&2
+    echo "gh-as-author:   gh pr close $PR_NUM --repo $PR_REPO --comment 'Wrong author identity (see #241). Recreating.'" >&2
+    echo "gh-as-author:   scripts/gh-as-author.sh -- gh pr create --repo $PR_REPO --title '...' --body '...'" >&2
+    echo "gh-as-author: See REVIEW_POLICY.md § Recovery: PR created under the wrong identity." >&2
+    exit 5
+  fi
+
+  echo "gh-as-author: verified PR #$PR_NUM author=$ACTUAL_AUTHOR (matches expected $AUTHOR)" >&2
+  exit 0
+fi
+
+# Non-gh-pr-create path: run the wrapped command in this shell (NOT
+# exec) so the EXIT trap still fires and restores $PRIOR. Using exec
+# would replace the bash process with the wrapped command, dropping
+# the trap and leaving the keyring stuck on $AUTHOR — the exact
+# state the wrapper exists to prevent. Capture the wrapped command's
+# exit code and propagate it so callers see the same rc they would
+# from running the command directly.
+set +e
+"$@"
+WRAPPED_RC=$?
+set -e
+exit "$WRAPPED_RC"

--- a/scripts/gh-as-reviewer.sh
+++ b/scripts/gh-as-reviewer.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# scripts/gh-as-reviewer.sh
+#
+# Run a `gh` command under the REVIEWER identity (the agent identity,
+# e.g. nathanpayne-claude), then restore the previously-active gh
+# keyring account. Companion to scripts/gh-as-author.sh — same trap-
+# EXIT pattern, same prior-active detection via `gh config get`, but
+# switches to the reviewer identity instead.
+#
+# Usage:
+#   GH_AS_REVIEWER_IDENTITY=nathanpayne-claude \
+#     scripts/gh-as-reviewer.sh -- gh pr review 123 --comment --body "..."
+#
+# Environment:
+#   GH_AS_REVIEWER_IDENTITY   reviewer identity to switch to.
+#                             Default: nathanpayne-claude
+#
+# On most agent machines the reviewer identity is ALREADY the active
+# account per the CLAUDE.md convention, so this wrapper is mostly a
+# no-op (switches to itself, runs the command, switches back to
+# itself). The value is for the inverse case — an agent in the
+# middle of an author-identity flow (e.g. just finished a wrapped
+# `gh pr create`) who needs to post a reviewer comment WITHOUT
+# leaving the keyring in a wrong state on return.
+#
+# Exit codes mirror gh-as-author.sh except there is no post-create
+# verification (the reviewer wrapper is not the canonical path for
+# pr create).
+#
+# Bash 3.2 compatible (macOS default).
+
+set -euo pipefail
+
+REVIEWER="${GH_AS_REVIEWER_IDENTITY:-nathanpayne-claude}"
+
+PRIOR=$(gh config get -h github.com user 2>/dev/null || echo "")
+if [ -z "$PRIOR" ]; then
+  echo "gh-as-reviewer: could not determine prior active gh account (gh config get -h github.com user returned empty)" >&2
+  echo "gh-as-reviewer: refusing to proceed; running the wrapped command without a recorded prior account would leave the keyring in an unknown state on switch-back." >&2
+  exit 1
+fi
+
+restore_prior() {
+  if ! gh auth switch -u "$PRIOR" >/dev/null 2>&1; then
+    echo "gh-as-reviewer: WARNING failed to restore prior active account ($PRIOR). Run 'gh auth switch -u $PRIOR' manually to recover." >&2
+  fi
+}
+trap 'restore_prior' EXIT
+
+if ! gh auth switch -u "$REVIEWER" >/dev/null 2>&1; then
+  echo "gh-as-reviewer: gh auth switch -u $REVIEWER failed. Is $REVIEWER in the keyring? Run 'gh auth login' once for that identity." >&2
+  exit 2
+fi
+
+[ "${1:-}" = "--" ] && shift
+
+# Run the wrapped command in THIS shell (NOT exec) so the EXIT trap
+# still fires and restores $PRIOR. `exec "$@"` would replace the
+# bash process with the wrapped command, dropping the trap and
+# leaving the keyring stuck on $REVIEWER. Capture and propagate the
+# wrapped command's exit code so callers see the same rc they would
+# from running the command directly. Same fix shape as
+# scripts/gh-as-author.sh.
+set +e
+"$@"
+WRAPPED_RC=$?
+set -e
+exit "$WRAPPED_RC"

--- a/scripts/gh-projects/README.md
+++ b/scripts/gh-projects/README.md
@@ -13,12 +13,12 @@ The MUX Video Integration initiative ([Project #5](https://github.com/users/nath
 ## Prerequisites
 
 - `gh` installed (via Homebrew on this machine).
-- A PAT in 1Password with `repo` + `project` scopes. The `nathanjohnpayne` author PAT (item `sm5kopwk6t6p3xmu2igesndzhe`) works.
+- A PAT with `repo` + `project` scopes. Use the author PAT or a reviewer-identity PAT — see [REVIEW_POLICY.md § PAT lookup table](../../REVIEW_POLICY.md#pat-lookup-table) for the 1Password item IDs (the table is the canonical source; don't re-list IDs here to avoid drift).
 - Run [scripts/op-preflight.sh](../op-preflight.sh) once per session to cache credentials.
 - The target Project v2 board must have a `Status` single-select field (the default template does). `move-item.sh` discovers the field by that exact name.
 
 ```bash
-# Session setup
+# Session setup — preflight populates OP_PREFLIGHT_AUTHOR_PAT in env.
 eval "$(scripts/op-preflight.sh --agent claude --mode all)"
 export GH_TOKEN="$OP_PREFLIGHT_AUTHOR_PAT"
 ```
@@ -99,9 +99,11 @@ Create children in dependency order: if child C2's body references C1, create C1
 
 [Sub-issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-sub-issues) render as a real parent-child tree in the GitHub UI and in Projects, and the parent's progress bar tracks children automatically. Task-list checkboxes in the body work but don't roll up. `lib.sh` uses the REST API:
 
-```
+```http
 POST /repos/{owner}/{repo}/issues/{parent_num}/sub_issues
-Body: {"sub_issue_id": <child_db_id>}
+Content-Type: application/json
+
+{"sub_issue_id": <child_db_id>}
 ```
 
 Note the `sub_issue_id` is the **integer database ID** of the child (from `gh api repos/.../issues/<num> --jq .id`), not the issue number. `gh api` must send it as a number with `-F`, not a string with `-f`.
@@ -117,3 +119,35 @@ Note the `sub_issue_id` is the **integer database ID** of the child (from `gh ap
 ## Worked example
 
 See [`examples/mux-video-integration/`](./examples/mux-video-integration/) for the exact files used to create issues #210–#230. The driver is rerunnable against a fresh project — delete existing issues first or re-point `PROJECT` to a new board.
+
+## Two driver lifecycle patterns
+
+Two driver shapes cover the full per-initiative lifecycle. Both use this same `lib.sh`; the difference is what they're for.
+
+### Fresh-create driver (`examples/<initiative>/create-issues.sh`)
+
+One-shot, non-idempotent script that builds the initial issue tree from scratch. Creates labels, parent issues, child issues in dependency order, links children as native sub-issues, and adds everything to the Project board. Use when a new initiative kicks off.
+
+The MUX example above is a fresh-create driver. After it runs, the issue tree exists and the kit's job is mostly done — subsequent work is moving items between swimlanes via `move-item.sh` and (occasionally) refining the plan.
+
+### Additions driver (`examples/<initiative>/additions/add-*.sh`)
+
+Companion one-shot, non-idempotent driver that adds new children to **existing** parent issues without recreating the tree. Use when:
+
+- A plan-review surfaces follow-on work that needs ticket coverage under existing parents (e.g., "phase 2 also needs a child for X")
+- A phase scope expands mid-flight
+- A mid-phase discovery needs its own ticket
+
+Same `lib.sh` helpers — no library changes. The driver fetches existing parent numbers (or accepts them as args), prep_body's sibling references, calls `create_child` + `link_sub_issue` for each new child, then adds to the Project. The reference implementation lives in nathanpaynedotcom (`scripts/gh-projects/examples/matchline/additions/add-plan-refinements.sh` on the `matchline/issue-driver` branch — promoted in [nathanpaynedotcom#263](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/263)).
+
+### Picking which to write
+
+| Situation | Driver |
+|---|---|
+| New initiative, no issues yet | Fresh-create |
+| Existing initiative, expanding scope | Additions |
+| Existing initiative, refining a single existing issue | Just edit the issue directly via `gh issue edit` — no driver needed |
+
+## Idempotency caveat
+
+Neither driver shape is currently idempotent. Re-running a fresh-create driver against a project that already has the issues will create duplicates. The scope-creep solution would be a `create_child_once` helper that skips when a child with the same title already exists under the same parent — file as a follow-up if you find yourself wanting to safely re-run an additions driver.

--- a/scripts/gh-projects/examples/mux-video-integration/create-issues.sh
+++ b/scripts/gh-projects/examples/mux-video-integration/create-issues.sh
@@ -22,6 +22,32 @@ export REPO="nathanjohnpayne/nathanpaynedotcom"
 export OWNER="nathanjohnpayne"
 export PROJECT=5
 
+# Safety gate (CodeRabbit on PR #180): this script writes to LIVE
+# project coordinates. Re-running creates duplicate issues #210+ and
+# spams the project board. Require explicit confirmation that the
+# operator knows they're hitting prod.
+#
+# Override:
+#   GHP_CONFIRM_LIVE=I_AM_REPOPULATING_PROJECT_5 ./create-issues.sh
+#
+# To repurpose this driver against a different project, change REPO/OWNER/
+# PROJECT above (and the override token) before running. This file is
+# the canonical worked example — copy it to your own examples/<initiative>/
+# directory before adapting, don't edit in place.
+if [[ "${GHP_CONFIRM_LIVE:-}" != "I_AM_REPOPULATING_PROJECT_5" ]]; then
+  echo "Refusing to run: this driver writes to live project coordinates"
+  echo "($REPO project #$PROJECT). Re-running creates duplicate issues."
+  echo ""
+  echo "If you're adapting this as a template for a different initiative,"
+  echo "COPY THE FILE to scripts/gh-projects/examples/<your-initiative>/"
+  echo "and edit REPO/OWNER/PROJECT plus this safety gate's override token"
+  echo "before running."
+  echo ""
+  echo "If you genuinely intend to repopulate $REPO project #$PROJECT,"
+  echo "set GHP_CONFIRM_LIVE=I_AM_REPOPULATING_PROJECT_5 and re-run."
+  exit 1
+fi
+
 # shellcheck source=../../lib.sh
 source "$SCRIPT_DIR/../../lib.sh"
 

--- a/scripts/gh-projects/examples/mux-video-integration/phase-2/c3.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-2/c3.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-file MD041 -->
 Wire Mux Data analytics into the MuxPlayer element.
 
 **Scope (one PR):**

--- a/scripts/gh-projects/examples/mux-video-integration/phase-2/c4.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-2/c4.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-file MD041 -->
 Manual QA: confirm Mux Data is recording views.
 
 **Checks (no code change — evidence only):**

--- a/scripts/gh-projects/examples/mux-video-integration/phase-3/c1.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-3/c1.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-file MD041 -->
 Extract MuxPlayer logic from ProjectLayout into a reusable component.
 
 **Scope (one PR):**

--- a/scripts/gh-projects/examples/mux-video-integration/phase-3/c2.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-3/c2.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-file MD041 -->
 Replace inline MuxPlayer block in ProjectLayout with the extracted component.
 
 **Scope (one PR):**

--- a/scripts/gh-projects/examples/mux-video-integration/phase-3/c3.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-3/c3.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-file MD041 -->
 Document "How to add a MUX video to a project page" in AGENTS.md.
 
 **Scope (one PR):**

--- a/scripts/gh-projects/examples/mux-video-integration/phase-3/c4.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-3/c4.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-file MD041 -->
 Verify theming cascades across every `project-page--*` accent class.
 
 **Checks (no committed code — local smoke test + evidence):**

--- a/scripts/gh-projects/examples/mux-video-integration/phase-3/parent.md
+++ b/scripts/gh-projects/examples/mux-video-integration/phase-3/parent.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-file MD041 -->
 Tracks Phase 3 of **MUX Video Integration** (Project #5).
 
 **Goal:** MuxPlayer usage lives in a single reusable Astro component so any future project page can embed a video by adding `muxPlaybackId` to its frontmatter. Per-page theming flows automatically from each project's `--project-accent`.
@@ -6,7 +7,7 @@ Tracks Phase 3 of **MUX Video Integration** (Project #5).
 - `src/components/ProjectMuxPlayer.astro` is the sole consumer of `@mux/mux-player-astro`.
 - `src/layouts/ProjectLayout.astro` calls the component once, no inline MuxPlayer logic.
 - AGENTS.md documents: "How to add a MUX video to a project page" (one frontmatter field).
-- Theming verified against each `project-page--*` accent class (red, yellow, blue, lightblue, paper).
+- Theming verified against each `project-page--*` accent class (red, yellow, black, blue, lightblue, paper).
 
 **Depends on:** the Phase 1 parent issue. Phase 2 is optional — component should work without a Mux Data env key.
 

--- a/scripts/gh-projects/lib.sh
+++ b/scripts/gh-projects/lib.sh
@@ -23,18 +23,9 @@ set -euo pipefail
 : "${REPO:?REPO must be set (owner/repo)}"
 : "${OWNER:?OWNER must be set}"
 : "${PROJECT:?PROJECT must be set (v2 number)}"
+: "${GH_TOKEN:?GH_TOKEN must be set to a PAT with repo + project scopes (CodeRabbit on PR #180: every helper here makes mutations on GitHub; failing fast at source-time is better than letting gh fall through to ambient auth and posting under the wrong identity)}"
 
-# If the caller already exported a GHP_TMPDIR they're responsible for
-# its lifecycle (e.g. a wrapper script that wants to inspect issue
-# bodies after the run). Otherwise we mint one here and register a
-# trap to clean it up on script exit so re-running create-issues.sh
-# does not leave a graveyard of $TMPDIR/tmp.XXXXXX/phase-*-c*.md
-# behind. See #342 → #232 nit.
-if [ -z "${GHP_TMPDIR:-}" ]; then
-  GHP_TMPDIR="$(mktemp -d)"
-  GHP_TMPDIR_OWNED=1
-  trap 'rm -rf "$GHP_TMPDIR"' EXIT
-fi
+GHP_TMPDIR="${GHP_TMPDIR:-$(mktemp -d)}"
 export GHP_TMPDIR
 
 # Add a created issue to the configured project.

--- a/scripts/gh-projects/move-item.sh
+++ b/scripts/gh-projects/move-item.sh
@@ -19,6 +19,13 @@ STATUS_NAME="${2:?status name required}"
 : "${REPO:?REPO must be set (owner/repo)}"
 : "${OWNER:?OWNER must be set}"
 : "${PROJECT:?PROJECT must be set}"
+: "${GH_TOKEN:?GH_TOKEN must be set to a PAT with project scope (this script mutates project items)}"
+
+# Required tooling: gh and python3 (used for parsing gh's JSON output below).
+# CodeRabbit on PR #180 caught the missing python3 check — fail fast with a
+# clear error rather than letting the python3 invocation crash mid-pipeline.
+command -v gh      >/dev/null 2>&1 || { echo "Error: gh CLI not on PATH (install via 'brew install gh')." >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "Error: python3 not on PATH (this script uses python3 to parse gh's JSON output; install python3 via your package manager)." >&2; exit 1; }
 
 export STATUS_NAME
 

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 # gh-pr-guard.sh — PreToolUse hook for Claude Code
 #
-# Gates three operations:
-#   1. gh pr create — blocks unless the command text includes
-#      "Authoring-Agent:" and "## Self-Review"
+# Gates four operations:
+#   1. gh pr create — blocks unless (a) the keyring's active gh
+#      account is the AUTHOR identity (nathanjohnpayne by default;
+#      override via GH_PR_GUARD_EXPECTED_AUTHOR), AND (b) the command
+#      text includes "Authoring-Agent:" and "## Self-Review". The
+#      identity check (#241) prevents the split-invocation footgun
+#      where a `gh auth switch` in one Bash tool call drifts before
+#      the `gh pr create` in a subsequent call, landing the PR under
+#      the wrong account. Canonical fix is to use
+#      scripts/gh-as-author.sh which wraps switch + create + switch-
+#      back in one bash process.
 #   2. gh pr merge --admin — blocks unless BREAK_GLASS_ADMIN=1
 #      (human must explicitly authorize in chat)
 #   3. gh pr merge (non-admin) — blocks when the target PR carries
@@ -13,6 +21,13 @@
 #      merge gate at the hook layer so an agent can't accidentally
 #      merge past Label Gate by removing the label without running
 #      the gate check first.
+#
+# The identity check (1a) honors a
+# BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK=1 escape hatch for tests
+# that PATH-shim gh and have no real keyring. Production code should
+# never set this — the wrapper script gh-as-author.sh switches to the
+# author identity BEFORE the gh pr create call lands, so the check
+# passes naturally without the bypass.
 #
 # Exit codes:
 #   0 = allow
@@ -512,6 +527,58 @@ fi
 # structural ones, and they don't depend on argument positions or
 # global flags.
 if [ "$PR_SUBCOMMAND" = "create" ]; then
+  # Identity check (#241): the keyring's active account must be the
+  # AUTHOR identity (nathanjohnpayne) at the moment of `gh pr create`,
+  # otherwise the PR is authored by whatever identity IS active —
+  # observed concretely on friends-and-family-billing#262 where a
+  # split switch / pr-create across two Bash tool calls landed a PR
+  # under the wrong identity. The canonical fix is to wrap the entire
+  # sequence in `scripts/gh-as-author.sh` so the switch and the create
+  # share one bash process.
+  #
+  # The check uses `gh config get -h github.com user`, NOT `gh auth
+  # status`. The latter is GH_TOKEN-poisonable: when GH_TOKEN is set
+  # it reports the GH_TOKEN entry as Active, but the keyring entry is
+  # still the one that signs writes. `gh config get` reads the
+  # keyring config file directly and is the authoritative read for
+  # "who will this write attribute to".
+  #
+  # Escape hatch: `BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK=1` lets
+  # tests and edge cases bypass this check. The check is additive
+  # defense-in-depth on top of gh-as-author.sh — when an agent runs
+  # `scripts/gh-as-author.sh -- gh pr create ...` correctly, the
+  # wrapper has already switched to the author identity by the time
+  # this hook fires, so the check passes naturally without the
+  # escape. The escape exists for test harnesses that PATH-shim `gh`
+  # and have no real keyring to read.
+  EXPECTED_AUTHOR="${GH_PR_GUARD_EXPECTED_AUTHOR:-nathanjohnpayne}"
+  if [ "${BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK:-0}" != "1" ]; then
+    ACTIVE_GH_USER=$(gh config get -h github.com user 2>/dev/null || echo "")
+    if [ -z "$ACTIVE_GH_USER" ]; then
+      echo "BLOCKED: gh-pr-guard could not read the active gh account from 'gh config get -h github.com user'." >&2
+      echo "  Either gh is not installed/authenticated, or the keyring config is corrupt." >&2
+      echo "  Run 'gh auth login' for the $EXPECTED_AUTHOR identity, then retry via scripts/gh-as-author.sh." >&2
+      exit 2
+    fi
+    if [ "$ACTIVE_GH_USER" != "$EXPECTED_AUTHOR" ]; then
+      echo "BLOCKED: gh pr create is about to run under active account '$ACTIVE_GH_USER', not the expected author identity '$EXPECTED_AUTHOR'." >&2
+      echo "" >&2
+      echo "  This is the #241 footgun. A PR created right now would be authored by '$ACTIVE_GH_USER'," >&2
+      echo "  which breaks self-approval (Can not approve your own pull request) and inverts the" >&2
+      echo "  Authoring-Agent: fingerprint in the PR body." >&2
+      echo "" >&2
+      echo "  Canonical fix: wrap the call in scripts/gh-as-author.sh, which switches to" >&2
+      echo "  $EXPECTED_AUTHOR, runs gh pr create, then restores the prior active account via" >&2
+      echo "  trap EXIT — all inside one bash process so the switch and the create can't drift apart:" >&2
+      echo "" >&2
+      echo "    scripts/gh-as-author.sh -- gh pr create --title '...' --body '...'" >&2
+      echo "" >&2
+      echo "  See REVIEW_POLICY.md § Recovery: PR created under the wrong identity for the case" >&2
+      echo "  where a PR already landed under the wrong account." >&2
+      exit 2
+    fi
+  fi
+
   MISSING=""
 
   if ! echo "$COMMAND" | grep -qi 'Authoring-Agent:'; then

--- a/scripts/hooks/label-removal-guard.sh
+++ b/scripts/hooks/label-removal-guard.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# label-removal-guard.sh — PreToolUse hook for Claude Code.
+#
+# Blocks `gh pr edit ... --remove-label <label>` calls (and the
+# add-label inverse for the same labels) for the human-action labels
+# defined in REVIEW_POLICY.md § Agent prohibitions:
+#
+#   - needs-external-review
+#   - needs-human-review
+#   - policy-violation
+#
+# Rationale: agents must never remove these labels, even when a human
+# authorizes it in chat. One-time chat authorization does not extrapolate
+# into standing permission. The sanctioned path is
+# `scripts/request-label-removal.sh <PR#> <label>`, which posts a
+# templated ask + optional iMessage ping, after which the human clears
+# the label from any device.
+#
+# This hook is mechanism enforcement — it makes the doctrinal rule
+# unbreakable regardless of whether the agent read the policy doc.
+#
+# Scope: this hook applies ONLY to `Bash` tool calls from interactive
+# agent sessions (claude / cursor / codex). It does NOT and SHOULD NOT
+# apply to `gh` calls executed inside GitHub Actions workflows — those
+# run in the CI runner's environment, not under an agent's PreToolUse
+# surface. Per the REVIEW_POLICY.md § Agent prohibitions sanctioned-
+# automation exception (#191/#195), the `auto-clear-blocking-labels.yml`
+# workflow is the only sanctioned automated path for
+# needs-external-review removal; this hook does not interfere with it.
+#
+# Architecture: same shape as scripts/hooks/gh-pr-guard.sh — read the
+# Bash command from stdin (Claude Code passes JSON via stdin to
+# PreToolUse hooks), tokenize with shlex (quote-aware), walk to find
+# `gh ... pr edit`, then scan the edit subcommand's flags for
+# --remove-label / --add-label whose value matches the prohibited set.
+#
+# A break-glass override is intentionally NOT provided. If a human
+# genuinely needs the agent to act on the label, they remove it
+# themselves; the agent can re-trigger merge after.
+#
+# Exit codes:
+#   0 = allow
+#   2 = block (hard stop)
+
+set -eo pipefail
+
+# Read stdin payload (Claude Code passes JSON; older harness passes raw
+# command). Be permissive: if stdin parses as JSON with .tool_input.command,
+# use that; otherwise treat stdin as the raw command.
+INPUT=$(cat)
+COMMAND=""
+TMP_CMD=$(mktemp)
+trap 'rm -f "$TMP_CMD" "${TMP_TOKENS:-}"' EXIT
+if echo "$INPUT" | python3 -c '
+import sys, json
+try:
+    d = json.loads(sys.stdin.read())
+    cmd = d.get("tool_input", {}).get("command", "")
+    sys.stdout.write(cmd)
+except Exception:
+    sys.exit(1)
+' > "$TMP_CMD" 2>/dev/null; then
+  COMMAND=$(cat "$TMP_CMD")
+else
+  COMMAND="$INPUT"
+fi
+
+# Empty command → allow (nothing to gate).
+if [ -z "$COMMAND" ]; then exit 0; fi
+
+# Cheap pre-check: if the command isn't `gh pr edit`, skip the tokenize
+# work entirely. We deliberately do NOT pre-check for the prohibited
+# label name as a substring — Codex P1 on PR #172 caught that the
+# substring gate is bypassable when the label value is supplied via
+# shell expansion (`--remove-label "$VAR"`) or ANSI-C quoting
+# (`--remove-label $'needs-human-review'`). The token-walk below sees
+# the EXPANDED value (because the harness passes the literal command
+# string the agent intends to run) — which means the post-tokenize
+# regex check is the source of truth, and any pre-check on label name
+# would either let bypasses through (bug) or false-positive on
+# unrelated commands. The `gh pr edit` form check is structural (the
+# binary name + subcommand must be literal for the command to do
+# anything), so it remains safe.
+case "$COMMAND" in
+  *gh*pr*edit*|*gh*-R*pr*edit*|*gh*--repo*pr*edit*) ;;
+  *) exit 0 ;;
+esac
+
+TMP_TOKENS=$(mktemp)
+trap 'rm -f "$TMP_CMD" "$TMP_TOKENS"' EXIT
+if ! printf '%s' "$COMMAND" | python3 -c '
+import sys, shlex
+try:
+    for tok in shlex.split(sys.stdin.read()):
+        sys.stdout.buffer.write(tok.encode("utf-8", errors="replace") + b"\x00")
+except ValueError:
+    sys.exit(1)
+' > "$TMP_TOKENS" 2>/dev/null; then
+  exit 0
+fi
+
+TOKENS=()
+while IFS= read -r -d '' tok; do TOKENS+=("$tok"); done < "$TMP_TOKENS"
+
+# Walk to find `gh ... pr edit`. We only need to know IF the command is
+# `gh pr edit`; we don't need the full state machine that gh-pr-guard.sh
+# uses for its merge-gate logic. A simple scan suffices because the
+# label-value scan below operates on the entire token list anyway.
+saw_gh=0
+saw_pr=0
+saw_edit=0
+edit_index=-1
+for i in "${!TOKENS[@]}"; do
+  tok="${TOKENS[$i]}"
+  if [ "$saw_gh" -eq 0 ]; then
+    [ "$tok" = "gh" ] && saw_gh=1
+    continue
+  fi
+  if [ "$saw_pr" -eq 0 ]; then
+    if [ "$tok" = "pr" ]; then saw_pr=1; fi
+    continue
+  fi
+  if [ "$saw_edit" -eq 0 ]; then
+    if [ "$tok" = "edit" ]; then
+      saw_edit=1
+      edit_index=$i
+    fi
+    continue
+  fi
+done
+[ "$saw_edit" -eq 1 ] || exit 0
+
+# Scan tokens AFTER `edit` for --remove-label or --add-label values.
+# Both forms are blocked: removing a label bypasses human gating;
+# adding one (e.g. spuriously re-applying policy-violation) is also a
+# human action.
+#
+# Two block triggers:
+#   1. Literal value matches the prohibited set.
+#   2. Value undergoes shell expansion (contains $, backtick, or starts
+#      with $') — Codex P1 on PR #172. The hook receives the literal
+#      command string before bash expands variables, so a value like
+#      `--remove-label "$VAR"` would tokenize as the literal `$VAR`
+#      and slip past a value-only regex check, even though the bash
+#      that actually runs the command would expand it to a prohibited
+#      label. Block any expansion-bearing value with a message
+#      directing the agent to use a literal label name (so the hook
+#      can see what's being modified) or scripts/request-label-removal.sh.
+PROHIBITED_RE='^(needs-external-review|needs-human-review|policy-violation)$'
+EXPANSION_RE='[$`]'
+walk_start=$((edit_index + 1))
+SKIP_AS=""  # "" | "label-flag-value"
+
+# Codex r1 on PR #172 caught: gh accepts `--remove-label A,B` as a
+# comma-separated list, but the regex above only matches the entire
+# token. So `--remove-label needs-external-review,foo` would slip
+# past — the joined value doesn't match `^needs-external-review$`,
+# but bash splits and removes both labels. Check each comma-split
+# segment instead of the whole value.
+check_label_value() {
+  local raw="$1"
+  if [[ "$raw" =~ $EXPANSION_RE ]]; then block_expansion "$raw"; fi
+  local IFS=','
+  for sub in $raw; do
+    sub="${sub# }"; sub="${sub% }"   # trim incidental whitespace
+    [[ -z "$sub" ]] && continue
+    if [[ "$sub" =~ $PROHIBITED_RE ]]; then block_prohibited "$sub"; fi
+  done
+}
+
+block_prohibited() {
+  local label="$1"
+  cat <<EOF >&2
+BLOCKED: agents must not modify the '$label' label on PRs.
+
+Per REVIEW_POLICY.md § Agent prohibitions, the labels:
+  - needs-external-review
+  - needs-human-review
+  - policy-violation
+are HUMAN-ACTION labels. One-time chat authorization does not extend to
+agent action on these labels.
+
+If the PR is otherwise green and only this label is blocking merge:
+  scripts/request-label-removal.sh <PR#> $label
+
+That helper posts a templated ask on the PR (and optionally iMessages
+the human). The human clears the label from any device; auto-merge
+fires immediately.
+EOF
+  exit 2
+}
+
+block_expansion() {
+  local val="$1"
+  cat <<EOF >&2
+BLOCKED: --add-label / --remove-label value '$val' contains shell
+expansion (\$, backtick, or \$'…' quoting). The hook can't see what
+this expands to until bash runs the command — so it cannot verify the
+label isn't one of the prohibited set (needs-external-review,
+needs-human-review, policy-violation).
+
+Use a literal label name so the guard can verify it, OR — if you
+intended to remove a prohibited label — run:
+  scripts/request-label-removal.sh <PR#> <label>
+
+See REVIEW_POLICY.md § Agent prohibitions.
+EOF
+  exit 2
+}
+
+for j in "${!TOKENS[@]}"; do
+  if [ "$j" -lt "$walk_start" ]; then continue; fi
+  tok="${TOKENS[$j]}"
+  if [ "$SKIP_AS" = "label-flag-value" ]; then
+    SKIP_AS=""
+    check_label_value "$tok"
+    continue
+  fi
+  case "$tok" in
+    --remove-label|--add-label)
+      SKIP_AS="label-flag-value"
+      continue
+      ;;
+    --remove-label=*|--add-label=*)
+      check_label_value "${tok#*=}"
+      continue
+      ;;
+  esac
+done
+
+exit 0

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -26,7 +26,7 @@
 #
 # Modes:
 #   review  — reviewer PAT + author PAT + SSH key warming
-#   deploy  — GCP ADC credential
+#   deploy  — GCP ADC credential + Cloudflare cache-purge token
 #   all     — everything (default)
 #
 # Flags:
@@ -45,6 +45,14 @@
 #                             file does NOT extend its effective lifetime.
 #   OP_PREFLIGHT_CACHE_DIR    Override cache dir (default
 #                             $XDG_CACHE_HOME/mergepath or $HOME/.cache/mergepath).
+#   OP_PREFLIGHT_SSH_WARM_TTL_SECONDS
+#                             Override SSH-warm freshness window (default
+#                             1800s = 30 min). Independent of the PAT
+#                             cache TTL because the 1Password SSH agent
+#                             has its own session lifetime, typically
+#                             shorter than 4h. Skipping re-warm within
+#                             this window prevents a biometric prompt on
+#                             every cache-hit invocation. See #163.
 #
 # Session file:
 #   Path:        $cache_dir/op-preflight-<agent>.env
@@ -52,11 +60,25 @@
 #   Format:      bash-sourceable KEY='value' lines (printf %q-escaped)
 #   TTL anchor:  OP_PREFLIGHT_CREATED_AT_EPOCH (embedded in file, not mtime)
 #
-# After eval, downstream scripts and agent commands use the exported env
-# vars instead of calling op directly:
-#   GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh pr review ...
-#   GH_TOKEN="$OP_PREFLIGHT_AUTHOR_PAT"   gh pr merge ...
-#   # gcloud/firebase use GOOGLE_APPLICATION_CREDENTIALS automatically
+# After eval, downstream usage splits along the gh read/write boundary
+# (see CLAUDE.md § Active-account convention):
+#
+#   # Read-path: GH_TOKEN authenticates the request (no byline involved).
+#   GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" gh api user --jq .login
+#   GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/codex-review-check.sh <PR#>
+#
+#   # Helpers that may also POST a trigger comment — GH_TOKEN authenticates
+#   # the API call, but the comment byline is the active keyring account.
+#   GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/coderabbit-wait.sh <PR#>
+#   GH_TOKEN="$OP_PREFLIGHT_REVIEWER_PAT" scripts/codex-review-request.sh <PR#>
+#
+#   # Write-path: active keyring is the byline; GH_TOKEN is irrelevant.
+#   # This script warns if active != expected.
+#   gh pr review <PR#> --comment --body "..."   # active = nathanpayne-<agent>
+#   gh auth switch -u nathanjohnpayne && gh pr merge <PR#> ... && \
+#     gh auth switch -u nathanpayne-<agent>     # author write
+#
+#   # gcloud/firebase use GOOGLE_APPLICATION_CREDENTIALS automatically.
 
 set -eo pipefail
 umask 077  # Restrict file permissions before any mktemp/cache writes
@@ -91,6 +113,15 @@ TTL_SECONDS="${OP_PREFLIGHT_TTL_SECONDS:-$DEFAULT_TTL_SECONDS}"
 
 # ── GCP ADC ───────────────────────────────────────────────────────────
 DEFAULT_ADC_OP_URI="${GCP_ADC_OP_URI:-op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential}"
+
+# ── Cloudflare Cache Purge token (#167) ───────────────────────────────
+# Shared API token with Purge:Edit permission across all domains. Wired
+# into preflight so scripts/deploy.sh's existing CF purge step
+# (currently no-op when CF_API_TOKEN is unset) actually fires on
+# agent-driven deploys without an extra biometric prompt. CF_ZONE_ID
+# is intentionally NOT sourced here — it's per-repo and lives in each
+# downstream consumer's own bootstrap, not in this shared wiring.
+DEFAULT_CF_TOKEN_OP_URI="${CF_TOKEN_OP_URI:-op://Private/4x6wslp3f6pal5t6h3jhhe63ie/credential}"
 SSH_AUTHOR_HOST="github.com"
 
 # ── Parse arguments ───────────────────────────────────────────────────
@@ -123,20 +154,15 @@ done
 if $PURGE_ALL; then
   if [[ -d "$CACHE_DIR" ]]; then
     echo "# Purging all session files under $CACHE_DIR" >&2
-    find "$CACHE_DIR" -maxdepth 1 -type f \( -name 'op-preflight-*.env' -o -name 'op-preflight-*-adc.json' \) -print -delete >&2
+    find "$CACHE_DIR" -maxdepth 1 -type f \( -name 'op-preflight-*.env' -o -name 'op-preflight-*-adc.json' -o -name 'op-preflight-*.ssh-warmed' \) -print -delete >&2
   fi
   exit 0
 fi
 
-if [[ "$MODE" == "review" || "$MODE" == "deploy" || "$MODE" == "all" || "$PURGE" == "true" ]] && [[ -z "$AGENT" ]]; then
-  # Deploy mode also requires --agent because the cache file paths below
-  # are derived from $AGENT (op-preflight-$AGENT.env / op-preflight-$AGENT-adc.json).
-  # An empty agent produces shared filenames (`op-preflight-.env`) that
-  # collide across invocations and would silently mix credentials between
-  # cowork sessions. See #342 → #250 P3 finding.
-  echo "Error: --agent is required for review, deploy, all, or --purge mode." >&2
+if [[ "$MODE" == "review" || "$MODE" == "all" || "$PURGE" == "true" ]] && [[ -z "$AGENT" ]]; then
+  echo "Error: --agent is required for review, all, or --purge mode." >&2
   echo "Usage: eval \"\$(scripts/op-preflight.sh --agent claude --mode all)\"" >&2
-  exit 2
+  exit 1
 fi
 
 if [[ -n "$AGENT" ]] && [[ -z "$(reviewer_pat_item_for "$AGENT" 2>/dev/null || true)" ]]; then
@@ -152,11 +178,13 @@ fi
 # ── Cache paths (deterministic per agent) ─────────────────────────────
 SESSION_FILE="$CACHE_DIR/op-preflight-$AGENT.env"
 ADC_TMPFILE="$CACHE_DIR/op-preflight-$AGENT-adc.json"
+SSH_WARM_MARKER="$CACHE_DIR/op-preflight-$AGENT.ssh-warmed"
+SSH_WARM_TTL_SECONDS="${OP_PREFLIGHT_SSH_WARM_TTL_SECONDS:-1800}"  # 30 min default; #163
 
 # ── Purge mode ────────────────────────────────────────────────────────
 if $PURGE; then
-  rm -f "$SESSION_FILE" "$ADC_TMPFILE"
-  echo "# Purged session file + ADC tempfile for agent=$AGENT" >&2
+  rm -f "$SESSION_FILE" "$ADC_TMPFILE" "$SSH_WARM_MARKER"
+  echo "# Purged session file + ADC tempfile + SSH-warm marker for agent=$AGENT" >&2
   exit 0
 fi
 
@@ -186,6 +214,7 @@ if $DRY_RUN; then
   fi
   if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
     echo "# Would read: GCP ADC ($DEFAULT_ADC_OP_URI)" >&2
+    echo "# Would read: Cloudflare cache-purge token ($DEFAULT_CF_TOKEN_OP_URI)" >&2
   fi
   exit 0
 fi
@@ -300,12 +329,57 @@ log_stale_adc_guidance() {
 # incomplete codex session file look valid and causing gh to run as
 # the wrong identity. See round-5 Codex finding on the propagation
 # PRs for the multi-agent repro.
+# Active-account check (warn-only). gh's write paths use the keyring's
+# active account regardless of GH_TOKEN. Each agent's machine should
+# have its agent identity (nathanpayne-<agent>) as the active gh
+# account so reviewer-identity writes (gh pr review --comment) attribute
+# correctly without a switch. Author-identity writes (gh pr create /
+# merge / edit) still need a temporary `gh auth switch -u nathanjohnpayne`
+# around them. See nathanjohnpayne/mergepath#164 for the empirical
+# diagnosis (matchline PRs #181, #182 — wrong-byline reviews when active
+# was nathanjohnpayne instead of the agent identity).
+warn_active_account_mismatch() {
+  # Skip silently when no agent is selected (e.g. deploy-only runs that
+  # don't need a reviewer identity). The check only makes sense when
+  # we know which agent identity SHOULD be active. Codex P2 on PR #171.
+  [[ -z "$AGENT" ]] && return 0
+  command -v gh >/dev/null 2>&1 || return 0
+  local expected="nathanpayne-${AGENT}"
+  local actual=""
+  # Use `gh config get -h github.com user` to read the active keyring
+  # account. This is the GH_TOKEN-immune signal:
+  #
+  #   - `gh auth status` honors GH_TOKEN — when GH_TOKEN is set, gh
+  #     reports the GH_TOKEN entry as Active: true and flips the
+  #     keyring entry to Active: false, even though writes still use
+  #     the keyring active. Codex CHANGES_REQUESTED on #171 reproduced
+  #     this masking: GH_TOKEN=<codex PAT> + keyring active=claude
+  #     made `gh auth status` parsers report codex as active, masking
+  #     the mismatch the warn function exists to surface.
+  #
+  #   - `gh config get -h github.com user` reads the keyring's stored
+  #     active username directly from ~/.config/gh/hosts.yml. It does
+  #     NOT honor GH_TOKEN. Verified: returns `nathanpayne-claude`
+  #     unchanged with and without GH_TOKEN set.
+  #
+  # Wrap in `|| true` so a `gh config` failure (corrupt hosts.yml,
+  # no gh login) cannot abort the parent under `set -eo pipefail`.
+  actual=$(gh config get -h github.com user 2>/dev/null || true)
+  if [[ -n "$actual" ]] && [[ "$actual" != "$expected" ]]; then
+    echo "# WARNING: gh active account is '$actual' (expected '$expected')." >&2
+    echo "#   Reviewer-identity writes (gh pr review) will mis-attribute." >&2
+    echo "#   Fix once: gh auth switch -u $expected" >&2
+    echo "#   See CLAUDE.md § Active-account convention for the full pattern." >&2
+  fi
+}
+
 emit_from_session_file() (
   # Subshell: the (  ... ) above means unset/source/return here do
   # not escape back to the caller. We still "return" rc codes via
   # stdout+exit; parent stays clean.
   unset OP_PREFLIGHT_REVIEWER_PAT OP_PREFLIGHT_AUTHOR_PAT
   unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
+  unset CF_API_TOKEN
   unset OP_PREFLIGHT_DONE OP_PREFLIGHT_AGENT OP_PREFLIGHT_MODE
   unset OP_PREFLIGHT_CREATED_AT_EPOCH OP_PREFLIGHT_TTL_SECONDS
 
@@ -351,23 +425,14 @@ emit_from_session_file() (
       exit 2
     fi
     if ! adc_is_usable "${GOOGLE_APPLICATION_CREDENTIALS}"; then
-      # File exists but refresh token is rejected. Exit 2 to fall
-      # through to the full-fetch path below, matching how a missing
-      # ADC file is treated three lines up. The full-fetch path will
-      # re-read from 1Password — if the user has rotated the ADC
-      # since this cache was written, the refresh picks up the new
-      # credential and the system self-heals; if 1Password still
-      # holds the same stale ADC, the slow path itself logs guidance
-      # and continues with PATs only (lines 503-507 below), so the
-      # cost of "self-healing" is one biometric prompt rather than
-      # waiting out TTL.
-      #
-      # Earlier code treated this as a partial-success (warn + emit
-      # PATs from the cache) which violated the symmetry with the
-      # missing-ADC case and meant a rotated 1Password ADC stayed
-      # invisible to the system until TTL expiry. See #342 → #250 P2.
+      # File exists but refresh token is rejected. Warn and skip the
+      # export so downstream deploy callers can fall back to local
+      # firebase-login / ADC. OP_PREFLIGHT_DONE stays 1 and PATs are
+      # still emitted below, because preflight itself succeeded —
+      # only the ADC-specific path is degraded, which matches what
+      # the user will see when they run `gcloud auth ...` manually.
       log_stale_adc_guidance
-      exit 2
+      unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
     fi
   fi
 
@@ -379,6 +444,8 @@ emit_from_session_file() (
     printf 'export GOOGLE_APPLICATION_CREDENTIALS=%q\n' "$GOOGLE_APPLICATION_CREDENTIALS"
   [[ -n "${OP_PREFLIGHT_ADC_TMPFILE:-}" ]] && \
     printf 'export OP_PREFLIGHT_ADC_TMPFILE=%q\n' "$OP_PREFLIGHT_ADC_TMPFILE"
+  [[ -n "${CF_API_TOKEN:-}" ]] && \
+    printf 'export CF_API_TOKEN=%q\n' "$CF_API_TOKEN"
   printf 'export OP_PREFLIGHT_DONE=1\n'
   printf 'export OP_PREFLIGHT_AGENT=%q\n' "$AGENT"
   exit 0
@@ -392,7 +459,34 @@ emit_from_session_file() (
 # means subsequent git/gh SSH operations can still block on auth even
 # after preflight reports success (friends-and-family-billing#227
 # round-5 Codex P2). Output goes to stderr so it's not eval'd.
+#
+# SSH-warm freshness (#163): the 1Password SSH agent has its OWN
+# session TTL — independent of the chmod-600 PAT cache. Re-warming
+# on every cache-hit invocation re-prompts biometric whenever the
+# 1Password agent's own session has expired (typically much shorter
+# than the 4h PAT TTL). Track an SSH-warm marker file and skip the
+# warm if it's recent enough. The marker's age is the only thing
+# that matters here — if the 1Password agent expires inside our
+# SSH_WARM_TTL window, the next git push/pull still triggers
+# biometric, but at least preflight itself doesn't multiply that.
+ssh_warm_is_fresh() {
+  [[ -f "$SSH_WARM_MARKER" ]] || return 1
+  local mtime now age
+  mtime=$(stat -f %m "$SSH_WARM_MARKER" 2>/dev/null || stat -c %Y "$SSH_WARM_MARKER" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  age=$((now - mtime))
+  [[ "$age" -lt "$SSH_WARM_TTL_SECONDS" ]]
+}
+
 warm_ssh_keys() {
+  if ssh_warm_is_fresh; then
+    local mtime now age
+    mtime=$(stat -f %m "$SSH_WARM_MARKER" 2>/dev/null || stat -c %Y "$SSH_WARM_MARKER" 2>/dev/null || echo 0)
+    now=$(date +%s); age=$((now - mtime))
+    echo "# Preflight: SSH keys recently warmed (${age}s ago / TTL ${SSH_WARM_TTL_SECONDS}s) — skipping" >&2
+    SUMMARY+=("SSH keys: cached (${age}s ago)")
+    return 0
+  fi
   echo "# Preflight: warming SSH keys..." >&2
   if ssh -T "git@${SSH_AUTHOR_HOST}" 2>&1 | grep -qi "successfully authenticated"; then
     SUMMARY+=("SSH key ($SSH_AUTHOR_HOST): authorized")
@@ -406,7 +500,20 @@ warm_ssh_keys() {
   else
     SUMMARY+=("SSH key ($reviewer_host): warming attempted")
   fi
+  # Touch the marker AFTER both warms attempted. If either warm failed
+  # (network blip, key not in agent) we still set the marker — the next
+  # git op will surface the underlying problem rather than masking it
+  # with a re-warm cycle. Marker-touch failures are non-fatal.
+  touch "$SSH_WARM_MARKER" 2>/dev/null || true
+  chmod 600 "$SSH_WARM_MARKER" 2>/dev/null || true
 }
+
+# ── Refresh forces both PAT cache + SSH-warm marker invalidation ─────
+# (--refresh is the "I want a brand-new biometric burst" knob; honor
+# it for SSH too, otherwise the warm would skip via the marker.)
+if $REFRESH; then
+  rm -f "$SSH_WARM_MARKER"
+fi
 
 # ── Fast path: reuse session file when fresh ──────────────────────────
 if ! $REFRESH && session_is_fresh; then
@@ -441,6 +548,7 @@ if ! $REFRESH && session_is_fresh; then
       echo "#   $line" >&2
     done
     echo "# Run with --refresh to force a new biometric fetch." >&2
+    warn_active_account_mismatch
     echo "# ──────────────────────────────────────────────────────────" >&2
     exit 0
   fi
@@ -524,6 +632,20 @@ if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
     echo "# Warning: could not read GCP ADC. Deploy credentials not cached." >&2
     SUMMARY+=("GCP ADC: SKIPPED (not available)")
   fi
+
+  # Cloudflare cache-purge token (#167). Optional — if 1Password is
+  # unreachable for this item the deploy still proceeds; deploy.sh's
+  # CF purge step gracefully no-ops on empty CF_API_TOKEN.
+  echo "# Preflight: reading Cloudflare cache-purge token..." >&2
+  cf_token=$(op read "$DEFAULT_CF_TOKEN_OP_URI" 2>/dev/null || true)
+  if [[ -n "$cf_token" ]]; then
+    EXPORTS+=("export CF_API_TOKEN=$(printf '%q' "$cf_token")")
+    SESSION_LINES+=("CF_API_TOKEN=$(printf '%q' "$cf_token")")
+    SUMMARY+=("Cloudflare cache-purge token: loaded")
+  else
+    echo "# Warning: could not read Cloudflare cache-purge token. CF_API_TOKEN not exported; deploy.sh will skip the purge step." >&2
+    SUMMARY+=("Cloudflare cache-purge token: SKIPPED (not available)")
+  fi
 fi
 
 # ── Phase 2: SSH key warming ──────────────────────────────────────────
@@ -567,5 +689,6 @@ for line in "${SUMMARY[@]}"; do
 done
 echo "# Session file: $SESSION_FILE (TTL ${TTL_SECONDS}s)" >&2
 echo "# OP_PREFLIGHT_DONE=1" >&2
+warn_active_account_mismatch
 echo "# Human can step away." >&2
 echo "# ──────────────────────────────────────────────────────" >&2

--- a/scripts/phase-4b-classifier.sh
+++ b/scripts/phase-4b-classifier.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+# phase-4b-classifier.sh — classify a PR against the Phase 4b proactive-
+# trigger taxonomy from REVIEW_POLICY.md § Phase 4b Triggers (#158).
+#
+# Reads the PR's changed-files list + body, runs five trigger detectors,
+# emits a JSON recommendation. Consumed by CLAUDE.md step 8.5 (#187) to
+# decide whether to invoke Phase 4b proactively in addition to its
+# fallback role.
+#
+# Usage:
+#   scripts/phase-4b-classifier.sh <PR#>
+#   scripts/phase-4b-classifier.sh <PR#> --repo owner/name
+#   scripts/phase-4b-classifier.sh <PR#> --fixture path/to/files.json
+#
+# The --fixture flag is for testability: instead of calling
+# `gh api repos/.../pulls/{pr}/files`, read the changed-files JSON from
+# the fixture file. Same shape as gh's response (array of {filename,
+# patch} objects). Used by scripts/ci/check_phase_4b_classifier.
+#
+# Exit codes (per #158):
+#   0 — no 4b needed (no trigger matched OR phase_4b_default == "fallback-only")
+#   1 — 4b recommended (one or more triggers matched AND policy is
+#       "complex-changes" or "always")
+#   2 — gh API failure / malformed config
+#   3 — bad arguments
+#
+# Output (stdout, JSON):
+#   {
+#     "match": true|false,
+#     "triggers": ["state-machine-change", "concurrency", ...],
+#     "recommendation": "invoke-4b" | "fallback-only",
+#     "rationale": "<human-readable>",
+#     "phase_4b_default": "<policy value>",
+#     "files_inspected": <count>
+#   }
+
+set -euo pipefail
+
+# ── Argument parsing ─────────────────────────────────────────────────────────
+
+PR_NUM=""
+REPO=""
+FIXTURE=""
+
+usage() {
+  cat <<'EOF' >&2
+Usage: scripts/phase-4b-classifier.sh <PR#> [--repo owner/name] [--fixture path]
+
+Classifies a PR against the Phase 4b proactive-trigger taxonomy
+(REVIEW_POLICY.md § Phase 4b Triggers). Outputs JSON recommendation.
+
+Exit codes:
+  0 = no 4b needed
+  1 = 4b recommended
+  2 = API / config error
+  3 = bad arguments
+
+EOF
+  exit 3
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)
+      if [ $# -lt 2 ] || [ -z "$2" ]; then
+        echo "Error: --repo requires a non-empty value (owner/name)" >&2; usage
+      fi
+      REPO="$2"; shift 2 ;;
+    --fixture)
+      if [ $# -lt 2 ] || [ -z "$2" ]; then
+        echo "Error: --fixture requires a non-empty value (path)" >&2; usage
+      fi
+      FIXTURE="$2"; shift 2 ;;
+    -h|--help) usage ;;
+    -*) echo "Unknown flag: $1" >&2; usage ;;
+    *)
+      if [ -z "$PR_NUM" ]; then PR_NUM="$1"
+      else echo "Unexpected positional: $1" >&2; usage
+      fi
+      shift
+      ;;
+  esac
+done
+
+[ -z "$PR_NUM" ] && usage
+if ! [[ "$PR_NUM" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Error: PR# must be a positive integer; got '$PR_NUM'" >&2; exit 3
+fi
+
+if [ -n "$REPO" ] && ! [[ "$REPO" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+  echo "Error: invalid --repo value: '$REPO' (expected owner/name)" >&2; exit 3
+fi
+
+if [ -n "$FIXTURE" ] && [ ! -r "$FIXTURE" ]; then
+  echo "Error: --fixture file not readable: $FIXTURE" >&2; exit 3
+fi
+
+# ── Policy: phase_4b_default ─────────────────────────────────────────────────
+
+CONFIG=".github/review-policy.yml"
+PHASE_4B_DEFAULT=""
+if [ -f "$CONFIG" ]; then
+  PHASE_4B_DEFAULT=$(awk '
+    $1 == "phase_4b_default:" {
+      sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+      gsub(/^"/, "", $0); gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+      gsub(/[[:space:]]*#.*$/, "", $0); sub(/[[:space:]]+$/, "", $0)
+      print; exit
+    }
+  ' "$CONFIG")
+fi
+PHASE_4B_DEFAULT=${PHASE_4B_DEFAULT:-fallback-only}
+case "$PHASE_4B_DEFAULT" in
+  fallback-only|complex-changes|always) ;;
+  *)
+    echo "Error: phase_4b_default must be one of fallback-only / complex-changes / always; got '$PHASE_4B_DEFAULT'" >&2
+    echo "       See REVIEW_POLICY.md § Phase 4b Triggers." >&2
+    exit 2
+    ;;
+esac
+
+# ── Fast-path: policy short-circuits ─────────────────────────────────────────
+
+emit_json() {
+  local match=$1 triggers=$2 recommendation=$3 rationale=$4 files_inspected=$5
+  jq -n \
+    --argjson match "$match" \
+    --argjson triggers "$triggers" \
+    --arg rec "$recommendation" \
+    --arg rationale "$rationale" \
+    --arg policy "$PHASE_4B_DEFAULT" \
+    --argjson files_inspected "$files_inspected" \
+    '{match: $match, triggers: $triggers, recommendation: $rec,
+      rationale: $rationale, phase_4b_default: $policy,
+      files_inspected: $files_inspected}'
+}
+
+if [ "$PHASE_4B_DEFAULT" = "fallback-only" ]; then
+  emit_json false '[]' "fallback-only" "policy is fallback-only; classifier short-circuits without inspecting diff" 0
+  exit 0
+fi
+
+if [ "$PHASE_4B_DEFAULT" = "always" ]; then
+  emit_json true '[]' "invoke-4b" "policy is always; 4b handoff is required for every threshold-PR regardless of trigger match" 0
+  exit 1
+fi
+
+# Past this point: PHASE_4B_DEFAULT == "complex-changes". Run the
+# trigger detectors.
+
+# ── Resolve repo + fetch PR data ────────────────────────────────────────────
+
+# --fixture bypasses live API calls, so REPO resolution is unnecessary.
+# Only resolve when actually going to call gh.
+if [ -z "$REPO" ] && [ -z "$FIXTURE" ]; then
+  REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) || {
+    echo "Error: could not resolve repo. Pass --repo owner/name (or --fixture)." >&2; exit 2
+  }
+fi
+
+if [ -n "$FIXTURE" ]; then
+  FILES_JSON=$(cat "$FIXTURE")
+  # Validate JSON shape up-front — jq's native exit codes (e.g., 4 on
+  # parse error, 5 on schema mismatch) would otherwise propagate
+  # through `set -e` and break the script's documented 0/1/2/3 exit
+  # contract. CodeRabbit Major on PR #190.
+  if ! echo "$FILES_JSON" | jq -e . >/dev/null 2>&1; then
+    echo "Error: fixture is not valid JSON: $FIXTURE" >&2
+    exit 2
+  fi
+  PR_BODY=""
+  # Fixtures may include an optional body field via .body — extract it
+  # if present, otherwise empty. The fixture file's top-level shape is
+  # either a bare files array (legacy/simple) or a {body, files} object
+  # (when body-text triggers need to be exercised).
+  if echo "$FILES_JSON" | jq -e 'type == "object" and has("files")' >/dev/null 2>&1; then
+    PR_BODY=$(echo "$FILES_JSON" | jq -r '.body // ""' 2>/dev/null) || {
+      echo "Error: failed to read .body from fixture object" >&2; exit 2
+    }
+    FILES_JSON=$(echo "$FILES_JSON" | jq '.files' 2>/dev/null) || {
+      echo "Error: failed to read .files from fixture object" >&2; exit 2
+    }
+  fi
+  if ! echo "$FILES_JSON" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    echo "Error: fixture changed-files payload must be an array (got non-array after .files extraction)" >&2
+    exit 2
+  fi
+else
+  if [ -z "${GH_TOKEN:-}" ]; then
+    echo "Error: GH_TOKEN required for live API call (or use --fixture)." >&2
+    exit 2
+  fi
+  FILES_JSON=$(gh api --paginate "repos/$REPO/pulls/$PR_NUM/files" 2>&1) || {
+    echo "Error: failed to fetch PR files: $FILES_JSON" >&2; exit 2
+  }
+  # gh --paginate emits a stream of arrays; flatten into one. Normalize
+  # any jq failure here to exit 2 per the contract.
+  FILES_JSON=$(echo "$FILES_JSON" | jq -s 'add // []' 2>/dev/null) || {
+    echo "Error: failed to flatten gh pulls/files paginated response" >&2; exit 2
+  }
+  # Mirror the fixture-path shape guard: after flatten, the live API
+  # response must be a JSON array. Anything else (a string error blob
+  # gh somehow snuck through, an object, null) is a contract violation
+  # — exit 2 instead of letting jq's downstream `.[]` produce confusing
+  # failures. CR Major on PR #190 r1.
+  if ! echo "$FILES_JSON" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    echo "Error: live API changed-files payload must be an array (got non-array after flatten)" >&2
+    exit 2
+  fi
+  # PR body fetch failure must NOT silently mask body-only triggers
+  # (state-machine via "state machine" body mention, invariant via
+  # "invariant" body mention). Hard-fail with exit 2 instead of
+  # falling through with PR_BODY="" — codex r1 Phase 4b on PR #190
+  # caught the prior `|| echo ""` swallow + reproduced with stubbed gh.
+  PR_BODY=$(gh api "repos/$REPO/pulls/$PR_NUM" --jq '.body // ""' 2>&1) || {
+    echo "Error: failed to fetch PR body for $REPO#$PR_NUM: $PR_BODY" >&2
+    echo "       Body-only triggers (state-machine / invariant body mention) require this fetch to succeed." >&2
+    exit 2
+  }
+fi
+
+FILES_COUNT=$(echo "$FILES_JSON" | jq 'length' 2>/dev/null) || {
+  echo "Error: failed to compute files count (malformed FILES_JSON)" >&2; exit 2
+}
+if [ "$FILES_COUNT" -eq 0 ]; then
+  emit_json false '[]' "fallback-only" "no files in PR diff" 0
+  exit 0
+fi
+
+# Pre-extract for the detectors:
+#   FILE_PATHS — newline-separated filenames
+#   PATCH_TEXT — concatenated patch hunks for keyword scanning
+FILE_PATHS=$(echo "$FILES_JSON" | jq -r '.[].filename // empty')
+PATCH_TEXT=$(echo "$FILES_JSON" | jq -r '.[].patch // empty')
+
+# ── Trigger detectors ───────────────────────────────────────────────────────
+# Each function: prints rationale fragment to stdout on match; returns 0
+# on match, 1 on no-match. The caller composes hits into the triggers
+# array and the rationale into the JSON output.
+
+detect_state_machine_changes() {
+  # Tagged-union pattern: `type X = | { kind: "..."` or similar.
+  # Plus PR body explicit "state machine" mention.
+  local matched_files matched_body=""
+  matched_files=$(echo "$PATCH_TEXT" | grep -E '\| \{ kind: "|\| \{ status: "|type [A-Z][A-Za-z0-9_]+ = .* \| .* \|' || true)
+  if echo "$PR_BODY" | grep -qiE '\bstate[ -]machine\b'; then
+    matched_body="PR body mentions state machine"
+  fi
+  if [ -n "$matched_files" ] || [ -n "$matched_body" ]; then
+    local frag="state-machine pattern detected"
+    [ -n "$matched_body" ] && frag="$frag ($matched_body)"
+    [ -n "$matched_files" ] && frag="$frag (tagged-union pattern in diff)"
+    printf '%s' "$frag"
+    return 0
+  fi
+  return 1
+}
+
+detect_concurrency() {
+  local matched_keywords matched_paths
+  # `|| true` on each grep — under `set -euo pipefail` an empty-match
+  # grep exits 1, which propagates through pipefail and aborts the
+  # script before the no-match branch is taken. CR Major on PR #190 r1.
+  matched_keywords=$({ echo "$PATCH_TEXT" | grep -Eo 'runTransaction|setSnapshot|applyOptimistic|compare-and-set|Promise\.all|writeBatch' || true; } | sort -u | head -3)
+  matched_paths=$({ echo "$FILE_PATHS" | grep -E '(^|/)(transactions?|concurrency)/' || true; } | head -3)
+  if [ -n "$matched_keywords" ] || [ -n "$matched_paths" ]; then
+    local frag="concurrency/transactional pattern detected"
+    [ -n "$matched_keywords" ] && frag="$frag (keywords: $(echo "$matched_keywords" | tr '\n' ',' | sed 's/,$//'))"
+    [ -n "$matched_paths" ] && frag="$frag (paths: $(echo "$matched_paths" | tr '\n' ',' | sed 's/,$//'))"
+    printf '%s' "$frag"
+    return 0
+  fi
+  return 1
+}
+
+detect_prompt_design() {
+  local matched
+  matched=$({ echo "$FILE_PATHS" | grep -E '(^|/)prompts/|\.v[0-9]+\.md$|prompts/.*\.json$' || true; } | head -3)
+  if [ -n "$matched" ]; then
+    printf 'prompt design / LLM contract change in: %s' "$(echo "$matched" | tr '\n' ',' | sed 's/,$//')"
+    return 0
+  fi
+  return 1
+}
+
+detect_cross_cutting_refactor() {
+  # Heuristic: count distinct top-level dirs in the changed-files list.
+  # If ≥3 distinct dirs OR diff includes BOTH src/types/ AND src/services/
+  # (or analogous layer pair), match.
+  local distinct_top_dirs has_types has_services
+  # Count distinct top-level DIRECTORIES, not filenames. A path with no
+  # `/` is a root-level file; collapse all such files to a single
+  # sentinel ("<root>") so a docs-only PR touching N root files counts
+  # as 1 distinct entry, not N. Codex P2 + CR Minor on PR #190 caught
+  # the prior `awk -F/ '{print $1}'` over-counting root files as dirs,
+  # which spuriously triggered cross-cutting on docs-only PRs.
+  distinct_top_dirs=$(echo "$FILE_PATHS" | awk -F/ 'NF>1 {print $1; next} {print "<root>"}' | sort -u | wc -l | tr -d ' ')
+  has_types=$(echo "$FILE_PATHS" | grep -cE '(^|/)types/' || true)
+  has_services=$(echo "$FILE_PATHS" | grep -cE '(^|/)services/' || true)
+  if [ "$distinct_top_dirs" -ge 3 ]; then
+    printf 'cross-cutting refactor (changes span %s distinct top-level dirs)' "$distinct_top_dirs"
+    return 0
+  fi
+  if [ "$has_types" -gt 0 ] && [ "$has_services" -gt 0 ]; then
+    printf 'cross-cutting refactor (changes span both types/ and services/ layers)'
+    return 0
+  fi
+  return 1
+}
+
+detect_invariant_enforcement() {
+  local matched_paths matched_body
+  matched_paths=$({ echo "$FILE_PATHS" | grep -E '(^|/)(validation|security|policies)/' || true; } | head -3)
+  matched_body=""
+  if echo "$PR_BODY" | grep -qiE '\binvariant\b'; then
+    matched_body="PR body mentions invariant"
+  fi
+  if [ -n "$matched_paths" ] || [ -n "$matched_body" ]; then
+    local frag="invariant/validation change"
+    [ -n "$matched_body" ] && frag="$frag ($matched_body)"
+    [ -n "$matched_paths" ] && frag="$frag (paths: $(echo "$matched_paths" | tr '\n' ',' | sed 's/,$//'))"
+    printf '%s' "$frag"
+    return 0
+  fi
+  return 1
+}
+
+# ── Run detectors + compose output ──────────────────────────────────────────
+
+TRIGGERS=()
+RATIONALE_PARTS=()
+
+run_detector() {
+  local name=$1 fn=$2
+  local frag
+  if frag=$($fn); then
+    TRIGGERS+=("$name")
+    RATIONALE_PARTS+=("$name: $frag")
+  fi
+}
+
+run_detector "state-machine-change"      detect_state_machine_changes
+run_detector "concurrency"               detect_concurrency
+run_detector "prompt-design"             detect_prompt_design
+run_detector "cross-cutting-refactor"    detect_cross_cutting_refactor
+run_detector "invariant-enforcement"     detect_invariant_enforcement
+
+if [ "${#TRIGGERS[@]}" -eq 0 ]; then
+  emit_json false '[]' "fallback-only" "no trigger classes matched on $FILES_COUNT changed file(s)" "$FILES_COUNT"
+  exit 0
+fi
+
+TRIGGERS_JSON=$(printf '%s\n' "${TRIGGERS[@]}" | jq -R . | jq -s .)
+RATIONALE=$(printf '%s; ' "${RATIONALE_PARTS[@]}" | sed 's/; $//')
+emit_json true "$TRIGGERS_JSON" "invoke-4b" "$RATIONALE" "$FILES_COUNT"
+exit 1

--- a/scripts/request-label-removal.sh
+++ b/scripts/request-label-removal.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# request-label-removal.sh — post a structured label-removal ask on a PR.
+#
+# Background: REVIEW_POLICY.md prohibits agents from removing the
+# `needs-external-review`, `needs-human-review`, and `policy-violation`
+# labels — even when authorized in chat. Label removal is a human action.
+# This helper turns the prohibition into a one-command ask: the agent
+# posts a templated PR comment and (optionally) pings the human via
+# iMessage so they can clear the label without opening a chat window.
+#
+# Note for `needs-external-review`: the `auto-clear-blocking-labels.yml`
+# workflow (#191/#195) usually removes that label automatically once
+# `scripts/codex-review-check.sh` clears the merge gate. The workflow
+# fires on pull_request_target / pull_request_review / workflow_run
+# events (event-driven path) and on a 15-minute `schedule` cron
+# (#197 — catches the 👍-after-last-push case). Use this script for
+# `needs-external-review` only when neither the event-driven path
+# nor the sweep has fired in a reasonable window — typically rare.
+# For `needs-human-review` and `policy-violation`, this script is
+# the only path; both remain manual-only by design.
+#
+# Usage:
+#   scripts/request-label-removal.sh <PR#> <label>
+#   scripts/request-label-removal.sh <PR#> <label> --reason "<short reason>"
+#   scripts/request-label-removal.sh <PR#> <label> --repo owner/name
+#
+# Notification: if MERGEPATH_NOTIFY_IMESSAGE_TO is set to a phone number
+# or contact name resolvable by Messages.app, this script also fires an
+# iMessage with the PR URL. Otherwise it skips silently.
+#
+# Examples:
+#   scripts/request-label-removal.sh 182 needs-external-review
+#   scripts/request-label-removal.sh 182 needs-human-review \
+#     --reason "Codex cleared r3; CI green; only blocker is this label"
+#   MERGEPATH_NOTIFY_IMESSAGE_TO="+15551234567" \
+#     scripts/request-label-removal.sh 182 needs-external-review
+#
+# Exit codes:
+#   0 = comment posted (and iMessage sent if configured)
+#   1 = bad arguments / unsupported label
+#   2 = gh failure (auth, missing PR, network)
+
+set -eo pipefail
+
+ALLOWED_LABELS=(needs-external-review needs-human-review policy-violation)
+
+usage() {
+  cat <<'EOF' >&2
+Usage: scripts/request-label-removal.sh <PR#> <label> [--reason <text>] [--repo owner/name]
+
+Allowed labels: needs-external-review | needs-human-review | policy-violation
+
+Posts a templated PR comment asking the human to remove the label.
+Sends an iMessage to MERGEPATH_NOTIFY_IMESSAGE_TO if set.
+EOF
+  exit 1
+}
+
+PR_NUM=""
+LABEL=""
+REASON=""
+REPO=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --reason) REASON="$2"; shift 2 ;;
+    --repo)   REPO="$2"; shift 2 ;;
+    -h|--help) usage ;;
+    -*) echo "Unknown flag: $1" >&2; usage ;;
+    *)
+      if [ -z "$PR_NUM" ]; then PR_NUM="$1"
+      elif [ -z "$LABEL" ]; then LABEL="$1"
+      else echo "Unexpected positional: $1" >&2; usage
+      fi
+      shift
+      ;;
+  esac
+done
+
+[ -z "$PR_NUM" ] && usage
+[ -z "$LABEL" ] && usage
+
+allowed=0
+for ok in "${ALLOWED_LABELS[@]}"; do
+  if [ "$LABEL" = "$ok" ]; then allowed=1; break; fi
+done
+if [ "$allowed" -ne 1 ]; then
+  echo "Refusing: '$LABEL' is not a human-action label." >&2
+  echo "Allowed: ${ALLOWED_LABELS[*]}" >&2
+  echo "If this label is genuinely a no-op blocker, just remove it directly." >&2
+  exit 1
+fi
+
+REPO_FLAG=()
+if [ -n "$REPO" ]; then REPO_FLAG=(--repo "$REPO"); fi
+
+PR_URL=$(gh pr view "$PR_NUM" "${REPO_FLAG[@]}" --json url --jq .url 2>/dev/null) || {
+  echo "Could not resolve PR #$PR_NUM. Check --repo and gh auth." >&2
+  exit 2
+}
+
+REASON_BLOCK=""
+if [ -n "$REASON" ]; then
+  REASON_BLOCK=$'\n\n**Context:** '"$REASON"
+fi
+
+# For needs-external-review specifically, the auto-clear workflow
+# (#191/#195) usually handles removal. Surface that fact in the
+# message so the human knows the manual ask is a fallback path.
+AUTOCLEAR_NOTE=""
+if [ "$LABEL" = "needs-external-review" ]; then
+  AUTOCLEAR_NOTE=$'\n\n_Note: `auto-clear-blocking-labels.yml` normally removes this label automatically once `codex-review-check.sh` clears the merge gate (event-driven on `pull_request_target` / `pull_request_review` / `workflow_run`, plus a 15-min `schedule` sweep — the sweep can be intentionally disabled via `auto_clear_labels.scheduled_sweep_enabled: false`). If you\'re seeing this ask, none of those triggers fired AND the sweep hasn\'t caught it yet (or is disabled, or the gate is genuinely not yet met). Manual removal is the fallback._'
+fi
+
+BODY="@nathanjohnpayne — this PR is blocked only on the \`$LABEL\` label.
+
+Per [REVIEW_POLICY.md § Agent prohibitions](https://github.com/nathanjohnpayne/mergepath/blob/main/REVIEW_POLICY.md), agents do not remove this label. When you're ready, clear it from any device:
+
+- GitHub UI: Labels sidebar → click \`x\` on \`$LABEL\`
+- CLI: \`gh pr edit $PR_NUM --remove-label $LABEL\` $([ -n "$REPO" ] && echo "--repo $REPO")
+
+Auto-merge will fire as soon as the label is gone.${REASON_BLOCK}${AUTOCLEAR_NOTE}
+
+— posted by \`scripts/request-label-removal.sh\`"
+
+if ! gh pr comment "$PR_NUM" "${REPO_FLAG[@]}" --body "$BODY" >/dev/null; then
+  echo "Failed to post comment on PR #$PR_NUM" >&2
+  exit 2
+fi
+echo "Posted label-removal request on $PR_URL"
+
+if [ -n "${MERGEPATH_NOTIFY_IMESSAGE_TO:-}" ]; then
+  IMSG_BODY="Mergepath: PR #$PR_NUM blocked on '$LABEL' label. Clear when ready: $PR_URL"
+  IMSG_BODY_ESC=${IMSG_BODY//\"/\\\"}
+  TARGET_ESC=${MERGEPATH_NOTIFY_IMESSAGE_TO//\"/\\\"}
+  if osascript -e "tell application \"Messages\" to send \"$IMSG_BODY_ESC\" to buddy \"$TARGET_ESC\" of (service 1 whose service type is iMessage)" >/dev/null 2>&1; then
+    echo "Notified $MERGEPATH_NOTIFY_IMESSAGE_TO via iMessage"
+  else
+    echo "iMessage notify failed (non-fatal); comment is the source of truth" >&2
+  fi
+fi

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -1,0 +1,414 @@
+#!/usr/bin/env bash
+# resolve-pr-threads.sh — Enumerate and resolve open review threads on a PR.
+#
+# Branch protection on `main` typically requires
+# `required_conversation_resolution: true`, which means **every review
+# thread on the PR must be resolved** before `mergeStateStatus` flips
+# from `BLOCKED` to `CLEAN`. This includes CodeRabbit's `🧹 Nitpick` /
+# `🔵 Trivial` comments that don't block merge in CodeRabbit's own
+# model but DO block the conversation-resolution gate.
+#
+# The blocker is invisible in `gh pr checks` output — only the GitHub
+# UI surfaces it. This script fills the discoverability gap.
+#
+# Usage:
+#   scripts/resolve-pr-threads.sh <PR#> [--repo owner/name] [--list]
+#                                 [--auto-resolve-bots] [--dry-run]
+#
+# Modes:
+#   --list                  List unresolved threads with author + path +
+#                           first-comment excerpt. No mutations.
+#   --auto-resolve-bots     Resolve threads whose author is a bot
+#                           (CodeRabbit, Codex Connector, Dependabot)
+#                           AND whose latest comment is on the current
+#                           HEAD. Use ONLY when:
+#                           - The agent has already addressed each
+#                             finding in a fix commit on this HEAD, OR
+#                             posted a rebuttal reply, AND
+#                           - The bot author has not auto-resolved in
+#                             a reasonable window.
+#                           Per REVIEW_POLICY.md § Implementation notes
+#                           for branch protection gates: this is a
+#                           CLEAN-UP mechanism, not a policy override.
+#                           Human-authored threads are NEVER auto-
+#                           resolved regardless of mode.
+#   --dry-run               With --auto-resolve-bots, print what would
+#                           be resolved without mutating.
+#
+# Default mode (no flags): equivalent to --list.
+#
+# Exit codes:
+#   0 — no unresolved threads
+#   1 — bad arguments
+#   2 — gh failure (auth, missing PR, network)
+#   3 — unresolved threads exist (in --list mode); call again with
+#       --auto-resolve-bots after addressing findings, or resolve
+#       human-authored threads via the GitHub UI.
+#
+# References:
+#   nathanjohnpayne/mergepath#166 — the issue this closes
+#   matchline #181, #190, #192 — observed cases of conversation-
+#                                resolution blocker
+
+set -eo pipefail
+
+usage() {
+  cat <<'EOF' >&2
+Usage: scripts/resolve-pr-threads.sh <PR#> [--repo owner/name] [--list]
+                                            [--auto-resolve-bots] [--dry-run]
+
+  --list                List unresolved threads (default).
+  --auto-resolve-bots   Resolve bot-authored threads on current HEAD.
+  --dry-run             With --auto-resolve-bots, print without mutating.
+EOF
+  exit 1
+}
+
+PR_NUM=""
+REPO=""
+MODE="list"
+DRY_RUN=false
+# Match both REST and GraphQL bot-login formats. The REST API returns
+# `coderabbitai[bot]`; GraphQL `author{login}` returns `coderabbitai`
+# (un-suffixed user-facing handle). The trailing `(\[bot\])?` accepts
+# either form so the auto-resolve mode works with the GraphQL data
+# this script reads. Caught on PR #180 review when every CR thread
+# was skipped as "human author" — see #182.
+BOT_LOGINS_RE='^(coderabbitai|chatgpt-codex-connector|dependabot)(\[bot\])?$'
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)
+      # Codex r2 on PR #172: bare `shift 2` silently consumed nothing
+      # when --repo was the last arg, leaving REPO empty and falling
+      # through to gh-repo-view auto-detect. Validate the value is
+      # present and non-empty so the user gets a clear error instead.
+      if [ $# -lt 2 ] || [ -z "$2" ]; then
+        echo "Error: --repo requires a non-empty value (owner/name)" >&2
+        usage
+      fi
+      REPO="$2"; shift 2 ;;
+    --list) MODE="list"; shift ;;
+    --auto-resolve-bots) MODE="auto-resolve-bots"; shift ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    -h|--help) usage ;;
+    -*) echo "Unknown flag: $1" >&2; usage ;;
+    *)
+      if [ -z "$PR_NUM" ]; then PR_NUM="$1"
+      else echo "Unexpected positional: $1" >&2; usage
+      fi
+      shift
+      ;;
+  esac
+done
+
+[ -z "$PR_NUM" ] && usage
+
+# PR_NUM must be a positive integer (no leading zeros, no other chars).
+if ! [[ "$PR_NUM" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Invalid PR number: '$PR_NUM' (must be a positive integer)" >&2
+  exit 1
+fi
+
+# Resolve the read PAT once + define the wrapper before any `gh`
+# call. CR Major on PR #194 r4 caught that the bare `gh repo view`
+# and `gh api` invocations below this point would still hit the
+# empty-GH_TOKEN keyring-fallback trap. Centralizing the wrapper
+# above all read-path gh calls fixes it.
+READ_GH_TOKEN="${OP_PREFLIGHT_REVIEWER_PAT:-${GH_TOKEN:-}}"
+gh_read() {
+  if [ -n "$READ_GH_TOKEN" ]; then
+    GH_TOKEN="$READ_GH_TOKEN" gh "$@"
+  else
+    gh "$@"
+  fi
+}
+
+if [ -z "$REPO" ]; then
+  REPO=$(gh_read repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) || {
+    echo "Could not resolve repo. Pass --repo owner/name." >&2
+    exit 2
+  }
+fi
+
+# --repo value validation. Codex r1 on PR #172 caught the missing
+# check. Must be `owner/name` where each side is GitHub-legal:
+# alphanumerics, hyphens, dots, underscores; no leading dash; ≤39
+# chars per GitHub's username rules but we only enforce the syntactic
+# shape — gh will reject genuinely-invalid combinations downstream.
+if ! [[ "$REPO" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+  echo "Invalid --repo value: '$REPO' (expected owner/name)" >&2
+  exit 1
+fi
+
+OWNER="${REPO%/*}"
+NAME="${REPO#*/}"
+
+# Fetch the PR's current HEAD commit oid — used by --auto-resolve-bots
+# to verify each thread's latest comment is on the current HEAD before
+# resolving. Codex P2 on PR #172 caught that the docstring promised
+# this check but the code didn't enforce it.
+HEAD_OID=$(gh_read api "repos/$OWNER/$NAME/pulls/$PR_NUM" --jq .head.sha 2>/dev/null) || {
+  echo "Could not resolve PR HEAD oid for $REPO#$PR_NUM" >&2
+  exit 2
+}
+
+# Fetch all review threads with isResolved state. Three design
+# choices, all load-bearing:
+#
+# 1. `-F cursor=null` (typed) on the first call, NOT `-f cursor=null`
+#    (string). The prior code used `-f cursor=null` which sent the
+#    literal STRING "null" as the cursor; GitHub's GraphQL endpoint
+#    interpreted that as a real cursor and silently returned the
+#    wrong thread set. This was the actual root cause of the
+#    PR #189 undercount (May 2026 — initially misdiagnosed as
+#    eventual consistency; #192 has the post-mortem). The cursor-
+#    state branching below sends GraphQL null on the first call,
+#    then a real cursor string on subsequent pages.
+#
+# 2. Two GraphQL aliases — `commentsFirst: comments(first: 1)` for
+#    the original review's author/path/body (what the user/agent
+#    needs to recognize the thread) AND `commentsLast: comments(last:
+#    1)` for the HEAD-anchor commit_oid (the truly-latest comment).
+#    Earlier draft used `comments(first: 50)` and indexed `[-1]` for
+#    the last comment, but Codex P2 on PR #194 caught that >50-comment
+#    threads (rare but possible — bot churn over a long-lived PR)
+#    would misclassify HEAD anchor. The dual-alias shape is
+#    deterministic for any thread depth.
+#
+# 3. `totalCount` cross-validation — after assembling THREADS_JSON,
+#    compare the returned node count against the API's reported
+#    totalCount. If they disagree the script reports on stderr +
+#    exits 2 rather than the silent "no unresolved threads" output
+#    that bit PR #189. Belt-and-suspenders: even with the cursor fix
+#    above, a future API quirk could re-introduce undercount; the
+#    cross-check catches it.
+#
+# Codex P2 on PR #172 caught that the prior `first: 100` (no pager)
+# could undercount on PRs with many threads — paginating with
+# `first: 50` + cursor preserves that fix.
+THREADS_JSON='[]'
+TOTAL_COUNT=0
+# CURSOR sentinel "" means "first call — send GraphQL null". A string
+# value "null" is NOT the same: passing it via `-f cursor=null` sends
+# the literal string "null" which GitHub interprets as a real cursor
+# and silently returns the wrong thread set. Always use `-F` (typed)
+# for null on first call; switch to `-f` (string) once we have a real
+# cursor. This was the actual root cause of the PR #189 undercount —
+# not eventual consistency.
+CURSOR=""
+QUERY='
+  query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 50, after: $cursor) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            isResolved
+            isOutdated
+            # `commentsFirst` for the original review (excerpt + author).
+            # `commentsLast` for the HEAD-anchor commit_oid — `last: 1`
+            # guarantees the truly-latest comment regardless of thread
+            # depth. Codex P2 on PR #194 caught that `first: 50` would
+            # misclassify HEAD anchor on threads with >50 comments
+            # (rare but possible — bot churn).
+            commentsFirst: comments(first: 1) {
+              nodes {
+                author { login }
+                path
+                body
+                createdAt
+              }
+            }
+            commentsLast: comments(last: 1) {
+              nodes {
+                commit { oid }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+'
+while :; do
+  # Read-path: pin to preflight reviewer PAT when available; otherwise
+  # let gh use its keyring fallback (no empty-GH_TOKEN trap).
+  if [ -z "$CURSOR" ]; then
+    PAGE=$(gh_read api graphql -f query="$QUERY" \
+      -F owner="$OWNER" -F repo="$NAME" -F pr="$PR_NUM" -F cursor=null 2>&1) || {
+      echo "GraphQL query failed: $PAGE" >&2
+      exit 2
+    }
+  else
+    PAGE=$(gh_read api graphql -f query="$QUERY" \
+      -F owner="$OWNER" -F repo="$NAME" -F pr="$PR_NUM" -f cursor="$CURSOR" 2>&1) || {
+      echo "GraphQL query failed: $PAGE" >&2
+      exit 2
+    }
+  fi
+  THREADS_JSON=$(jq -c --argjson acc "$THREADS_JSON" \
+    '$acc + .data.repository.pullRequest.reviewThreads.nodes' <<<"$PAGE")
+  TOTAL_COUNT=$(jq -r '.data.repository.pullRequest.reviewThreads.totalCount' <<<"$PAGE")
+  HAS_NEXT=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<<"$PAGE")
+  [ "$HAS_NEXT" = "true" ] || break
+  CURSOR=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor' <<<"$PAGE")
+done
+
+# totalCount cross-validation — fail on ANY mismatch (under OR over).
+# Equality check, not `< totalCount`: an over-count would indicate a
+# duplicate-page / cursor-reset regression in the pagination loop and
+# is just as bad as an undercount. CR Major on PR #194 r2.
+RETURNED_COUNT=$(jq -r 'length' <<<"$THREADS_JSON")
+if [ "$RETURNED_COUNT" != "$TOTAL_COUNT" ]; then
+  cat >&2 <<EOF
+ERROR: GraphQL count mismatch on $REPO#$PR_NUM.
+       reviewThreads.totalCount = $TOTAL_COUNT, but the paginated query
+       returned $RETURNED_COUNT nodes. Either undercount (cursor-typing
+       bug per #192) or overcount (duplicate-page / cursor-reset
+       regression). Do NOT trust the "no unresolved threads" output
+       below; fall back to the manual GraphQL escape hatch in
+       CLAUDE.md § 7.6.
+EOF
+  exit 2
+fi
+
+UNRESOLVED=$(echo "$THREADS_JSON" | jq -c '
+  .[]
+  # `!= true` instead of `== false` so a null/missing isResolved
+  # field is treated as unresolved (defensive — prefer to surface
+  # noise over silently skip).
+  | select(.isResolved != true)
+  | {
+      id: .id,
+      outdated: .isOutdated,
+      # commentsFirst = original review (excerpt + author for display).
+      # commentsLast = guaranteed-latest comment (HEAD anchor commit_oid).
+      author: (.commentsFirst.nodes[0].author.login // "unknown"),
+      path: (.commentsFirst.nodes[0].path // "(no path)"),
+      created: (.commentsFirst.nodes[0].createdAt // ""),
+      commit_oid: (.commentsLast.nodes[0].commit.oid // ""),
+      excerpt: ((.commentsFirst.nodes[0].body // "") | .[0:160])
+    }
+')
+
+if [ -z "$UNRESOLVED" ]; then
+  echo "No unresolved threads on PR #$PR_NUM."
+  exit 0
+fi
+
+UNRESOLVED_COUNT=$(echo "$UNRESOLVED" | wc -l | tr -d ' ')
+echo "Unresolved threads on $REPO#$PR_NUM: $UNRESOLVED_COUNT"
+echo ""
+
+# List mode: print and exit 3.
+if [ "$MODE" = "list" ]; then
+  echo "$UNRESOLVED" | jq -r '
+    "  [\(.author)] \(.path)" + (if .outdated then " (outdated)" else "" end) +
+    "\n    " + .excerpt + "\n"
+  '
+  echo "To resolve bot-authored threads where you have already addressed"
+  echo "the finding: re-run with --auto-resolve-bots."
+  echo "Human-authored threads must be resolved via the GitHub UI or by"
+  echo "asking the human. Per REVIEW_POLICY.md § Agent prohibitions."
+  exit 3
+fi
+
+# auto-resolve-bots mode: resolve bot threads, leave human threads alone.
+# Use process substitution (`< <(...)`) instead of `echo $UNRESOLVED | while`
+# so the loop runs in the parent shell — counter increments survive past the
+# loop and the trailing summary is accurate.
+RESOLVED_COUNT=0
+SKIPPED_HUMAN=0
+SKIPPED_STALE=0
+WOULD_RESOLVE_COUNT=0
+FAILED_COUNT=0
+while IFS= read -r thread; do
+  AUTHOR=$(echo "$thread" | jq -r .author)
+  THREAD_ID=$(echo "$thread" | jq -r .id)
+  PATH_=$(echo "$thread" | jq -r .path)
+  EXCERPT=$(echo "$thread" | jq -r .excerpt)
+  COMMIT_OID=$(echo "$thread" | jq -r .commit_oid)
+
+  if ! [[ "$AUTHOR" =~ $BOT_LOGINS_RE ]]; then
+    echo "  SKIP (human author $AUTHOR): $PATH_"
+    echo "    $EXCERPT"
+    SKIPPED_HUMAN=$((SKIPPED_HUMAN + 1))
+    continue
+  fi
+
+  # Current-HEAD check. The advertised contract is "resolve only when
+  # the latest comment is on the current HEAD" — a thread anchored to
+  # an older commit (or with no commit linkage at all) means the
+  # agent's most recent push hasn't been re-reviewed by the bot, so
+  # resolving it would force-clear an unaddressed finding.
+  #
+  # Codex r1 on PR #172 caught that the previous check
+  # `if [ -n "$COMMIT_OID" ] && [ "$COMMIT_OID" != "$HEAD_OID" ]`
+  # treated EMPTY commit_oid as "matches HEAD" → bot threads with no
+  # commit linkage in the GraphQL response would be force-resolved
+  # silently. The safe default is the opposite: missing oid is
+  # treated as stale.
+  if [ -z "$COMMIT_OID" ] || [ "$COMMIT_OID" = "null" ] || [ "$COMMIT_OID" != "$HEAD_OID" ]; then
+    if [ -z "$COMMIT_OID" ] || [ "$COMMIT_OID" = "null" ]; then
+      reason="no commit linkage"
+    else
+      reason="latest comment on ${COMMIT_OID:0:7}, HEAD is ${HEAD_OID:0:7}"
+    fi
+    echo "  SKIP (stale: $reason): [$AUTHOR] $PATH_"
+    echo "    Push a fix commit (or rebuttal reply) to re-trigger the bot, then retry."
+    SKIPPED_STALE=$((SKIPPED_STALE + 1))
+    continue
+  fi
+
+  if $DRY_RUN; then
+    echo "  WOULD RESOLVE [$AUTHOR] $PATH_"
+    echo "    $EXCERPT"
+    WOULD_RESOLVE_COUNT=$((WOULD_RESOLVE_COUNT + 1))
+    continue
+  fi
+
+  if gh api graphql -f query='
+    mutation($id: ID!) {
+      resolveReviewThread(input: {threadId: $id}) {
+        thread { isResolved }
+      }
+    }
+  ' -F id="$THREAD_ID" >/dev/null 2>&1; then
+    echo "  RESOLVED [$AUTHOR] $PATH_"
+    RESOLVED_COUNT=$((RESOLVED_COUNT + 1))
+  else
+    echo "  FAILED [$AUTHOR] $PATH_ — mutation rejected" >&2
+    FAILED_COUNT=$((FAILED_COUNT + 1))
+  fi
+done < <(printf '%s\n' "$UNRESOLVED")
+
+echo ""
+if $DRY_RUN; then
+  echo "(dry-run; no threads modified) — would-resolve: $WOULD_RESOLVE_COUNT, skipped (human): $SKIPPED_HUMAN, skipped (stale-HEAD): $SKIPPED_STALE"
+  # Codex r2 on PR #172: dry-run previously exited 0 when only
+  # current-HEAD bot threads remained (because dry-run does not mutate
+  # them and they didn't increment SKIPPED_*). Callers would treat
+  # the PR as "all clear" and proceed to merge into a still-BLOCKED PR.
+  # Fix: dry-run exits 3 if ANY actionable items remain (would-resolve,
+  # human-skipped, or stale-skipped). The only exit-0 path through
+  # auto-resolve-bots --dry-run is "no unresolved threads at all"
+  # which is already short-circuited above (UNRESOLVED is empty).
+  if [ "$WOULD_RESOLVE_COUNT" -gt 0 ] || [ "$SKIPPED_HUMAN" -gt 0 ] || [ "$SKIPPED_STALE" -gt 0 ]; then
+    exit 3
+  fi
+  exit 0
+fi
+echo "Resolved: $RESOLVED_COUNT  Skipped (human): $SKIPPED_HUMAN  Skipped (stale-HEAD): $SKIPPED_STALE  Failed: $FAILED_COUNT"
+# Codex r1 on PR #172: previously this exited 0 even with stale or
+# human-authored threads remaining — callers would treat it as "all
+# clear" and proceed to merge into a still-BLOCKED PR. Exit codes:
+#   2 = mutation failure (transient: gh/network)
+#   3 = unresolved threads remain (human or stale-bot) — PR still
+#       conversation-resolution-blocked; address and retry
+#   0 = no unresolved threads on current HEAD
+[ "$FAILED_COUNT" -gt 0 ] && exit 2
+[ "$SKIPPED_HUMAN" -gt 0 ] || [ "$SKIPPED_STALE" -gt 0 ] && exit 3
+exit 0


### PR DESCRIPTION
Bulk sync to [mergepath@7c626c2](https://github.com/nathanjohnpayne/mergepath/commit/7c626c2200f6d81cc21c7ca06d99ec403017761d) — verbatim canonical/kit mirror per `.mergepath-sync.yml`.

Opened by `scripts/sync-to-downstream.sh --sync-all` (v0.4.0-layer3-sync-all, see [#168](https://github.com/nathanjohnpayne/mergepath/issues/168)). Unlike a per-commit propagation PR, this replays the **current HEAD state of every canonical + kit path** so a consumer that has fallen behind reaches a clean steady state in one shot.

## Canonical paths synced
  - scripts/op-preflight.sh
  - scripts/coderabbit-wait.sh
  - scripts/codex-review-request.sh
  - scripts/codex-review-check.sh
  - scripts/phase-4b-classifier.sh
  - scripts/codex-p1-gate.sh
  - scripts/disagreement-detector.js
  - scripts/resolve-pr-threads.sh
  - scripts/request-label-removal.sh
  - scripts/gh-as-author.sh
  - scripts/gh-as-reviewer.sh
  - scripts/hooks/gh-pr-guard.sh
  - scripts/hooks/label-removal-guard.sh
  - .github/workflows/agent-review.yml
  - .github/workflows/pr-review-policy.yml
  - .github/workflows/dependabot-auto-merge.yml
  - .github/workflows/auto-clear-blocking-labels.yml
  - .github/workflows/pr-audit.yml
  - .github/workflows/codex-p1-gate.yml

## Kit paths synced
  - scripts/ci/ (kit, allow-extras)
  - scripts/gh-projects/ (kit, allow-extras)

Authoring-Agent: claude

## Self-Review
- Correctness: mirrors mergepath@7c626c2 HEAD state verbatim per the manifest. Each path was already reviewed in its upstream PR.
- Regression risk: low. Verbatim mirror; kit paths use allow-extras semantics so consumer-only files are kept.
- Style: N/A (mirror).
- Test coverage: relies on the consumer repo CI. No test changes shipped.
- Security: no new attack surface; `.sync-overrides.yml` was honored per-consumer so documented divergences are untouched.