### PR TITLE
fix(home): tighten About Writing link spacing and stop arrow orphaning

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -97,9 +97,9 @@ const homepageJsonLd = {
                 <span class="about-label">Writing</span>
                 <p>Three pieces on building with AI coding agents: where they fail, what makes them reliable, and how to get real work out of them.</p>
                 <ul class="writing-list">
-                  <li><a href="/blog/six-prs-one-bug-agent-failure-modes/" class="p-name-link">Six PRs, One Bug: What AI Agents Actually Get Wrong<span class="link-arrow" aria-hidden="true">→</span></a></li>
-                  <li><a href="/blog/agent-approval-workflow-genesis-of-mergepath/" class="p-name-link">Agent Approval Workflow and the Genesis of Mergepath<span class="link-arrow" aria-hidden="true">→</span></a></li>
-                  <li><a href="/blog/html-mockups-as-spec/" class="p-name-link">The HTML Mock-up Is the Spec<span class="link-arrow" aria-hidden="true">→</span></a></li>
+                  <li><a href="/blog/six-prs-one-bug-agent-failure-modes/" class="p-name-link">Six PRs, One Bug: What AI Agents Actually Get <span class="no-break">Wrong<span class="link-arrow" aria-hidden="true">→</span></span></a></li>
+                  <li><a href="/blog/agent-approval-workflow-genesis-of-mergepath/" class="p-name-link">Agent Approval Workflow and the Genesis of <span class="no-break">Mergepath<span class="link-arrow" aria-hidden="true">→</span></span></a></li>
+                  <li><a href="/blog/html-mockups-as-spec/" class="p-name-link">The HTML Mock-up Is the <span class="no-break">Spec<span class="link-arrow" aria-hidden="true">→</span></span></a></li>
                 </ul>
               </div>
               <div class="now-ribbon">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -498,9 +498,12 @@ html[data-fonts-pending] .panel-label {
   display: flex;
   flex-direction: column;
   gap: 0.3rem;
-  /* Exceed the 0.3rem inter-link gap so the framing sentence reads as
-     governing the whole trio, not as belonging to the first link. */
-  margin-top: var(--su);
+  /* Sit tighter than the 0.3rem inter-link gap so the trio reads as
+     belonging to the framing sentence above. The paragraph is set in a
+     larger face with more line-height leading below its last line, so a
+     gap equal to the inter-link spacing looked detached; pulling it in
+     keeps the whole block proportional. */
+  margin-top: 0.1rem;
   /* One continuous left rule bracketing all three links as a single
      group. Same visual values as the Giving rule (1px var(--rule),
      0.6rem inset) but on the container, not per-item, so it reads as
@@ -521,6 +524,15 @@ html[data-fonts-pending] .panel-label {
 .writing-list .p-name-link .link-arrow {
   color: var(--blue);
   font-weight: 700;
+}
+
+/* Bind each title's final word to its arrow. The arrow is an inline-block
+   (atomic inline box), so the browser allows a line break right before it;
+   on a title that wraps, that lets the arrow orphan onto its own line.
+   nowrap on the trailing word+arrow keeps them one unit while the rest of
+   the title still wraps normally. */
+.writing-list .no-break {
+  white-space: nowrap;
 }
 
 .social-stack,


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Two small layout fixes to the homepage About → Writing block:

- **Tighter, proportional spacing.** `.writing-list` `margin-top` reduced from `var(--su)` (0.42rem) to `0.1rem`. The framing sentence is set in a larger face with more line-height leading below its last line, so a gap equal to the inter-link spacing made the link trio look detached. Pulling it in makes the block read as one proportional unit.
- **No orphaned arrows.** Each title's final word + trailing arrow are now wrapped in a `white-space: nowrap` `.no-break` span. The arrow is an `inline-block` (atomic inline box), so the browser allowed a line break right before it — on a wrapping title (visible at mobile widths) the arrow could drop onto its own line. The wrapper keeps word+arrow together while the rest of the title still wraps normally.

## Self-Review

- **Correctness:** Verified in the Astro dev preview at mobile (375px) and desktop. Pre-fix, "Wrong →" orphaned at 375px; post-fix the arrow stays bound to "Wrong"/"Mergepath"/"Spec". Paragraph→first-link gap is now ~9.4px vs ~12.3px between links, reading as connected.
- **Regression risk:** Low. Changes are scoped to `.writing-list` and the new `.no-break` class (used only inside `.writing-list`). No overflow on desktop (longest link 323px in a 605px column). The `.no-break` nesting preserves the existing underline-on-title / no-underline-on-arrow treatment.
- **Style:** Spacing uses a rem value consistent with the block's existing `0.3rem` units (no motion tokens involved). Stale comment on the old `margin-top` rule rewritten to match the new intent.
- **Test coverage:** `astro build` + full vitest suite green (164 passed). No test asserts on the homepage writing-list DOM, so the added wrapper span is safe.
- **Security/dependency hygiene:** No dependency, auth, or data-path changes. Markup/CSS only.

## Test plan

- [x] `npm test` (astro build + vitest) — 164 passed
- [x] Manual preview: arrows bound at 375px; spacing tighter/proportional at desktop and mobile
- [ ] Post-merge: verify on https://nathanpayne.com after deploy