### PR TITLE
style(home): continuous left rule on the About Writing links

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -462,6 +462,14 @@ html[data-fonts-pending] .panel-label {
   margin-top: var(--su);
 }
 
+/* The now-ribbon is a flex child of .about-blocks, so the flex gap
+   already spaces it; drop the shared ribbon margin-top here so the
+   rule→ribbon gap reads as tight as the Community (Giving) ribbon
+   instead of doubling (flex gap + margin). Scoped to About only. */
+.about-blocks .now-ribbon {
+  margin-top: 0;
+}
+
 .about-block p {
   margin-bottom: 0;
 }
@@ -488,6 +496,13 @@ html[data-fonts-pending] .panel-label {
   /* Exceed the 0.3rem inter-link gap so the framing sentence reads as
      governing the whole trio, not as belonging to the first link. */
   margin-top: var(--su);
+  /* One continuous left rule bracketing all three links as a single
+     group. Same visual values as the Giving rule (1px var(--rule),
+     0.6rem inset) but on the container, not per-item, so it reads as
+     one unbroken bracket. Inset matches the prior per-item version:
+     rule at the ul's left edge, text at +1px +0.6rem. */
+  border-left: 1px solid var(--rule);
+  padding-left: 0.6rem;
 }
 
 .writing-list .p-name-link {


### PR DESCRIPTION
## Summary
- Bracket the three About-panel WRITING links under **one continuous left rule** (on the `.writing-list` container), reusing the Giving rule's exact values — `1px solid var(--rule)`, `0.6rem` inset — so the two read as one system, but continuous rather than per-item.
- Tighten the rule→"Last updated" ribbon gap to match the Community ribbon by dropping the now-ribbon's redundant margin in the About flex context (the `.about-blocks` flex gap already spaces it).

Authoring-Agent: claude

## Self-Review
- **Correctness:** Verified in preview (desktop + mobile). The rule is one unbroken bracket spanning first-link-top → last-link-bottom (the three `<li>` have `0px` border); text inset unchanged at 10.6px (1px + 0.6rem); the WRITING label and framing sentence stay outside the rule. About rule→ribbon gap reduced 11.8px → 6.7px (Community is 5.7px). Color uses `var(--rule)`, no hardcoded values.
- **Regression risk:** Low — 15 lines, CSS-only, scoped to `.writing-list` and `.about-blocks .now-ribbon`. **Giving is unchanged**: `.effort-list li` keeps its per-item rule (confirmed via computed styles; not in the diff), and the ribbon margin override is scoped to About so Community/Builds ribbons are untouched. `npm run test` passes 164/164.
- **Style:** Reuses the `--rule` token and the established `0.6rem`/`1px` values from the Giving rule (no new color/spacing values). Comments explain the container-vs-per-item choice and the flex-gap rationale.
- **Test coverage:** Existing homepage/blog/responsive suites pass; purely presentational, no new test needed.
- **Security/dependency hygiene:** No dependencies, secrets, or auth/payments/credential/`.github` paths touched.

## Test plan
- [x] `npm run test` (build + 164 Vitest) green
- [x] Continuous rule brackets the 3 links only (desktop + mobile); Giving unchanged
- [x] Ribbon gap tightened to ~Community
- [ ] CI green on PR