### PR TITLE
docs(mergepath): soften unverifiable "167 hook test cases" claim

### DIFF
--- a/src/content/blog/agent-approval-workflow-genesis-of-mergepath.md
+++ b/src/content/blog/agent-approval-workflow-genesis-of-mergepath.md
@@ -240,7 +240,7 @@ The process-level fix was even simpler: apply the label *before* posting any rev
 Over six weeks of daily use across seven repositories:
 
 - **30+ PRs** opened, reviewed, and merged on the template repo alone
-- **167 hook test cases** covering the `gh-pr-guard.sh` parser across 7 rounds of review
+- **A dedicated hook test suite** covering the `gh-pr-guard.sh` parser, built up across 7 rounds of review
 - **17 template bugs** discovered during propagation to downstream repos
 - **5 dry-run scenarios** validated on live infrastructure
 - **142–342 seconds** average Codex response time per review round

--- a/src/content/projects/mergepath.md
+++ b/src/content/projects/mergepath.md
@@ -64,7 +64,7 @@ There is no backend, no build system, and no network calls. The draft YAML panel
 
 - **100+ PRs** merged on the Mergepath repo itself, each one exercising the governance loop end-to-end.
 - **~27 fail-closed CI checks** enforced on every push and PR.
-- **167 hook test cases** covering the PR guard, review policy parser, and credential preflight script.
+- **A dedicated hook test suite** covering the PR guard and the review-policy parser.
 - **17 template bugs** surfaced during propagation across downstream projects—bugs that had survived seven rounds of review on the template before fresh eyes in a new codebase found them.
 - **8 repositories** currently using Mergepath, including Override, Device Source of Truth, Friends & Family Billing, Swipewatch, and this site.
 


### PR DESCRIPTION
Authoring-Agent: claude

## Summary
- Follow-up to #362. The "167 hook test cases" figure on the Mergepath project page and in the origin-story blog post could not be re-verified against the Mergepath repo — the test suite was restructured after that number was written, and "167" was never recorded in Mergepath itself.
- Replaces the specific count with a qualitative description in both `src/content/projects/mergepath.md` and `src/content/blog/agent-approval-workflow-genesis-of-mergepath.md`. The "7 rounds of review" detail in the blog post is kept — that one is documented in the post itself (PR #66).
- Content-only, prose-only change.

## Testing
- [x] `npm run build` succeeds (25 pages)
- [x] Content tests pass — `content-schema`, `project-pages`, `blog-pages` (57/57)

## Self-Review
- **Correctness:** Verified via `git log -S'167'` that the figure was never in the Mergepath repo's own docs; `tests/test_gh_pr_guard.sh` now self-reports 8 cases, no `op-preflight` test file exists, and the review-policy parser tests live in `check_workflow_parsers`. The replacement text claims only what's currently true.
- **Regression risk:** None. Two lines of list-item prose; no frontmatter or schema changes.
- **Style and conventions:** Keeps the bold lead-in list style of the surrounding "The numbers" sections; CMOS em-dash style unaffected.
- **Test coverage:** No code paths; existing content tests pass.
- **Security and dependency hygiene:** No deps, no secrets, no executables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)