### PR TITLE
fix(reading-time): exclude fence delimiters from code word count (#369)

### DIFF
--- a/src/lib/reading-time.ts
+++ b/src/lib/reading-time.ts
@@ -38,10 +38,13 @@ export function estimateReadingMinutes(body: string | undefined | null): number 
     return ' ';
   });
   const proseWords = prose.trim().split(WHITESPACE).filter(Boolean).length;
-  const codeWords = codeBlocks.reduce(
-    (n, b) => n + b.split(WHITESPACE).filter(Boolean).length,
-    0,
-  );
+  // Strip the opening (with optional language tag) and closing fence tokens
+  // before counting so the ``` delimiters aren't tallied as code words —
+  // each fenced block would otherwise contribute 2 phantom "words".
+  const codeWords = codeBlocks.reduce((n, b) => {
+    const codeOnly = b.replace(/^```[^\n]*\n?/, '').replace(/\n?```$/, '');
+    return n + codeOnly.split(WHITESPACE).filter(Boolean).length;
+  }, 0);
   const minutes = Math.ceil((proseWords + codeWords * CODE_WEIGHT) / WORDS_PER_MINUTE);
   return Math.max(1, minutes);
 }

--- a/tests/reading-time.test.js
+++ b/tests/reading-time.test.js
@@ -40,4 +40,22 @@ describe('estimateReadingMinutes (src/lib/reading-time.ts)', () => {
     // 0 prose + 1000 × 0.3 = 300 → 300/225 = 1.33 → ceil = 2.
     expect(estimateReadingMinutes(code)).toBe(2);
   });
+
+  it('does not count fence ``` delimiters as code words', () => {
+    // Exactly 225 prose words sits right on the 1-minute boundary
+    // (ceil(225/225) = 1). Appending an empty fenced block must not push
+    // the result to 2 min — the ``` tokens are syntax, not content.
+    const prose = Array.from({ length: 225 }, () => 'w').join(' ');
+    const emptyFence = '```\n```';
+    expect(estimateReadingMinutes(`${prose}\n\n${emptyFence}`)).toBe(1);
+  });
+
+  it('does not count a fence language tag as a code word', () => {
+    // Same boundary case, with a language-tagged empty block. The opening
+    // ```js token (with its language hint) is also syntax and must be
+    // stripped before counting.
+    const prose = Array.from({ length: 225 }, () => 'w').join(' ');
+    const taggedFence = '```js\n```';
+    expect(estimateReadingMinutes(`${prose}\n\n${taggedFence}`)).toBe(1);
+  });
 });


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Resolves the lone VALID finding from sweep [#369](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/369): CodeRabbit flagged on the merged [#351](https://github.com/nathanjohnpayne/nathanpaynedotcom/pull/351) that the `codeWords` reducer in [`src/lib/reading-time.ts`](src/lib/reading-time.ts) was counting the opening/closing ` ``` ` fence tokens as words, inflating reading-time estimates.

Each fenced block contributed 2 phantom "words"; with the 0.3 code-weight applied, that adds 0.6 weighted words per block to the numerator. Almost invisible on most posts, but enough to push bodies sitting on a minute boundary into the next minute.

## Changes

- [`src/lib/reading-time.ts`](src/lib/reading-time.ts): strip the opening fence (with optional language tag like ` ```js `) and closing fence from each block before splitting by whitespace.
- [`tests/reading-time.test.js`](tests/reading-time.test.js): add 2 regression tests pinned to the 1-minute boundary — 225 prose words + an empty fenced block must stay at 1 min, both for a plain ` ``` ` fence and a ` ```js ` language-tagged one.

The 6 pre-existing tests in the suite still pass; the boundary cases they hit weren't sensitive to the 0.6-weighted-word delta (which is why the bug went unnoticed when reading-time was extracted in #351).

## Self-Review

- **Correctness.** The regex pair `^\`\`\`[^\n]*\n?` and `\n?\`\`\`$` removes exactly the opening fence line (preserving any language tag's role as syntax, not content) and the closing fence line. Manually walked through `\`\`\`js\nconst x = 1;\n\`\`\`` → strips to `const x = 1;` → 4 words instead of the previous 6.
- **Regression risk.** All 164 vitest tests pass locally. The 4 pre-existing reading-time tests still produce the same minute values because their bodies don't sit near a minute boundary. New boundary tests would have failed against the old code (225 prose + 2 phantom fence "words" × 0.3 = 225.6 → ceil → 2 min) and now pass.
- **Style.** Single short comment explaining why fences are stripped. No dead code, no scope creep, no API change.
- **Test coverage.** Two new tests covering both fence shapes (plain and language-tagged). No other code paths to test.
- **Security/dependency hygiene.** Pure-string transformation, no new deps. Inputs are post bodies authored by the site owner — no injection surface.

## Test plan

- [x] `npx vitest run tests/reading-time.test.js` — 8/8 pass
- [x] `npx vitest run` — 164/164 pass
- [ ] CI builds the site successfully (`astro build && vitest run`)

## Sweep follow-up

Once this lands I'll close [#369](https://github.com/nathanjohnpayne/nathanpaynedotcom/issues/369). The other 4 findings on that sweep were re-triaged as ALREADY-FIXED on HEAD (track 8 restored in #329; `COLOR_BY_PANEL` removed; `.catch(() => {})` now logs via `console.warn`; reduced-motion gate moved inside the page in #347). I'll post reply comments on each of those threads as part of the close-out.