### PR TITLE
feat(home): About Writing section, NOW/Builds copy trims, Connect relabel

### DIFF
--- a/src/content/bio/now.md
+++ b/src/content/bio/now.md
@@ -2,4 +2,4 @@
 lastUpdated: May 2026
 ---
 
-The current seam is where AI coding agents meet shipped software. Building products end-to-end with Claude Code, Codex, and Cursor, under an enforcement system I designed to catch the failure modes agents miss. Writing about what the work is teaching me. Open to product roles where streaming infrastructure, developer tools, or AI-augmented workflows are the center of gravity.
+The current seam is where AI coding agents meet shipped software. Building products end-to-end with Claude Code, Codex, and Cursor, under an enforcement system I designed to catch the failure modes agents miss. Open to product roles where streaming infrastructure, developer tools, or AI-augmented workflows are the center of gravity.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -92,10 +92,19 @@ const homepageJsonLd = {
               <div class="about-block about-block--now">
                 <span class="about-label">Now</span>
                 <NowContent />
-                <div class="now-ribbon">
-                  <span class="now-ribbon-label">Last updated</span>
-                  <span class="now-ribbon-date">{nowEntry.data.lastUpdated}</span>
-                </div>
+              </div>
+              <div class="about-block about-block--writing">
+                <span class="about-label">Writing</span>
+                <p>Three pieces on building with AI coding agents: where they fail, what makes them reliable, and how to get real work out of them.</p>
+                <ul class="writing-list">
+                  <li><a href="/blog/six-prs-one-bug-agent-failure-modes/" class="p-name-link">Six PRs, One Bug: What AI Agents Actually Get Wrong<span class="link-arrow" aria-hidden="true">→</span></a></li>
+                  <li><a href="/blog/agent-approval-workflow-genesis-of-mergepath/" class="p-name-link">Agent Approval Workflow and the Genesis of Mergepath<span class="link-arrow" aria-hidden="true">→</span></a></li>
+                  <li><a href="/blog/html-mockups-as-spec/" class="p-name-link">The HTML Mock-up Is the Spec<span class="link-arrow" aria-hidden="true">→</span></a></li>
+                </ul>
+              </div>
+              <div class="now-ribbon">
+                <span class="now-ribbon-label">Last updated</span>
+                <span class="now-ribbon-date">{nowEntry.data.lastUpdated}</span>
               </div>
             </div>
           </div>
@@ -109,7 +118,7 @@ const homepageJsonLd = {
         <div class="panel-content">
           <div class="content-inner">
             <h2>Builds</h2>
-            <p>Every project started as a real problem. Each one was built end-to-end with AI agents—Claude Code, Codex, and Cursor—within a multi-agent code review system I designed to catch failure modes that agents don’t catch on their own. <a href="/blog/six-prs-one-bug-agent-failure-modes/" class="p-link">What agents get wrong<span class="link-arrow" aria-hidden="true">→</span></a> · <a href="/blog/agent-approval-workflow-genesis-of-mergepath/" class="p-link">How the enforcement system works<span class="link-arrow" aria-hidden="true">→</span></a></p>
+            <p>Every project started as a real problem. Each one was built end-to-end with AI agents—Claude Code, Codex, and Cursor—within a multi-agent code review system I designed to catch failure modes that agents don’t catch on their own.</p>
             <div class="project-list">
               <div class="project-item">
                 <div class="p-head">
@@ -307,7 +316,7 @@ const homepageJsonLd = {
             </div>
             {latestPost && (
               <div class="blog-callout">
-                <span class="blog-callout-label">From the Blog</span>
+                <span class="blog-callout-label">Latest Post</span>
                 <a href={`/blog/${latestPost.id}/`} class="blog-callout-link">{latestPost.data.title}<span class="link-arrow" aria-hidden="true">→</span></a>
               </div>
             )}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -456,6 +456,12 @@ html[data-fonts-pending] .panel-label {
   gap: var(--su);
 }
 
+/* Extra breathing room so WRITING reads as its own unit, not a
+   continuation of NOW. One additional --su on top of the flex gap. */
+.about-block--writing {
+  margin-top: var(--su);
+}
+
 .about-block p {
   margin-bottom: 0;
 }
@@ -468,6 +474,33 @@ html[data-fonts-pending] .panel-label {
   font-weight: 500;
   color: rgba(23, 19, 15, 0.50);
   margin-bottom: calc(var(--su) * 0.5);
+}
+
+/* About panel "Writing" block — intro line + selected post links.
+   Links mirror the Builds project-name treatment: Cormorant Garamond,
+   inherit color (dark on the open parchment, cream on the mobile red
+   base), underlined per the site link convention. */
+.writing-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  /* Exceed the 0.3rem inter-link gap so the framing sentence reads as
+     governing the whole trio, not as belonging to the first link. */
+  margin-top: var(--su);
+}
+
+.writing-list .p-name-link {
+  font-size: 0.85rem;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+/* Blue arrow matches the Builds .p-name-link convention. */
+.writing-list .p-name-link .link-arrow {
+  color: var(--blue);
+  font-weight: 700;
 }
 
 .social-stack,
@@ -3303,6 +3336,12 @@ a:focus-visible {
 
   .panel--red .now-ribbon {
     border-top-color: rgba(242, 237, 225, 0.28);
+  }
+
+  /* Dark-blue arrow is near-invisible on the red mobile base; keep it
+     cream (matching the link text) so the affordance stays legible. */
+  .panel--red .writing-list .p-name-link .link-arrow {
+    color: var(--cream);
   }
 
   .panel--yellow .stack-label,


### PR DESCRIPTION
## Summary
- **About panel:** add a "Writing" block — a framing line plus the three strongest posts (Six PRs / Mergepath genesis / HTML mock-up) — placed below Now, with the "Last updated" ribbon moved to the very bottom so it closes the panel.
- **NOW:** drop the redundant "Writing about what the work is teaching me." sentence; the Writing block carries that claim now.
- **Spacing:** WRITING reads as its own unit (`margin-top: var(--su)`, the existing inter-section token); the framing sentence out-gaps the inter-link gap so it governs all three links.
- **Builds:** reduce the intro to its framing sentence (drop the two trailing blog links, now surfaced in the About Writing block).
- **Connect:** relabel the blog callout "From the Blog" → "Latest Post".

Authoring-Agent: claude

## Self-Review
- **Correctness:** Verified in preview (desktop + mobile). About order is Context → Approach → Now → Writing → Last-updated ribbon; Writing links use the Builds `.p-name-link` serif treatment (dark/inherit on parchment, cream on mobile red; blue arrow on desktop, cream on mobile). NOW paragraph ends "…center of gravity." with the redundant clause removed. Builds intro ends "…on their own." with no trailing links. Connect callout renders "LATEST POST". All three post links resolve (200).
- **Regression risk:** Low. Scoped to the homepage (`index.astro`), the homepage About/Writing/Builds CSS (`global.css`), and the NOW content file (`now.md`). No shared layouts/components, no JS changes. The panel content-height measurement absorbs the added/removed height automatically. `npm run test` passes 164/164.
- **Style:** Spacing uses the existing `--su` token / `calc(var(--su) * N)` convention (no new magic values); new `.about-block--writing` mirrors the existing `.about-block--now` modifier pattern; CMOS em-dashes; FFB/Builds copy unchanged elsewhere. Removed the now-unused `.writing-item` / `.writing-gloss` CSS from the earlier draft.
- **Test coverage:** Existing homepage/blog/responsive suites pass. The homepage test ("blog link in the connect panel", `a[href="/blog/"]`) still holds — the Connect blog index link is unchanged. No new test needed (content + presentational).
- **Security/dependency hygiene:** No new dependencies, no secrets, no auth/payments/credential/`.github` paths touched.

## Test plan
- [x] `npm run test` (build + 164 Vitest tests) green
- [x] About panel renders new Writing block + ribbon order (desktop + mobile)
- [x] NOW clause removed; Builds intro trimmed; Connect relabeled
- [ ] CI green on PR