### PR TITLE
fix(blog): match /projects row pattern; light vertical rules on mobile

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -69,12 +69,11 @@ function readingTime(body: string | undefined): string {
 
       {/* ── Mondrian Blog Grid ──
            Mirrors the /projects index: every post flows through one map
-           so the row pattern repeats and scales. Rows 1–4 use fixed
-           Mondrian accent blocks; posts beyond 4 overflow into
-           alternating a/b rows. The last content row always pairs its
-           post with the RSS subscribe block (in place of a decorative
-           accent), so the subscription is pinned to the bottom of the
-           grid without taking a row of its own. */}
+           by index (rows 1–4, then alternating overflow), so the row
+           pattern matches /projects. The final post keeps its by-index
+           row layout but swaps its last accent cell for the RSS subscribe
+           block — pinning the subscription to the last row without
+           breaking the repeating column pattern. */}
       <div class="blog-grid">
 
         {posts.map((post, i) => {
@@ -88,14 +87,12 @@ function readingTime(body: string | undefined): string {
             </article>
           );
 
-          // Last row: post | RSS subscribe block. Pins the subscription
-          // beside the final post regardless of how many posts exist.
-          if (isLast) return (
-            <div class="grid-row--last">
-              {card}
-              <div class="accent-cream">
-                <a href="/rss.xml" class="rss-link">Subscribe via RSS &rarr;</a>
-              </div>
+          // The final post keeps its by-index row layout (matching the
+          // /projects pattern) but swaps its last accent cell for the RSS
+          // subscribe block, pinning the subscription to the last row.
+          const rssCell = (
+            <div class="accent-cream">
+              <a href="/rss.xml" class="rss-link">Subscribe via RSS &rarr;</a>
             </div>
           );
 
@@ -104,34 +101,36 @@ function readingTime(body: string | undefined): string {
             <div class="grid-row--1">
               {card}
               <div class="accent-red" aria-hidden="true"></div>
-              <div class="accent-blue" aria-hidden="true">
-                <span class="accent-blue-label">Latest</span>
-              </div>
+              {isLast ? rssCell : (
+                <div class="accent-blue" aria-hidden="true">
+                  <span class="accent-blue-label">Latest</span>
+                </div>
+              )}
             </div>
           );
           if (i === 1) return (
             <div class="grid-row--2">
               {card}
-              <div class="accent-yellow" aria-hidden="true"></div>
+              {isLast ? rssCell : <div class="accent-black" aria-hidden="true"></div>}
             </div>
           );
           if (i === 2) return (
             <div class="grid-row--3">
               {card}
-              <div class="accent-white" aria-hidden="true"></div>
+              {isLast ? rssCell : <div class="accent-white" aria-hidden="true"></div>}
             </div>
           );
           if (i === 3) return (
             <div class="grid-row--4">
               {card}
-              <div class="accent-black" aria-hidden="true"></div>
-              <div class="accent-paper" aria-hidden="true"></div>
+              <div class="accent-yellow" aria-hidden="true"></div>
+              {isLast ? rssCell : <div class="accent-paper" aria-hidden="true"></div>}
             </div>
           );
           return (
             <div class={i % 2 === 0 ? 'grid-row--overflow-a' : 'grid-row--overflow-b'}>
               {card}
-              <div class={i % 2 === 0 ? 'accent-overflow accent-overflow--cream' : 'accent-overflow accent-overflow--yellow'} aria-hidden="true"></div>
+              {isLast ? rssCell : <div class={i % 2 === 0 ? 'accent-overflow accent-overflow--cream' : 'accent-overflow accent-overflow--yellow'} aria-hidden="true"></div>}
             </div>
           );
         })}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1999,15 +1999,6 @@ body.blog-page {
   min-height: 13rem;
 }
 
-/* Last content row: post | RSS subscribe block (50/50), so the
-   subscription always sits beside the final post. */
-.grid-row--last {
-  display: grid;
-  grid-template-columns: minmax(0, 5fr) minmax(0, 5fr);
-  gap: var(--line);
-  min-height: 14rem;
-}
-
 /* ── Post Cards ── */
 .post-card {
   background: var(--surface);
@@ -2124,8 +2115,10 @@ a.tag:hover {
   background: var(--yellow);
 }
 
+/* RSS subscribe cell. Uses the paper accent (#DDE1E5) so the blog's
+   last row matches the /projects last cell. */
 .accent-cream {
-  background: var(--accent-gray);
+  background: #DDE1E5;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -3358,6 +3351,13 @@ a:focus-visible {
     border-top-color: rgba(242, 237, 225, 0.28);
   }
 
+  /* The vertical WRITING rule uses var(--rule) (dark), near-invisible on
+     the red mobile base — flip it to the same light divider color as the
+     ribbon above so the vertical and horizontal rules read as one system. */
+  .panel--red .writing-list {
+    border-left-color: rgba(242, 237, 225, 0.28);
+  }
+
   /* Dark-blue arrow is near-invisible on the red mobile base; keep it
      cream (matching the link text) so the affordance stays legible. */
   .panel--red .writing-list .p-name-link .link-arrow {
@@ -3380,6 +3380,12 @@ a:focus-visible {
 
   .panel--black .impact-ribbon {
     border-top-color: rgba(239, 232, 216, 0.22);
+  }
+
+  /* Match the Giving vertical rule to the ribbon's light divider on the
+     black mobile base (var(--rule) is invisible there). */
+  .panel--black .effort-list li {
+    border-left-color: rgba(239, 232, 216, 0.22);
   }
 
   .panel--blue .connect-label {
@@ -3448,8 +3454,7 @@ a:focus-visible {
   .grid-row--3,
   .grid-row--4,
   .grid-row--overflow-a,
-  .grid-row--overflow-b,
-  .grid-row--last {
+  .grid-row--overflow-b {
     grid-template-columns: 1fr;
     min-height: auto;
   }


### PR DESCRIPTION
## Summary
- **Blog last row matches /projects:** the final post keeps its by-index row layout (lands on `grid-row--4`: 3-column post + accent + RSS cell) instead of the special 2-column `grid-row--last`. The accent sequence is aligned to /projects (row 2 → black, row 4 → yellow), and the RSS cell is colored with the paper accent (`#DDE1E5`) so the last cell matches /projects' last cell. `grid-row--last` removed (dead).
- **Homepage vertical rules on mobile:** the About WRITING and Community Giving bracket rules use `var(--rule)` (dark), near-invisible on the dark mobile panel bases. On mobile they now flip to each panel's light divider color (matching the ribbon lines) — `rgba(242,237,225,0.28)` (red), `rgba(239,232,216,0.22)` (black) — so the vertical and horizontal rules read as one system. Desktop/parchment unchanged.

Authoring-Agent: claude

## Self-Review
- **Correctness:** Verified in preview (desktop + mobile). /blog last row is now `grid-row--4` (3-col): post + yellow + RSS(paper); accent sequence red+blue/black/white/yellow matches /projects. Homepage WRITING rule = `rgba(242,237,225,0.28)` and Giving rule = `rgba(239,232,216,0.22)` on mobile (light/visible), `var(--rule)` on desktop.
- **Regression risk:** Low — scoped to the blog index map and homepage/blog grid CSS. `.accent-cream` (RSS cell) is blog-only; the mobile rule-color overrides are panel-scoped. No JS, layouts, or shared components changed. `npm run test` passes 164/164.
- **Style:** Mobile rule colors reuse the exact ribbon-divider values (one system, no new values); RSS cell reuses the existing paper `#DDE1E5`. Removed dead `.grid-row--last` rule + its mobile entry.
- **Test coverage:** Existing blog/responsive suites pass; presentational only.
- **Security/dependency hygiene:** No deps, secrets, or auth/payments/credential/`.github` paths touched.

## Test plan
- [x] `npm run test` (build + 164 Vitest) green
- [x] /blog last row matches /projects (layout + colors); RSS = paper cell
- [x] Homepage WRITING + Giving vertical rules light/visible on mobile
- [ ] CI green on PR