### PR TITLE
fix(home): undo doubled top gap above the About WRITING section

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -457,9 +457,14 @@ html[data-fonts-pending] .panel-label {
 }
 
 /* Extra breathing room so WRITING reads as its own unit, not a
-   continuation of NOW. One additional --su on top of the flex gap. */
+   continuation of NOW. Half an --su on top of the flex gap — the
+   .about-blocks flex gap already provides one --su above every section,
+   so a full margin-top would double WRITING's gap (the same flex-gap-
+   plus-margin doubling removed from .now-ribbon). Half keeps WRITING
+   distinct (it's a label + framing sentence + linked trio, not prose)
+   without doubling. */
 .about-block--writing {
-  margin-top: var(--su);
+  margin-top: calc(var(--su) * 0.5);
 }
 
 /* The now-ribbon is a flex child of .about-blocks, so the flex gap


### PR DESCRIPTION
## Summary
The four About sections are flex children of `.about-blocks` (`gap: var(--su)`), so each already gets one `--su` of space above it from the flex gap. `.about-block--writing` then added `margin-top: var(--su)` on top — doubling WRITING's gap vs CONTEXT/APPROACH/NOW. Change to `calc(var(--su) * 0.5)`: WRITING stays a touch more separated (it's a different content type — label + framing sentence + linked trio) without doubling. Same flex-gap-plus-margin doubling previously fixed for `.now-ribbon`.

Authoring-Agent: claude

## Self-Review
- **Correctness:** Verified in the rendered panel — gap above APPROACH/NOW = 6.72px (`--su`), gap above WRITING = 10.08px (1.5×`--su`): visibly larger than the prose sections but no longer double (the old doubled gap was 13.44px; 10.08 is exactly halfway).
- **Regression risk:** Minimal — one declaration (`.about-block--writing` margin-top) + its comment. Did not touch `.about-blocks .now-ribbon`, `.about-label`, CONTEXT/APPROACH/NOW, or the `.writing-list` rule. `npm run test` passes 164/164.
- **Style:** Reuses the `--su` token via `calc(var(--su) * 0.5)` (the established `calc(var(--su) * N)` convention); no new values. Comment updated to explain the half-`--su` rationale.
- **Test coverage:** Existing suites pass; purely presentational spacing.
- **Security/dependency hygiene:** No deps, secrets, or auth/payments/credential/`.github` paths touched.

## Test plan
- [x] `npm run test` (build + 164 Vitest) green
- [x] WRITING gap = 1.5×`--su`, larger than APPROACH/NOW but not doubled
- [ ] CI green on PR