### PR TITLE
sync: bulk reconcile to mergepath@b1ec16f

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,80 @@
+// eslint.config.js
+//
+// Auto-generated from nathanjohnpayne/mergepath's templated source
+// at examples/eslint.config.js (per the Mergepath ESLint standard,
+// mergepath#250). Edit upstream, not this rendered copy — local
+// edits will be overwritten on the next propagation run.
+//
+
+import js from "@eslint/js";
+import globals from "globals";
+
+import tseslint from "typescript-eslint";
+import astro from "eslint-plugin-astro";
+
+export default [
+  // Ignore generated / vendored output. Customize per-consumer via
+  // a follow-up commit on the propagation PR if a repo needs extras
+  // (e.g., functions/lib for cloud-functions repos).
+  {
+    ignores: [
+      "node_modules/**",
+      "dist/**",
+      "build/**",
+      "coverage/**",
+      ".astro/**",
+      ".next/**",
+      ".vercel/**",
+    ],
+  },
+
+  // Baseline JS recommended — required by the Mergepath policy floor.
+  js.configs.recommended,
+
+  // Apply browser + node globals to all JS sources by default. Narrow
+  // these per-file-pattern in a follow-up commit if the repo has a
+  // clean split (e.g., scripts/* node-only, src/* browser-only).
+  //
+  // `*.cjs` files are split out so ESLint parses them as CommonJS
+  // (`sourceType: "commonjs"`) rather than ES modules — otherwise
+  // top-level `require`/`module.exports` and CommonJS scope rules
+  // produce false-positive parse errors. The defaults ESLint applies
+  // by extension are: `module` for `.js`/`.mjs`, `commonjs` for
+  // `.cjs`; we make that explicit here so the policy is
+  // self-documenting.
+  {
+    files: ["**/*.{js,mjs,jsx}"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+  },
+  {
+    files: ["**/*.cjs"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "commonjs",
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+
+  // TypeScript recommended ruleset — applied to .ts / .tsx via the
+  // typescript-eslint plugin's flat-config preset. Includes the
+  // parser, the recommended rule set, and the file-glob targeting.
+  ...tseslint.configs.recommended,
+
+  // Astro flat-config recommended ruleset — applied to .astro files.
+  // The plugin exposes its flat-config preset under the bracketed
+  // `configs['flat/recommended']` key (NOT the legacy
+  // `configs.recommended` which is the eslintrc-shape config).
+  // Same key for ESM and CJS — the plugin's export shape is
+  // module-system-agnostic.
+  ...astro.configs['flat/recommended'],
+
+];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,6 +25,10 @@ export default [
       ".astro/**",
       ".next/**",
       ".vercel/**",
+      // CONSUMER-LOCAL: agent-spawned git worktrees (e.g. parallel
+      // PR exploration). Local state, not source — linting them
+      // double-counts findings against the main tree.
+      ".claude/worktrees/**",
     ],
   },
 
@@ -77,4 +81,27 @@ export default [
   // module-system-agnostic.
   ...astro.configs['flat/recommended'],
 
+  // ─────────────────────────────────────────────────────────────────
+  // CONSUMER-LOCAL POLICY — TS + style-rule overrides. MUST be LAST.
+  //
+  // Same template policy class as dpr#83 / ffb#274 / tadlock#58:
+  // - `@typescript-eslint/no-unused-vars`: standard `^_`-prefix
+  //   ignore convention (covers catch-clause args, destructured
+  //   leftovers, intentional shadow params).
+  // - `@typescript-eslint/no-explicit-any`: demoted to warn —
+  //   Playwright tests have legitimate `any` for cross-frame DOM
+  //   types that aren't worth typing strictly (5 sites in
+  //   tests/responsive/mondrian-rebalance-animation.spec.ts).
+  {
+    files: ["**/*.{js,mjs,ts,tsx,astro}"],
+    rules: {
+      "@typescript-eslint/no-unused-vars": ["error", {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+        caughtErrorsIgnorePattern: "^_",
+        destructuredArrayIgnorePattern: "^_",
+      }],
+      "@typescript-eslint/no-explicit-any": "warn",
+    },
+  },
 ];

--- a/package.json
+++ b/package.json
@@ -9,15 +9,21 @@
     "preview": "astro preview",
     "test": "astro build && vitest run",
     "test:e2e": "playwright test",
-    "deploy": "scripts/deploy.sh"
+    "deploy": "scripts/deploy.sh",
+    "lint": "eslint ."
   },
   "devDependencies": {
     "@astrojs/rss": "^4.0.0",
     "@astrojs/sitemap": "^3.0.0",
+    "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.59.1",
     "astro": "^6.1.0",
+    "eslint": "^9.39.4",
+    "eslint-plugin-astro": "^1.7.0",
+    "globals": "^16.5.0",
     "js-yaml": "^4.1.1",
     "jsdom": "^29.0.2",
+    "typescript-eslint": "^8.59.3",
     "unist-util-visit": "^5.1.0",
     "vitest": "^4.1.4"
   },

--- a/scripts/ci/check_export_consumer_facts
+++ b/scripts/ci/check_export_consumer_facts
@@ -12,6 +12,27 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TEST_SCRIPT="$REPO_ROOT/tests/test_export_consumer_facts.sh"
+SYNC_SCRIPT="$REPO_ROOT/scripts/sync-to-downstream.sh"
+
+# Disambiguate consumer-side vs mergepath-side misconfig via the
+# .mergepath-sync.yml marker (intentionally not propagated to
+# consumers). Same pattern as check_template_substitution.
+#
+# - sync script missing AND .mergepath-sync.yml missing →
+#   consumer checkout that received the kit-propagated wrapper →
+#   SKIP exit 0
+# - sync script missing AND .mergepath-sync.yml present →
+#   mergepath misconfig (sync script accidentally deleted/renamed)
+#   → FAIL exit 1. Codex P2 round 2 on PR #321 caught the fail-
+#   open risk on the blanket SKIP.
+if [ ! -f "$SYNC_SCRIPT" ]; then
+  if [ ! -f "$REPO_ROOT/.mergepath-sync.yml" ]; then
+    echo "check_export_consumer_facts: SKIP (consumer checkout: scripts/sync-to-downstream.sh + .mergepath-sync.yml both absent)"
+    exit 0
+  fi
+  echo "FAIL: scripts/sync-to-downstream.sh is missing but .mergepath-sync.yml IS present — mergepath misconfig (sync script accidentally deleted/renamed?)" >&2
+  exit 1
+fi
 
 if [ ! -f "$TEST_SCRIPT" ]; then
   echo "check_export_consumer_facts: ERROR (missing $TEST_SCRIPT)" >&2

--- a/scripts/ci/check_export_consumer_facts
+++ b/scripts/ci/check_export_consumer_facts
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# scripts/ci/check_export_consumer_facts — CI entry point for the
+# tests/test_export_consumer_facts.sh regression test.
+#
+# Guards the yq filter inside scripts/sync-to-downstream.sh's
+# export_consumer_facts() against the mikefarah-yq-incompatible
+# if/then/else form that silently broke Phase D's first
+# real-frameworks consumer (device-platform-reporting) — see the
+# test header for the full incident.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_export_consumer_facts.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  echo "check_export_consumer_facts: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"

--- a/scripts/ci/check_op_firebase_deploy_integration
+++ b/scripts/ci/check_op_firebase_deploy_integration
@@ -119,7 +119,7 @@ write_fake_sa_key() {
   "type": "service_account",
   "project_id": "fake-project",
   "private_key_id": "fake-key-id",
-  "private_key": "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+  "private_key": "REDACTED_TEST_FIXTURE_NOT_A_REAL_KEY",
   "client_email": "$sa_email",
   "client_id": "0",
   "auth_uri": "https://accounts.google.com/o/oauth2/auth",

--- a/scripts/ci/check_sync_manifest
+++ b/scripts/ci/check_sync_manifest
@@ -118,6 +118,77 @@ if [ -n "$consumer_rows" ]; then
   done <<< "$consumer_rows"
 fi
 
+# 3.5: per-consumer `facts:` block validation (optional; required
+# for templated propagation per docs/agents/templated-propagation.md).
+# Each fact key must match the lib's accepted charset [a-z0-9_-]+
+# (anything else is rejected at render time as malformed). List-valued
+# facts (yaml `[a, b]`) are allowed; scalar values are too. Mappings
+# of mappings are not — the lib expects flat scalar/list values, and
+# rejecting nested mappings here catches the misconfiguration at
+# manifest validation rather than at the first render attempt.
+
+# 3.5a: assert `.facts` ITSELF is a mapping when present. Without
+# this, a sequence-typed facts block (e.g. `facts: [react, typescript]`)
+# silently passes — `to_entries` on a sequence yields numeric
+# indices that pass the [a-z0-9_-]+ key charset check (digits are
+# valid), so the per-entry validation below false-passes. Codex
+# Phase 4b CHANGES_REQUESTED on PR #316 by nathanpayne-codex caught
+# this gap. Fail-closed at the structural-shape layer before the
+# per-entry iteration.
+if ! facts_shape_rows=$(yq -r '
+  .consumers[]
+  | select(.facts != null)
+  | .name + "\t" + (.facts | tag)
+' "$MANIFEST" 2>&1); then
+  echo "FAIL: could not extract consumer facts-block tags (yq error):"
+  printf '%s\n' "$facts_shape_rows"
+  echo "check_sync_manifest: FAIL"
+  exit 1
+fi
+if [ -n "$facts_shape_rows" ]; then
+  while IFS=$'\t' read -r facts_consumer facts_yaml_tag; do
+    [ -z "$facts_consumer" ] && continue
+    if [ "$facts_yaml_tag" != "!!map" ]; then
+      echo "FAIL: consumer '$facts_consumer' facts: must be a YAML mapping (got tag '$facts_yaml_tag')"
+      FAILED=1
+    fi
+  done <<< "$facts_shape_rows"
+fi
+
+if ! facts_rows=$(yq -r '
+  .consumers[]
+  | select(.facts != null)
+  | .name as $cn
+  | .facts | to_entries[]
+  | $cn + "\t" + .key + "\t" + (.value | tag)
+' "$MANIFEST" 2>&1); then
+  echo "FAIL: could not extract consumer facts from the manifest (yq error):"
+  printf '%s\n' "$facts_rows"
+  echo "check_sync_manifest: FAIL"
+  exit 1
+fi
+if [ -n "$facts_rows" ]; then
+  while IFS=$'\t' read -r fact_consumer fact_key fact_tag; do
+    [ -z "$fact_consumer" ] && continue
+    # Key charset — same as the lib's `_fact_value` validator.
+    case "$fact_key" in
+      ''|*[!a-z0-9_-]*)
+        echo "FAIL: consumer '$fact_consumer' facts: key '$fact_key' must match [a-z0-9_-]+ (per scripts/lib/template-substitution.sh contract)"
+        FAILED=1
+        ;;
+    esac
+    # Value type — scalar (any !!str/!!int/!!float/!!bool) or sequence.
+    # A nested mapping (!!map) is the misconfiguration this guards.
+    case "$fact_tag" in
+      '!!str'|'!!int'|'!!float'|'!!bool'|'!!seq'|'!!null') ;;
+      *)
+        echo "FAIL: consumer '$fact_consumer' fact '$fact_key' has unsupported value type '$fact_tag' (must be scalar or list)"
+        FAILED=1
+        ;;
+    esac
+  done <<< "$facts_rows"
+fi
+
 # Build a set of valid consumer names for cross-check
 valid_consumers=$(yq -r '.consumers[].name' "$MANIFEST" | tr '\n' ',')
 
@@ -136,16 +207,45 @@ if [ "$paths_tag" != "!!seq" ]; then
 fi
 if ! path_rows=$(yq -r '
   .paths[]
-  | ((.path // "") + "\t" + (.type // "") + "\t"
-     + (.consumers | (select(tag == "!!str") // (join(","))) | tostring))
+  | ((.path // "") + "|" + (.type // "") + "|"
+     + (.consumers | (select(tag == "!!str") // (join(","))) | tostring)
+     + "|" + (.dest // "") + "|" + (.source // "")
+     + "|" + (has("dest") | tostring) + "|" + (has("source") | tostring))
 ' "$MANIFEST" 2>&1); then
   echo "FAIL: could not extract .paths from the manifest (yq error):"
   printf '%s\n' "$path_rows"
   echo "check_sync_manifest: FAIL"
   exit 1
 fi
-while IFS=$'\t' read -r path type consumers; do
+# Why IFS='|' and not '\t': bash `read` with IFS=$'\t' collapses
+# runs of whitespace (including tabs), so an empty-valued field
+# between two tabs gets eaten and downstream fields shift left
+# (turning an explicit `dest: ""` into the next field's value).
+# `|` is non-whitespace, so empty fields are preserved positionally.
+# Pipes don't appear in repo-relative paths, type names, or consumer
+# names so the choice is unambiguous. Codex Phase 4b
+# CHANGES_REQUESTED on PR #316 by nathanpayne-codex surfaced the
+# empty-dest gap that made this field-stability issue visible.
+while IFS='|' read -r path type consumers dest source has_dest has_source; do
   [ -z "$path" ] && continue
+
+  # 4a-ter: empty-string `dest:` or `source:` is a misconfiguration —
+  # the yq `(.dest // "")` extraction collapses "absent" and
+  # "explicitly empty" to the same empty string, so we use the
+  # parallel `has("dest")` / `has("source")` probes to distinguish.
+  # An explicit `dest: ""` would pass through to materialize and
+  # blow up there (Codex P1 / Phase 4b CHANGES_REQUESTED on PR
+  # #316 by nathanpayne-codex). Reject at validation.
+  if [ "$has_dest" = "true" ] && [ -z "$dest" ]; then
+    echo "FAIL: path '$path' has explicit dest: \"\" — dest must be non-empty when set"
+    FAILED=1
+    continue
+  fi
+  if [ "$has_source" = "true" ] && [ -z "$source" ]; then
+    echo "FAIL: path '$path' has explicit source: \"\" — source must be non-empty when set"
+    FAILED=1
+    continue
+  fi
 
   # 4a: reject repo-escaping paths. An absolute path or one
   # containing a `..` segment would make the on-disk existence check
@@ -173,6 +273,45 @@ while IFS=$'\t' read -r path type consumers; do
       ;;
   esac
 
+  # 4a-bis: same safety checks on `dest:` (optional) and `source:`
+  # (optional) — both must be repo-relative, no absolute paths, no
+  # `..` segments. dest lives in the CONSUMER repo (so the existence
+  # check below doesn't apply), but the safety rule protects every
+  # consumer from a write-outside-root via a bad manifest entry.
+  # source lives in mergepath but defaults to `.path` when omitted;
+  # only validate when explicitly set.
+  for field_pair in "dest:$dest" "source:$source"; do
+    field_name="${field_pair%%:*}"
+    field_val="${field_pair#*:}"
+    [ -z "$field_val" ] && continue
+    case "$field_val" in
+      /*)
+        echo "FAIL: path '$path' has $field_name '$field_val' that is absolute — must be repo-relative"
+        FAILED=1
+        continue 2
+        ;;
+    esac
+    case "/$field_val/" in
+      */../*)
+        echo "FAIL: path '$path' has $field_name '$field_val' containing a '..' segment — must not escape the repo root"
+        FAILED=1
+        continue 2
+        ;;
+    esac
+  done
+
+  # 4b: templated entries SHOULD declare `dest:` explicitly (their
+  # whole point is source-dest decoupling — `examples/eslint.config.js`
+  # in mergepath renders to `eslint.config.js` at the consumer). A
+  # templated entry that omits `dest:` would land the rendered output
+  # at the same path the source lives at, which is almost never what
+  # you want. Warn-not-fail: there might be a future use case for
+  # path-preserving templated rendering (e.g., per-consumer customization
+  # of a same-name file), so don't block, but make the omission noisy.
+  if [ "$type" = "templated" ] && [ -z "$dest" ]; then
+    echo "WARN: templated path '$path' omits 'dest:' — rendered output will land at the same path as the source. If that's intentional, explicitly set 'dest: $path' to silence this warning."
+  fi
+
   # 4: path exists on disk
   case "$type" in
     kit)
@@ -194,6 +333,31 @@ while IFS=$'\t' read -r path type consumers; do
       FAILED=1
       ;;
   esac
+
+  # 4c: existence-check source override. If `source:` is set
+  # (currently only meaningful for templated entries with source ≠
+  # path, but accepted for canonical/kit too for future flexibility),
+  # verify the source-of-truth file exists in mergepath. The default
+  # source = path case was already covered by the existence check
+  # above; this only fires when source is explicitly set to a
+  # different path.
+  if [ -n "$source" ] && [ "$source" != "$path" ]; then
+    src_target="$REPO_ROOT/$source"
+    # Templated sources must be regular files (a directory can't be a
+    # template). Canonical/kit also accept the explicit source
+    # override for future flexibility; use `-f` (regular file) for
+    # templated and `-e` (any FS entry, since kit could point at a
+    # directory) for the others. CodeRabbit Major on PR #316.
+    if [ "$type" = "templated" ]; then
+      if [ ! -f "$src_target" ]; then
+        echo "FAIL: path '$path' source '$source' must be a regular file for templated entries"
+        FAILED=1
+      fi
+    elif [ ! -e "$src_target" ]; then
+      echo "FAIL: path '$path' source '$source' does not exist on disk"
+      FAILED=1
+    fi
+  fi
 
   # 6: consumers field
   if [ "$consumers" = "all" ]; then

--- a/scripts/ci/check_sync_manifest
+++ b/scripts/ci/check_sync_manifest
@@ -39,14 +39,45 @@ REPO_ROOT="${MERGEPATH_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." &&
 MANIFEST="${MERGEPATH_MANIFEST_PATH:-$REPO_ROOT/.mergepath-sync.yml}"
 SUPPORTED_VERSION=1
 
+# Consumer-side vs mergepath-side disambiguation MUST happen
+# before the yq prereq check below — consumers don't typically
+# have yq installed, so failing on yq first would mask the
+# manifest-absent skip path (Codex P1 round 1 on #321). The
+# marker file scripts/sync-to-downstream.sh exists in mergepath
+# and is intentionally NOT propagated to consumers, so its
+# presence distinguishes "running from mergepath" from "running
+# from a consumer that received the kit-propagated wrapper".
+#
+# Two outcomes when .mergepath-sync.yml is missing:
+#
+#   (a) consumer checkout (sync-to-downstream.sh ALSO absent) →
+#       SKIP with exit 0. The manifest is mergepath-internal by
+#       design (the entire manifest lists every consumer repo's
+#       privacy-sensitive metadata; #268/#271 keep it mergepath-
+#       only); consumers receiving the check_* wrapper through
+#       the scripts/ci/ kit propagation should no-op rather than
+#       fail. Phase D 4b on consumer PRs surfaced the previous
+#       FAIL-everywhere behavior.
+#
+#   (b) mergepath checkout (sync-to-downstream.sh present) →
+#       FAIL with exit 1. The manifest has been accidentally
+#       deleted/renamed in a PR that modifies the canonical
+#       repo. This is the original guardrail (Codex P2 round 1
+#       on #321 caught that a blanket SKIP would fail-open on
+#       this case).
+if [ ! -f "$MANIFEST" ]; then
+  MARKER="$REPO_ROOT/scripts/sync-to-downstream.sh"
+  if [ ! -f "$MARKER" ]; then
+    echo "check_sync_manifest: SKIP (mergepath-only: .mergepath-sync.yml not present in this checkout; scripts/sync-to-downstream.sh also absent → consumer checkout)"
+    exit 0
+  fi
+  echo "FAIL: .mergepath-sync.yml is missing at repo root (but scripts/sync-to-downstream.sh IS present — looks like mergepath itself; the manifest must not be deleted/renamed)"
+  exit 1
+fi
+
 if ! command -v yq >/dev/null 2>&1; then
   echo "FAIL: yq is required (mikefarah/yq v4+). Install via 'brew install yq' or apt."
   exit 2
-fi
-
-if [ ! -f "$MANIFEST" ]; then
-  echo "FAIL: .mergepath-sync.yml is missing at repo root"
-  exit 1
 fi
 
 # Parse-check: yq exits non-zero on a malformed YAML.
@@ -210,7 +241,8 @@ if ! path_rows=$(yq -r '
   | ((.path // "") + "|" + (.type // "") + "|"
      + (.consumers | (select(tag == "!!str") // (join(","))) | tostring)
      + "|" + (.dest // "") + "|" + (.source // "")
-     + "|" + (has("dest") | tostring) + "|" + (has("source") | tostring))
+     + "|" + (has("dest") | tostring) + "|" + (has("source") | tostring)
+     + "|" + (has("path") | tostring))
 ' "$MANIFEST" 2>&1); then
   echo "FAIL: could not extract .paths from the manifest (yq error):"
   printf '%s\n' "$path_rows"
@@ -226,8 +258,34 @@ fi
 # names so the choice is unambiguous. Codex Phase 4b
 # CHANGES_REQUESTED on PR #316 by nathanpayne-codex surfaced the
 # empty-dest gap that made this field-stability issue visible.
-while IFS='|' read -r path type consumers dest source has_dest has_source; do
-  [ -z "$path" ] && continue
+#
+# Why the outer `[ -n "$path_rows" ]` guard: an empty `.paths: []`
+# (yq emits no lines) combined with `<<< "$path_rows"` (here-string
+# always appends a newline) yields one blank `read` iteration, which
+# the new `has_path != "true"` fail-closed check below would treat
+# as a malformed entry. Same guard pattern as the consumer_rows
+# loop above. Codex Phase 4b P2 on PR #320 by nathanpayne-codex
+# caught this regression from PR #320's own fail-closed addition.
+if [ -n "$path_rows" ]; then
+while IFS='|' read -r path type consumers dest source has_dest has_source has_path; do
+  # An entry without a `path` field (or with `path: ""`) is a
+  # malformed manifest entry. Previously coerced to empty + silently
+  # `continue`d, letting malformed entries hide in the manifest with
+  # only an empty-line side effect. CodeRabbit Major + Codex Phase 4b
+  # CHANGES_REQUESTED on Phase D consumer PRs both flagged the
+  # silent-skip — fail-closed instead. has_path distinguishes
+  # "absent" from "explicit empty" (parallel to the dest/source
+  # has_* probes added in #316).
+  if [ "$has_path" != "true" ]; then
+    echo "FAIL: a .paths[] entry has no 'path' field (omitted entirely; manifest entries must declare 'path')"
+    FAILED=1
+    continue
+  fi
+  if [ -z "$path" ]; then
+    echo "FAIL: a .paths[] entry has explicit path: \"\" (empty); path must be non-empty"
+    FAILED=1
+    continue
+  fi
 
   # 4a-ter: empty-string `dest:` or `source:` is a misconfiguration —
   # the yq `(.dest // "")` extraction collapses "absent" and
@@ -383,6 +441,7 @@ while IFS='|' read -r path type consumers dest source has_dest has_source; do
     done
   fi
 done <<< "$path_rows"
+fi  # end: if [ -n "$path_rows" ]
 
 # 7. requires: closure invariant (#264).
 #

--- a/scripts/ci/check_template_substitution
+++ b/scripts/ci/check_template_substitution
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# scripts/ci/check_template_substitution — CI entry point for the
+# Layer 5 template-substitution lib tests.
+#
+# Wraps tests/test_template_substitution.sh so the repo_lint workflow's
+# explicit check_* list picks it up. The lib at
+# scripts/lib/template-substitution.sh is the substitution engine for
+# `type: templated` manifest entries (activated in a follow-up PR);
+# this check guards the lib's contract independently of integration.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_template_substitution.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  echo "check_template_substitution: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"

--- a/scripts/ci/check_template_substitution
+++ b/scripts/ci/check_template_substitution
@@ -12,6 +12,29 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TEST_SCRIPT="$REPO_ROOT/tests/test_template_substitution.sh"
+LIB="$REPO_ROOT/scripts/lib/template-substitution.sh"
+
+# Disambiguate consumer-side vs mergepath-side misconfig using the
+# .mergepath-sync.yml marker (intentionally not propagated to
+# consumers per the inline comment in that file).
+#
+# - lib missing AND .mergepath-sync.yml missing → consumer checkout
+#   that received the kit-propagated wrapper without the
+#   mergepath-internal lib → SKIP (exit 0). Phase D 4b on consumer
+#   PRs surfaced the previous fail-on-consumer behavior.
+# - lib missing AND .mergepath-sync.yml present → mergepath itself
+#   lost the lib (accidental deletion/rename in a PR) → FAIL (exit
+#   1). Without this branch, the SKIP would fail-open on mergepath
+#   and the lib's regression test suite would silently stop
+#   running (Codex P2 round 2 on PR #321).
+if [ ! -f "$LIB" ]; then
+  if [ ! -f "$REPO_ROOT/.mergepath-sync.yml" ]; then
+    echo "check_template_substitution: SKIP (consumer checkout: scripts/lib/template-substitution.sh + .mergepath-sync.yml both absent)"
+    exit 0
+  fi
+  echo "FAIL: scripts/lib/template-substitution.sh is missing but .mergepath-sync.yml IS present — mergepath misconfig (lib accidentally deleted/renamed?)" >&2
+  exit 1
+fi
 
 if [ ! -f "$TEST_SCRIPT" ]; then
   echo "check_template_substitution: ERROR (missing $TEST_SCRIPT)" >&2

--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -27,7 +27,7 @@ interface Props {
   slug: string;
 }
 
-const { playbackId, fallbackSrc, title, slug } = Astro.props;
+const { playbackId, fallbackSrc, title, slug: _slug } = Astro.props;
 
 const altText = `${title} product screenshot`;
 
@@ -90,7 +90,7 @@ if (isSvgFallback) {
       /<svg\b/,
       `<svg role="img" aria-label="${escapeAttr(altText)}"`
     );
-  } catch (err) {
+  } catch (_err) {
     // If the file isn't readable for any reason, fall back to the <img>
     // path so the hero still renders something.
     inlineSvg = null;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -119,6 +119,9 @@ const ogImageUrl = ogImage.includes('?') ? `${ogImage}&v=${buildTime}` : `${ogIm
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-7C29SRBXB1"></script>
   <script is:inline>
     window.dataLayer = window.dataLayer || [];
+    // Google's canonical GA4 gtag stub uses `arguments` by design;
+    // rewriting to rest params changes call-signature semantics GA expects.
+    // eslint-disable-next-line prefer-rest-params
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
     gtag('config', 'G-7C29SRBXB1', {
@@ -153,9 +156,9 @@ const ogImageUrl = ogImage.includes('?') ? `${ogImage}&v=${buildTime}` : `${ogIm
        JS-restricted users. See #344. -->
   <script is:inline>
     (function () {
-      var html = document.documentElement;
+      const html = document.documentElement;
       html.dataset.fontsPending = '';
-      var reveal = function () { delete html.dataset.fontsPending; };
+      const reveal = function () { delete html.dataset.fontsPending; };
       if (document.fonts && document.fonts.ready && typeof document.fonts.ready.then === 'function') {
         document.fonts.ready.then(reveal);
         setTimeout(reveal, 1500);

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -57,7 +57,6 @@ const normalizedPathname = rawPathname === '/' || rawPathname.includes('.')
     : `${rawPathname}/`;
 const canonical = new URL(normalizedPathname, Astro.site).href;
 const fullTitle = `${title} | Nathan Payne`;
-const kicker = tags.join(' · ');
 const publishedDate = date.toLocaleDateString('en-US', {
   year: 'numeric',
   month: 'long',

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -226,14 +226,14 @@ const homepageJsonLd = {
             </noscript>
             <script is:inline>
               (function () {
-                var el = document.getElementById('availability-mailto');
+                const el = document.getElementById('availability-mailto');
                 if (!el) return;
                 try {
-                  var user = atob(el.dataset.u);
-                  var domain = atob(el.dataset.d);
-                  var subject = el.dataset.s ? atob(el.dataset.s) : '';
+                  const user = atob(el.dataset.u);
+                  const domain = atob(el.dataset.d);
+                  const subject = el.dataset.s ? atob(el.dataset.s) : '';
                   el.href = 'mailto:' + user + '@' + domain + (subject ? '?subject=' + subject : '');
-                } catch (e) { /* leave href as "#" — noscript covers the fallback */ }
+                } catch (_e) { /* leave href as "#" — noscript covers the fallback */ }
               })();
             </script>
             <span class="connect-label">Elsewhere</span>

--- a/tests/robots-sitemap-integration.test.js
+++ b/tests/robots-sitemap-integration.test.js
@@ -10,7 +10,7 @@
  * @see Issue #164 — Prevent robots.txt sitemap drift from Astro output
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { mkdtemp, writeFile, readFile, rm, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/tests/test_export_consumer_facts.sh
+++ b/tests/test_export_consumer_facts.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# tests/test_export_consumer_facts.sh
+#
+# Regression-guard for the yq filter inside
+# scripts/sync-to-downstream.sh's `export_consumer_facts()`. The
+# initial Phase B2 (#316) implementation used a mikefarah/yq-
+# incompatible `if (tag == "!!seq") then ... else ... end` form
+# that silently emitted nothing — every templated render fell
+# through to the "no frameworks" baseline because
+# MERGEPATH_FACT_* was never exported. Phase D's swipewatch canary
+# fell-positive on the bug because swipewatch happens to declare
+# `frameworks: []` (rendered output is the same with or without
+# the facts loaded). device-platform-reporting's canary surfaced
+# the real failure: its `frameworks: [react]` should activate the
+# React block, but rendered to the JS baseline only.
+#
+# This test runs the EXACT yq filter from export_consumer_facts
+# against three fixture consumer profiles (seq fact, scalar fact,
+# empty seq fact, no facts at all) and asserts the output shape.
+# The lib's yq invocation and this test's yq invocation must stay
+# in sync — both carry a "keep in sync with tests/test_export_consumer_facts.sh"
+# comment for the next contributor.
+#
+# Bash 3.2 portable. Runs without network.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/sync-to-downstream.sh"
+
+[[ -r "$SCRIPT" ]] || { echo "missing $SCRIPT" >&2; exit 1; }
+command -v yq >/dev/null 2>&1 || { echo "SKIP: yq not available" >&2; exit 0; }
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/export-facts-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# Fixture manifest with four consumers exercising the value-type matrix.
+cat > "$WORKDIR/manifest.yml" <<'EOF'
+version: 1
+consumers:
+  - name: with_seq_multi
+    repo: example-org/with-seq-multi
+    visibility: public
+    facts:
+      frameworks: [react, typescript]
+      node_version: "20"
+  - name: with_seq_single
+    repo: example-org/with-seq-single
+    visibility: public
+    facts:
+      frameworks: [astro]
+  - name: with_empty_seq
+    repo: example-org/with-empty-seq
+    visibility: public
+    facts:
+      frameworks: []
+  - name: with_no_facts
+    repo: example-org/with-no-facts
+    visibility: public
+paths: []
+EOF
+
+# Run the yq filter that mirrors export_consumer_facts's filter.
+# KEEP IN SYNC with scripts/sync-to-downstream.sh's export_consumer_facts.
+run_filter() {
+  local consumer_name=$1
+  MERGEPATH_CONSUMER_NAME="$consumer_name" yq -r '
+    env(MERGEPATH_CONSUMER_NAME) as $cn
+    | .consumers[] | select(.name == $cn) | .facts // {} | to_entries[]
+    | .key + "\t"
+      + ((.value | select(tag == "!!seq") | join(" "))
+         // (.value | tostring))
+  ' "$WORKDIR/manifest.yml"
+}
+
+# Case 1: list-valued fact serializes as space-separated.
+out=$(run_filter with_seq_multi)
+expected="$(printf 'frameworks\treact typescript\nnode_version\t20')"
+if [ "$out" = "$expected" ]; then
+  pass "Case 1: list + scalar facts extract correctly (multi-element seq)"
+else
+  fail "Case 1: expected:\n$expected\ngot:\n$out"
+fi
+
+# Case 2: single-element list serializes to a single word.
+out=$(run_filter with_seq_single)
+expected="$(printf 'frameworks\tastro')"
+if [ "$out" = "$expected" ]; then
+  pass "Case 2: single-element list serializes to one word"
+else
+  fail "Case 2: expected:\n$expected\ngot:\n$out"
+fi
+
+# Case 3: empty list — join("") yields empty string; key still present.
+# This was the case that masked the original bug; both broken-yq and
+# correct-yq produced the same empty-string output for swipewatch's
+# `frameworks: []`. Regression test pins the CORRECT behavior so a
+# future broken-syntax change is caught.
+out=$(run_filter with_empty_seq)
+expected="$(printf 'frameworks\t')"
+if [ "$out" = "$expected" ]; then
+  pass "Case 3: empty-list fact yields key with empty value (masked the original bug)"
+else
+  fail "Case 3: expected:\n[$expected]\ngot:\n[$out]"
+fi
+
+# Case 4: consumer with no facts block at all — filter yields nothing.
+out=$(run_filter with_no_facts)
+if [ -z "$out" ]; then
+  pass "Case 4: consumer without facts block yields no output"
+else
+  fail "Case 4: expected empty output, got:\n$out"
+fi
+
+# Case 5: the lib script's source MUST contain the documented
+# select-fallback idiom. If a future contributor reverts to the
+# `if then else end` form (which mikefarah/yq rejects), this
+# assertion catches it before the broken syntax ships.
+if grep -q 'select(tag == "!!seq") | join(" ")' "$SCRIPT"; then
+  pass "Case 5: lib script uses the select+// idiom (not the broken if/then/else form)"
+else
+  fail "Case 5: scripts/sync-to-downstream.sh no longer uses the select+// idiom — this regression-guard expects 'select(tag == \"!!seq\") | join(\" \")' in the script"
+fi
+
+# Case 6: explicit no-regression check — the script must NOT contain
+# the broken form `if (tag == "!!seq") then`. This is the literal
+# substring that caused the bug.
+if ! grep -qF 'if (tag == "!!seq") then' "$SCRIPT"; then
+  pass "Case 6: lib script does not contain the broken yq if/then/else form"
+else
+  fail "Case 6: lib script contains the broken 'if (tag == \"!!seq\") then ... else ... end' form — mikefarah/yq rejects this at the lexer"
+fi
+
+echo
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -gt 0 ]; then
+  echo "test_export_consumer_facts: FAIL ($FAIL/$TOTAL failed)"
+  exit 1
+fi
+echo "test_export_consumer_facts: PASS ($TOTAL tests)"
+exit 0

--- a/tests/test_template_substitution.sh
+++ b/tests/test_template_substitution.sh
@@ -1,0 +1,617 @@
+#!/usr/bin/env bash
+# tests/test_template_substitution.sh
+#
+# Unit tests for scripts/lib/template-substitution.sh. Covers v1 syntax:
+# variable substitution, conditional blocks across the four expression
+# forms, comment-prefix flexibility, error paths (unclosed/nested/
+# unexpected markers, malformed expressions), strict-mode fact-miss,
+# atomic render_to.
+#
+# Bash 3.2 portable. Runs without network. Invoked by
+# scripts/ci/check_template_substitution (which the lib's introduction
+# PR also wires up).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIB="$ROOT/scripts/lib/template-substitution.sh"
+
+[[ -r "$LIB" ]] || { echo "missing $LIB" >&2; exit 1; }
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/template-sub-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# Reset all MERGEPATH_FACT_* env vars before each test so prior cases
+# can't bleed in.
+reset_facts() {
+  local var
+  for var in $(env | awk -F= '/^MERGEPATH_FACT_/ {print $1}'); do
+    unset "$var"
+  done
+  unset MERGEPATH_TEMPLATE_STRICT
+}
+
+# Source the lib in a subshell so test failures don't poison later
+# tests. Each render_case is its own subshell.
+render_case() {
+  # $1: template content (heredoc-friendly), $2..: KEY=VALUE env exports
+  local template_content=$1
+  shift
+  local src="$WORKDIR/src.$$.tpl"
+  local out="$WORKDIR/out.$$.txt"
+  local err="$WORKDIR/err.$$.txt"
+  printf '%s' "$template_content" > "$src"
+  (
+    reset_facts
+    for kv in "$@"; do
+      export "$kv"
+    done
+    # shellcheck disable=SC1090
+    source "$LIB"
+    local render_rc=0
+    template_substitution::render "$src" > "$out" 2> "$err" || render_rc=$?
+    echo "$render_rc" > "$WORKDIR/rc.$$.txt"
+  )
+  local rc
+  rc=$(cat "$WORKDIR/rc.$$.txt")
+  rm -f "$src" "$WORKDIR/rc.$$.txt"
+  # Echo: <rc>\t<stdout-file>\t<stderr-file>
+  printf '%s\t%s\t%s\n' "$rc" "$out" "$err"
+}
+
+# Helper: assert rendered output matches expected.
+expect_output() {
+  local label=$1 result=$2 expected=$3
+  local rc out_file err_file
+  rc=$(printf '%s' "$result" | cut -f1)
+  out_file=$(printf '%s' "$result" | cut -f2)
+  err_file=$(printf '%s' "$result" | cut -f3)
+  if [ "$rc" != "0" ]; then
+    fail "$label: expected rc=0, got rc=$rc; stderr:"
+    sed 's/^/    /' "$err_file" >&2
+    return
+  fi
+  local actual
+  actual=$(cat "$out_file")
+  if [ "$actual" = "$expected" ]; then
+    pass "$label"
+  else
+    fail "$label: output mismatch"
+    echo "  expected:" >&2
+    printf '%s\n' "$expected" | sed 's/^/    /' >&2
+    echo "  actual:" >&2
+    printf '%s\n' "$actual" | sed 's/^/    /' >&2
+  fi
+}
+
+expect_rc() {
+  local label=$1 result=$2 want_rc=$3
+  local rc err_file
+  rc=$(printf '%s' "$result" | cut -f1)
+  err_file=$(printf '%s' "$result" | cut -f3)
+  if [ "$rc" = "$want_rc" ]; then
+    pass "$label (rc=$rc)"
+  else
+    fail "$label: expected rc=$want_rc, got rc=$rc; stderr:"
+    sed 's/^/    /' "$err_file" >&2
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 1. Variable substitution
+# ---------------------------------------------------------------------------
+
+r=$(render_case "hello {{name}}!
+" "MERGEPATH_FACT_NAME=world")
+expect_output "1a {{key}} basic substitution" "$r" "hello world!"
+
+r=$(render_case "{{a}}-{{b}}-{{a}}
+" "MERGEPATH_FACT_A=foo" "MERGEPATH_FACT_B=bar")
+expect_output "1b multiple substitutions per line, repeats" "$r" "foo-bar-foo"
+
+r=$(render_case "plain line, no markers
+")
+expect_output "1c no markers passes through" "$r" "plain line, no markers"
+
+r=$(render_case "missing: <{{nope}}>
+")
+expect_output "1d lenient mode: missing fact = empty" "$r" "missing: <>"
+
+r=$(render_case "missing: <{{nope}}>
+" "MERGEPATH_TEMPLATE_STRICT=1")
+expect_rc "1e strict mode: missing fact = rc 3" "$r" 3
+
+# 1e2: regression guard for sentinel collision (Codex P3 round 2 on PR #313).
+# A fact legitimately set to the OLD sentinel string must NOT be
+# misclassified as unset. With the +x detection this is just an
+# ordinary set-to-value case.
+r=$(render_case "value: <{{collides}}>
+" "MERGEPATH_FACT_COLLIDES=__MERGEPATH_FACT_UNSET__")
+expect_output "1e2 sentinel-collision regression: literal sentinel as value treated as set" "$r" "value: <__MERGEPATH_FACT_UNSET__>"
+
+# 1e3: fact set to empty string is treated as SET (distinct from unset).
+# Lenient mode: empty value → empty substitution (same as before).
+# Strict mode: empty value → NOT a strict-mode failure (the var IS set).
+# This is the new behavior under +x detection; previously a value of
+# "" round-tripped through the sentinel test as "set", but the
+# documentation of strict-mode said only an "unknown fact" (set/unset
+# distinction) triggers rc 3.
+r=$(render_case "empty: <{{empty_fact}}>
+" "MERGEPATH_FACT_EMPTY_FACT=" "MERGEPATH_TEMPLATE_STRICT=1")
+expect_output "1e3 strict mode: empty-string fact is set (not a strict failure)" "$r" "empty: <>"
+
+r=$(render_case "unclosed: {{key
+")
+expect_output "1f unclosed {{ left verbatim" "$r" "unclosed: {{key"
+
+r=$(render_case "hyphen key: {{node-version}}
+" "MERGEPATH_FACT_NODE_VERSION=20")
+expect_output "1g hyphenated fact key → underscored env var" "$r" "hyphen key: 20"
+
+# 1h: injection attempt — key contains shell metacharacters. Without
+# input validation in _fact_value (CodeRabbit Critical on PR #313),
+# this key would be interpreted at eval time as a command
+# substitution. With validation, the renderer rejects with rc 2.
+r=$(render_case "compromised: {{foo\$(id)}}
+")
+expect_rc "1h injection attempt key -> rc 1 (rejected as malformed template)" "$r" 1
+
+# 1i: another injection vector — backticks.
+r=$(render_case "compromised: {{foo\`id\`}}
+")
+expect_rc "1i backtick key -> rc 1 (rejected as malformed template)" "$r" 1
+
+# 1j: uppercase keys rejected (reserved for env-var form).
+r=$(render_case "{{FOO}}
+" "MERGEPATH_FACT_FOO=bar")
+expect_rc "1j uppercase key -> rc 1 (rejected as malformed template)" "$r" 1
+
+# 1k: underscored keys allowed (natural shell var style).
+r=$(render_case "ts: {{has_ts}}
+" "MERGEPATH_FACT_HAS_TS=yes")
+expect_output "1k underscored key allowed" "$r" "ts: yes"
+
+# ---------------------------------------------------------------------------
+# 2. Bare conditional: >>> if <key>
+# ---------------------------------------------------------------------------
+
+r=$(render_case "before
+// >>> if has_ts
+typescript line
+// <<<
+after
+" "MERGEPATH_FACT_HAS_TS=1")
+expect_output "2a bare conditional, truthy fact" "$r" "before
+typescript line
+after"
+
+r=$(render_case "before
+// >>> if has_ts
+typescript line
+// <<<
+after
+")
+expect_output "2b bare conditional, unset fact (lenient)" "$r" "before
+after"
+
+r=$(render_case "before
+// >>> if has_ts
+typescript line
+// <<<
+after
+" "MERGEPATH_FACT_HAS_TS=")
+expect_output "2c bare conditional, empty fact = falsy" "$r" "before
+after"
+
+# ---------------------------------------------------------------------------
+# 3. Negation: >>> if !<key>
+# ---------------------------------------------------------------------------
+
+r=$(render_case "// >>> if !has_ts
+no typescript
+// <<<
+")
+expect_output "3a negation, unset fact = true" "$r" "no typescript"
+
+r=$(render_case "// >>> if !has_ts
+no typescript
+// <<<
+" "MERGEPATH_FACT_HAS_TS=1")
+expect_output "3b negation, set fact = false" "$r" ""
+
+# ---------------------------------------------------------------------------
+# 4. List membership: >>> if <key> contains <value>
+# ---------------------------------------------------------------------------
+
+r=$(render_case "// >>> if frameworks contains react
+react block
+// <<<
+" "MERGEPATH_FACT_FRAMEWORKS=react typescript")
+expect_output "4a contains, present" "$r" "react block"
+
+r=$(render_case "// >>> if frameworks contains vue
+vue block
+// <<<
+" "MERGEPATH_FACT_FRAMEWORKS=react typescript")
+expect_output "4b contains, absent" "$r" ""
+
+# Word-boundary safety: "react" must NOT match "react-native".
+r=$(render_case "// >>> if frameworks contains react
+matched react
+// <<<
+" "MERGEPATH_FACT_FRAMEWORKS=react-native")
+expect_output "4c contains, word-boundary (react ≠ react-native)" "$r" ""
+
+r=$(render_case "// >>> if frameworks contains react-native
+matched native
+// <<<
+" "MERGEPATH_FACT_FRAMEWORKS=react-native react")
+expect_output "4d contains, hyphenated value matches" "$r" "matched native"
+
+# ---------------------------------------------------------------------------
+# 5. Equality / inequality
+# ---------------------------------------------------------------------------
+
+r=$(render_case "// >>> if node_version == 20
+node 20
+// <<<
+" "MERGEPATH_FACT_NODE_VERSION=20")
+expect_output "5a equality, match" "$r" "node 20"
+
+r=$(render_case "// >>> if node_version == 20
+node 20
+// <<<
+" "MERGEPATH_FACT_NODE_VERSION=18")
+expect_output "5b equality, no match" "$r" ""
+
+r=$(render_case "// >>> if node_version != 18
+modern node
+// <<<
+" "MERGEPATH_FACT_NODE_VERSION=20")
+expect_output "5c inequality, match" "$r" "modern node"
+
+r=$(render_case "// >>> if node_version != 18
+modern node
+// <<<
+" "MERGEPATH_FACT_NODE_VERSION=18")
+expect_output "5d inequality, no match" "$r" ""
+
+# ---------------------------------------------------------------------------
+# 6. Comment-prefix flexibility (each comment style must be recognized)
+# ---------------------------------------------------------------------------
+
+for prefix_label_pair in \
+    "// js-line" \
+    "# shell-yaml" \
+    "-- sql-lua" \
+    "<!-- html-open"; do
+  prefix=${prefix_label_pair% *}
+  label=${prefix_label_pair#* }
+  # html close needs trailing -->; handle separately for marker close
+  if [ "$label" = "html-open" ]; then
+    template=$(printf '%s >>> if frameworks contains react\nreact-only\n%s <<< -->\n' "$prefix" "$prefix")
+  else
+    template=$(printf '%s >>> if frameworks contains react\nreact-only\n%s <<<\n' "$prefix" "$prefix")
+  fi
+  r=$(render_case "$template" "MERGEPATH_FACT_FRAMEWORKS=react")
+  expect_output "6 prefix '$prefix' ($label) — block kept" "$r" "react-only"
+done
+
+# Mixed leading whitespace on marker.
+r=$(render_case "    // >>> if frameworks contains react
+react-only
+  // <<<
+" "MERGEPATH_FACT_FRAMEWORKS=react")
+expect_output "6e leading whitespace on markers" "$r" "react-only"
+
+# ---------------------------------------------------------------------------
+# 7. Variable substitution INSIDE a kept block (and skipped block)
+# ---------------------------------------------------------------------------
+
+r=$(render_case "// >>> if has_ts
+ts version {{node_version}}
+// <<<
+" "MERGEPATH_FACT_HAS_TS=1" "MERGEPATH_FACT_NODE_VERSION=20")
+expect_output "7a {{vars}} substituted inside kept block" "$r" "ts version 20"
+
+r=$(render_case "// >>> if has_ts
+ts version {{node_version}}
+// <<<
+")
+expect_output "7b {{vars}} inside skipped block are not substituted" "$r" ""
+
+# ---------------------------------------------------------------------------
+# 8. Malformed templates → rc 1
+# ---------------------------------------------------------------------------
+
+r=$(render_case "// >>> if has_ts
+unclosed body
+")
+expect_rc "8a unclosed if marker -> rc 1" "$r" 1
+
+r=$(render_case "before
+// <<<
+after
+")
+expect_rc "8b unexpected close marker -> rc 1" "$r" 1
+
+r=$(render_case "// >>> if outer
+outer body
+// >>> if inner
+nested body
+// <<<
+// <<<
+")
+expect_rc "8c nested if -> rc 1 (v1 doesnt support nesting)" "$r" 1
+
+r=$(render_case "// >>> if foo bar baz quux
+body
+// <<<
+")
+expect_rc "8d unknown expression form → rc 1" "$r" 1
+
+# ---------------------------------------------------------------------------
+# 9. eval_expr direct (drives the expression evaluator in isolation)
+# ---------------------------------------------------------------------------
+
+(
+  reset_facts
+  export MERGEPATH_FACT_FRAMEWORKS="react typescript"
+  export MERGEPATH_FACT_HAS_TS=1
+  # shellcheck disable=SC1090
+  source "$LIB"
+  set +e
+  template_substitution::eval_expr "has_ts"; r1=$?
+  template_substitution::eval_expr "!has_ts"; r2=$?
+  template_substitution::eval_expr "frameworks contains react"; r3=$?
+  template_substitution::eval_expr "frameworks contains vue"; r4=$?
+  template_substitution::eval_expr "node_version == 20"; r5=$?
+  template_substitution::eval_expr ""; r6=$?
+  set -e
+  if [ "$r1" = "0" ] && [ "$r2" = "1" ] && [ "$r3" = "0" ] && \
+     [ "$r4" = "1" ] && [ "$r5" = "1" ] && [ "$r6" = "2" ]; then
+    echo "PASS: 9 eval_expr direct (truthy/falsy/match/miss/empty)"
+  else
+    echo "FAIL: 9 eval_expr direct: got $r1/$r2/$r3/$r4/$r5/$r6 (expected 0/1/0/1/1/2)" >&2
+    exit 1
+  fi
+) && PASS=$((PASS + 1)) || FAIL=$((FAIL + 1))
+
+# ---------------------------------------------------------------------------
+# 10. render_to atomic write
+# ---------------------------------------------------------------------------
+
+src="$WORKDIR/atomic-src.tpl"
+dest="$WORKDIR/atomic-dest.txt"
+cat > "$src" <<'EOF'
+rendered: {{key}}
+EOF
+(
+  reset_facts
+  export MERGEPATH_FACT_KEY=value
+  # shellcheck disable=SC1090
+  source "$LIB"
+  template_substitution::render_to "$src" "$dest"
+)
+if [ -f "$dest" ] && [ "$(cat "$dest")" = "rendered: value" ]; then
+  pass "10a render_to writes destination file"
+else
+  fail "10a render_to: expected 'rendered: value', got: $(cat "$dest" 2>/dev/null || echo MISSING)"
+fi
+
+# 10c: render_to preserves existing dest mode (Codex P2 round 2 on PR #313).
+# Pre-create dest with mode 0644 and verify mv doesn't strip to 0600.
+src="$WORKDIR/mode-src.tpl"
+dest="$WORKDIR/mode-dest.txt"
+echo "original content" > "$dest"
+chmod 644 "$dest"
+echo "new: {{key}}" > "$src"
+(
+  reset_facts
+  export MERGEPATH_FACT_KEY=after
+  # shellcheck disable=SC1090
+  source "$LIB"
+  template_substitution::render_to "$src" "$dest"
+)
+# Read mode in a portable way (same order as the lib — GNU first, BSD
+# fallback; the inverse order breaks on Linux because GNU `stat -f`
+# means filesystem status, not format, and writes garbage to stdout
+# before failing).
+actual_mode=$(stat -c '%a' "$dest" 2>/dev/null \
+              || stat -f '%Mp%Lp' "$dest" 2>/dev/null \
+              || echo "??")
+# BSD stat returns "0644", GNU returns "644". Accept both.
+case "$actual_mode" in
+  0644|644)
+    if [ "$(cat "$dest")" = "new: after" ]; then
+      pass "10c render_to preserves existing dest mode (0644, not 0600)"
+    else
+      fail "10c render_to: content wrong after mode-preservation render: $(cat "$dest")"
+    fi
+    ;;
+  *)
+    fail "10c render_to: expected mode 0644/644, got '$actual_mode'"
+    ;;
+esac
+
+# 10d: render_to writing a new file (no pre-existing dest) — verify
+# render still succeeds (mode preservation skips the chmod, but the
+# write must work).
+src="$WORKDIR/newfile-src.tpl"
+dest="$WORKDIR/newfile-dest.txt"
+echo "fresh: {{key}}" > "$src"
+[ -e "$dest" ] && rm "$dest"
+(
+  reset_facts
+  export MERGEPATH_FACT_KEY=new
+  # shellcheck disable=SC1090
+  source "$LIB"
+  template_substitution::render_to "$src" "$dest"
+)
+if [ -f "$dest" ] && [ "$(cat "$dest")" = "fresh: new" ]; then
+  pass "10d render_to writes new file (no pre-existing dest)"
+else
+  fail "10d render_to: expected fresh write, got: $(cat "$dest" 2>/dev/null || echo MISSING)"
+fi
+
+# render_to failure: malformed template → no partial write of dest.
+src="$WORKDIR/atomic-bad.tpl"
+dest="$WORKDIR/atomic-bad-dest.txt"
+echo "// >>> if has_ts" > "$src"
+echo "body" >> "$src"
+# (no <<<)
+(
+  reset_facts
+  # shellcheck disable=SC1090
+  source "$LIB"
+  exit_rc=0
+  template_substitution::render_to "$src" "$dest" || exit_rc=$?
+  echo "$exit_rc" > "$WORKDIR/atomic-rc.txt"
+)
+exit_rc=$(cat "$WORKDIR/atomic-rc.txt")
+if [ "$exit_rc" = "1" ] && [ ! -f "$dest" ]; then
+  pass "10b render_to atomic: malformed template leaves no partial dest"
+else
+  fail "10b render_to: expected rc=1 + no dest, got rc=$exit_rc, dest exists: $([ -f "$dest" ] && echo yes || echo no)"
+fi
+
+# ---------------------------------------------------------------------------
+# 11. End-to-end: ESLint-config-shaped template (the forcing function)
+# ---------------------------------------------------------------------------
+
+src="$WORKDIR/eslint.config.js.tpl"
+cat > "$src" <<'EOF'
+import js from "@eslint/js";
+import globals from "globals";
+
+// >>> if frameworks contains typescript
+import tseslint from "typescript-eslint";
+// <<<
+// >>> if frameworks contains astro
+import astro from "eslint-plugin-astro";
+// <<<
+// >>> if frameworks contains react
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+// <<<
+
+export default [
+  { ignores: ["node_modules/**", "dist/**"] },
+  js.configs.recommended,
+// >>> if frameworks contains typescript
+  ...tseslint.configs.recommended,
+// <<<
+// >>> if frameworks contains astro
+  ...astro.configs.recommended,
+// <<<
+// >>> if frameworks contains react
+  {
+    files: ["**/*.{jsx,tsx}"],
+    plugins: { react, "react-hooks": reactHooks },
+    rules: {
+      ...react.configs.recommended.rules,
+      "react/react-in-jsx-scope": "off",
+    },
+  },
+// <<<
+];
+EOF
+
+# Case 11a: swipewatch profile (JS-only, no frameworks)
+expected_swipewatch='import js from "@eslint/js";
+import globals from "globals";
+
+
+export default [
+  { ignores: ["node_modules/**", "dist/**"] },
+  js.configs.recommended,
+];'
+(
+  reset_facts
+  export MERGEPATH_FACT_FRAMEWORKS=""
+  # shellcheck disable=SC1090
+  source "$LIB"
+  template_substitution::render "$src" > "$WORKDIR/swipewatch.out"
+)
+if [ "$(cat "$WORKDIR/swipewatch.out")" = "$expected_swipewatch" ]; then
+  pass "11a ESLint template, swipewatch profile (JS-only)"
+else
+  fail "11a swipewatch profile mismatch:"
+  diff <(printf '%s\n' "$expected_swipewatch") "$WORKDIR/swipewatch.out" | sed 's/^/    /' >&2
+fi
+
+# Case 11b: matchline profile (TS + React)
+expected_matchline='import js from "@eslint/js";
+import globals from "globals";
+
+import tseslint from "typescript-eslint";
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+
+export default [
+  { ignores: ["node_modules/**", "dist/**"] },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ["**/*.{jsx,tsx}"],
+    plugins: { react, "react-hooks": reactHooks },
+    rules: {
+      ...react.configs.recommended.rules,
+      "react/react-in-jsx-scope": "off",
+    },
+  },
+];'
+(
+  reset_facts
+  export MERGEPATH_FACT_FRAMEWORKS="react typescript"
+  # shellcheck disable=SC1090
+  source "$LIB"
+  template_substitution::render "$src" > "$WORKDIR/matchline.out"
+)
+if [ "$(cat "$WORKDIR/matchline.out")" = "$expected_matchline" ]; then
+  pass "11b ESLint template, matchline profile (TS+React)"
+else
+  fail "11b matchline profile mismatch:"
+  diff <(printf '%s\n' "$expected_matchline") "$WORKDIR/matchline.out" | sed 's/^/    /' >&2
+fi
+
+# Case 11c: nathanpaynedotcom profile (TS + Astro)
+expected_npc='import js from "@eslint/js";
+import globals from "globals";
+
+import tseslint from "typescript-eslint";
+import astro from "eslint-plugin-astro";
+
+export default [
+  { ignores: ["node_modules/**", "dist/**"] },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  ...astro.configs.recommended,
+];'
+(
+  reset_facts
+  export MERGEPATH_FACT_FRAMEWORKS="astro typescript"
+  # shellcheck disable=SC1090
+  source "$LIB"
+  template_substitution::render "$src" > "$WORKDIR/npc.out"
+)
+if [ "$(cat "$WORKDIR/npc.out")" = "$expected_npc" ]; then
+  pass "11c ESLint template, nathanpaynedotcom profile (TS+Astro)"
+else
+  fail "11c nathanpaynedotcom profile mismatch:"
+  diff <(printf '%s\n' "$expected_npc") "$WORKDIR/npc.out" | sed 's/^/    /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "============================================================"
+echo "PASS: $PASS   FAIL: $FAIL"
+echo "============================================================"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Bulk sync to [mergepath@b1ec16f](https://github.com/nathanjohnpayne/mergepath/commit/b1ec16f6b014b87275ab17bb295a490d2e66d846) — verbatim canonical/kit mirror per `.mergepath-sync.yml`.

Opened by `scripts/sync-to-downstream.sh --sync-all` (v0.4.0-layer3-sync-all, see [#168](https://github.com/nathanjohnpayne/mergepath/issues/168)). Unlike a per-commit propagation PR, this replays the **current HEAD state of every canonical + kit path** so a consumer that has fallen behind reaches a clean steady state in one shot.

## Canonical paths synced
  - scripts/op-preflight.sh
  - scripts/lib/preflight-helpers.sh
  - scripts/coderabbit-wait.sh
  - scripts/codex-review-request.sh
  - scripts/codex-review-check.sh
  - scripts/phase-4b-classifier.sh
  - scripts/post-phase-4b-handoff.sh
  - scripts/codex-p1-gate.sh
  - scripts/daily-feedback-rollup.sh
  - scripts/lib/daily-feedback-rollup-helpers.sh
  - scripts/disagreement-detector.cjs
  - scripts/resolve-pr-threads.sh
  - scripts/request-label-removal.sh
  - scripts/gh-as-author.sh
  - scripts/gh-as-reviewer.sh
  - scripts/identity-check.sh
  - scripts/hooks/gh-pr-guard.sh
  - scripts/hooks/label-removal-guard.sh
  - tests/test_gh_pr_guard.sh
  - tests/test_gh_as_author.sh
  - tests/test_gh_as_reviewer.sh
  - tests/test_identity_check.sh
  - tests/test_verify_propagation_pr.sh
  - tests/test_codex_p1_gate.sh
  - tests/test_disagreement_detector.sh
  - tests/test_post_phase_4b_handoff.sh
  - tests/test_op_preflight_check.sh
  - tests/test_helper_autosource.sh
  - tests/test_resolve_pr_threads_rationale_tag.sh
  - tests/test_daily_feedback_rollup.sh
  - .github/workflows/agent-review.yml
  - .github/workflows/pr-review-policy.yml
  - .github/workflows/dependabot-auto-merge.yml
  - .github/workflows/auto-clear-blocking-labels.yml
  - .github/workflows/pr-audit.yml
  - .github/workflows/codex-p1-gate.yml
  - .github/workflows/daily-feedback-rollup.yml

## Kit paths synced
  - scripts/ci/ (kit, allow-extras)
  - scripts/gh-projects/ (kit, allow-extras)
  - scripts/workflow/ (kit, allow-extras)

## Templated paths rendered (per-consumer facts applied)
  - eslint.config.js (templated, rendered from examples/eslint.config.js)


Authoring-Agent: claude

## Self-Review
- Correctness: mirrors mergepath@b1ec16f HEAD state verbatim per the manifest. Each path was already reviewed in its upstream PR.
- Regression risk: low. Verbatim mirror; kit paths use allow-extras semantics so consumer-only files are kept.
- Style: N/A (mirror).
- Test coverage: relies on the consumer repo CI. No test changes shipped.
- Security: no new attack surface; `.sync-overrides.yml` was honored per-consumer so documented divergences are untouched.