### PR TITLE
fix(blog): align grid dividers on shared 50%/72% gridlines

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1950,36 +1950,48 @@ body.blog-page {
   display: grid;
   background: var(--ink);
   gap: var(--line);
+  /* Two shared vertical gridlines, centered on 50% and 72%, so the
+     post→accent and accent→accent dividers line up across every row
+     regardless of how many cells (and therefore gaps) a row has. Each
+     column is shrunk by half a line per adjacent gap so the black grid
+     line sits centered on the target percentage. Used by the desktop
+     row templates below; the mobile stack overrides to a single column. */
+  --col-post: calc(50% - var(--line) / 2);       /* column ending at the 50% line */
+  --col-mid: calc(22% - var(--line));            /* column spanning 50% → 72% */
+  --col-post-wide: calc(72% - var(--line) / 2);  /* column ending at the 72% line */
 }
 
-/* Row 1: post (~50%) | red (~22%) | blue (~28%) */
+/* Rows place their cells on the shared 50% / 72% gridlines (see the
+   .blog-grid --col-* vars) so the black grid lines run continuously down
+   the grid: the post→accent divider lands on 50%, accent→accent on 72%. */
+/* Row 1: post (50%) | accent (50%→72%) | accent (72%→100%) */
 .grid-row--1 {
   display: grid;
-  grid-template-columns: minmax(0, 5fr) minmax(0, 2.2fr) minmax(0, 2.8fr);
+  grid-template-columns: var(--col-post) var(--col-mid) minmax(0, 1fr);
   gap: var(--line);
   min-height: 16rem;
 }
 
-/* Row 2: post (~72%) | yellow (~28%) */
+/* Row 2: post (72%) | accent (72%→100%) */
 .grid-row--2 {
   display: grid;
-  grid-template-columns: minmax(0, 7.2fr) minmax(0, 2.8fr);
+  grid-template-columns: var(--col-post-wide) minmax(0, 1fr);
   gap: var(--line);
   min-height: 13rem;
 }
 
-/* Row 3: post (~50%) | rss/cream (~50%) */
+/* Row 3: post (50%) | accent (50%→100%) */
 .grid-row--3 {
   display: grid;
-  grid-template-columns: minmax(0, 5fr) minmax(0, 5fr);
+  grid-template-columns: var(--col-post) minmax(0, 1fr);
   gap: var(--line);
   min-height: 14rem;
 }
 
-/* Row 4: post (~50%) | black (~22%) | paper (~28%) */
+/* Row 4: post (50%) | accent (50%→72%) | accent (72%→100%) */
 .grid-row--4 {
   display: grid;
-  grid-template-columns: minmax(0, 5fr) minmax(0, 2.2fr) minmax(0, 2.8fr);
+  grid-template-columns: var(--col-post) var(--col-mid) minmax(0, 1fr);
   gap: var(--line);
   min-height: 14rem;
 }


### PR DESCRIPTION
## Summary
The per-row nested grids used `fr` units, so a divider reached after more gaps (3-column rows: post + accent + accent) landed a few px left of the same divider in a 2-column row. The post→accent (50%) and accent→accent (72%) black lines didn't line up between rows — e.g. row 1's blue and row 2's black were ~5px apart at the 72% line.

Fix: define two shared gridline columns on `.blog-grid` and place every row's cells on them, each column shrunk by half a line per adjacent gap so the divider sits centered on the target percentage:
- `--col-post: calc(50% - var(--line)/2)` — the 50% line (post→accent)
- `--col-post-wide: calc(72% - var(--line)/2)` — the 72% line (row 2 post→black)
- `--col-mid: calc(22% - var(--line))` — span between them (row 1/4 accent→accent also lands on 72%)

Both lines now run continuously on /blog and /projects (shared row classes). Overflow rows keep their intentional 60/40 alternation.

Authoring-Agent: claude

## Self-Review
- **Correctness:** Measured on both pages — 50% line = 571.5px (rows 1/3/4), 72% line = 820.98px (rows 1/2/4); row 1 blue-left == row 2 black-left (was 5.04px off). Verified visually (blue→black continuous).
- **Regression risk:** Low — CSS-only, scoped to `.blog-grid` + the four `.grid-row--N` templates; overflow rows untouched; mobile collapses to 1fr (vars unused). `npm run test` passes 164/164.
- **Style:** DRY via three `--col-*` custom properties with a comment explaining the half-line gap compensation; no magic per-row values.
- **Test coverage:** Existing blog/responsive suites pass; presentational only.
- **Security/dependency hygiene:** No deps, secrets, or auth/payments/credential/`.github` paths touched.

## Test plan
- [x] `npm run test` (build + 164 Vitest) green
- [x] 50% + 72% dividers align across rows on /blog and /projects
- [x] Overflow rows unchanged; mobile unaffected
- [ ] CI green on PR