### PR TITLE
docs(blog): refresh stale snapshot numbers on Mergepath genesis post

### DIFF
--- a/src/content/blog/agent-approval-workflow-genesis-of-mergepath.md
+++ b/src/content/blog/agent-approval-workflow-genesis-of-mergepath.md
@@ -35,7 +35,7 @@ sidebar:
     caption: "The five stages of agent review enforcement"
 ---
 
-I am not an engineer. I am a product manager who learned to use AI coding agents because I wanted to build things faster. That distinction matters for this story, because the system I am about to describe—a multi-agent code review enforcement layer across seven repositories—was not designed top-down from an engineering principles textbook. It was grown bottom-up from watching agents misbehave.
+I am not an engineer. I am a product manager who learned to use AI coding agents because I wanted to build things faster. That distinction matters for this story, because the system I am about to describe—a multi-agent code review enforcement layer across nine repositories—was not designed top-down from an engineering principles textbook. It was grown bottom-up from watching agents misbehave.
 
 [Mergepath](https://github.com/nathanjohnpayne/mergepath) (originally `ai_agent_repo_template`) is the result. It is a deterministic repository standard that keeps humans and AI agents aligned through canonical documentation, binding CI constraints, multi-identity code review, and automated external review via the OpenAI Codex GitHub App. It took roughly six weeks of daily use across six production repositories to arrive at the current architecture, and every major feature was born from a specific failure I watched happen in real time.
 
@@ -217,7 +217,7 @@ The process-level fix was even simpler: apply the label *before* posting any rev
 
 ## What the template actually is
 
-[Mergepath](https://github.com/nathanjohnpayne/mergepath) is the infrastructure that makes all of the above work consistently across eight repositories. It is not a framework or a library. It is a set of files that, when present in a repository, enforce a deterministic review workflow for any AI coding agent.
+[Mergepath](https://github.com/nathanjohnpayne/mergepath) is the infrastructure that makes all of the above work consistently across nine repositories. It is not a framework or a library. It is a set of files that, when present in a repository, enforce a deterministic review workflow for any AI coding agent.
 
 **Canonical documentation as a single source of truth.** `REVIEW_POLICY.md` is the policy document. `CLAUDE.md` is the agent's operational checklist. `AGENTS.md` is the behavioral index. `.github/review-policy.yml` is the machine-readable config. Each file has exactly one job, and they cross-reference each other rather than duplicating content.
 
@@ -237,9 +237,9 @@ The process-level fix was even simpler: apply the label *before* posting any rev
 
 ## The numbers
 
-Over six weeks of daily use across seven repositories:
+Over seven weeks of daily use across nine repositories:
 
-- **30+ PRs** opened, reviewed, and merged on the template repo alone
+- **100+ PRs** opened, reviewed, and merged on the template repo alone
 - **A dedicated hook test suite** covering the `gh-pr-guard.sh` parser, built up across 7 rounds of review
 - **17 template bugs** discovered during propagation to downstream repos
 - **5 dry-run scenarios** validated on live infrastructure


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

The Mergepath genesis blog post had three current-state numbers that had drifted since publish (2026-04-16). User flagged them in the "The numbers" section. Audited every numeric claim against ground truth and refreshed only the snapshot numbers — historical claims kept intact.

## Changes

`src/content/blog/agent-approval-workflow-genesis-of-mergepath.md`:

| Line | Was | Now | Why |
|---|---|---|---|
| 38 | "across seven repositories" | "across nine repositories" | matchline (2026-04-23) and tadlockpsychiatry (2026-05-01) have since adopted the template (verified via AGENTS.md + .github/review-policy.yml). Total = mergepath + 8 downstream = 9. |
| 220 | "across eight repositories" | "across nine repositories" | Inconsistent with line 38 (off by one even at publish). Same fix as line 38 lands both passages on 9. |
| 240 | "Over six weeks of daily use across seven repositories" | "Over seven weeks of daily use across nine repositories" | 51 days since mergepath created (2026-03-25) = 7.3 weeks. |
| 242 | "30+ PRs" | "100+ PRs" | Currently 128 merged PRs on `nathanjohnpayne/mergepath` (7 in March, 47 in April, 74 in May through the 15th). The "100+" threshold matches what [`src/content/projects/mergepath.md:65`](src/content/projects/mergepath.md#L65) already says — PR #362 refreshed the project page but missed the blog. |

## What I deliberately did NOT change

Three other numeric passages refer to the genesis arc through publish, not ongoing uptime, so they stay historical:

- Line 40: "six weeks of daily use across six production repositories to arrive at the current architecture" — describes when the architecture crystallized.
- Line 116: "roughly 30 PRs" — refers to the PR cost of building the 46 Project #2 items; the remaining ~98 PRs are propagation/maintenance outside that scope.
- Line 178: "Phase 4: propagating the template to six downstream repositories" — Phase 4 history at a fixed point.
- Line 261: "The lessons cost me six weeks" — same genesis-arc framing.

Verified-and-kept on HEAD:

- **"17 template bugs"** — mergepath commit `b820430` "back-port 17 propagation-discovered bugs (#75) (#76)".
- **"5 dry-run scenarios"** — mergepath PRs #70-74, narrated as dry-runs A-E in the post itself.
- **"7 rounds of review"** — table on lines 157-173 of the post documents the rounds against PR #66.
- **"46 project items / 5 phases"** — Project #2 currently has exactly 46 items across 5 phases (Design & Decisions / Template implementation / Template verification / Propagation / Close-out).
- **"142-342 seconds Codex response time"** — lower anchor (147s for dry-run A) is documented in the post; upper anchor is softer but kept as a range. Followed PR #364's pattern of keeping a soft range rather than fabricating precision.

## Self-Review

- **Correctness.** Each updated number traceable: 9 repos = `gh repo list nathanjohnpayne` filtered for template-file presence; 7.3 weeks = `(2026-05-15 − 2026-03-25)` in days; 128 PRs = `gh pr list --repo nathanjohnpayne/mergepath --state merged --limit 1000` count.
- **Regression risk.** Prose-only change in one Markdown file. No frontmatter or schema changes.
- **Style.** Matches surrounding prose, no new vocabulary introduced; keeps the existing "**XYZ** description" list style. CMOS em-dash style preserved.
- **Test coverage.** No code paths touched. Content tests (`content-schema`, `blog-pages`) pass — 8/8.
- **Security/dependency hygiene.** Static text. No deps, no secrets.

## Test plan

- [x] `npx vitest run tests/content-schema.test.js tests/blog-pages.test.js` — 8/8 pass
- [ ] CI builds the site successfully (`astro build && vitest run`)