### PR TITLE
sync: bulk reconcile to mergepath@1cdcc9d

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -436,12 +436,52 @@ jobs:
       github.event_name == 'pull_request_review' &&
       github.event.review.state == 'approved' &&
       !contains(github.event.pull_request.labels.*.name, 'needs-external-review') &&
-      !contains(github.event.pull_request.labels.*.name, 'needs-human-review')
+      !contains(github.event.pull_request.labels.*.name, 'needs-human-review') &&
+      !contains(github.event.pull_request.labels.*.name, 'human-hold')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Check author merge token
+        id: author_merge_token
+        env:
+          GH_TOKEN: ${{ secrets.AUTHOR_MERGE_TOKEN }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::notice::AUTHOR_MERGE_TOKEN is not configured; automatic PR merge is disabled. Merge manually as the author identity."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          expected_author=$(awk '
+            /^[^[:space:]]/ && $1 == "author_identity:" {
+              sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+              gsub(/^"/, "", $0)
+              gsub(/^\047/, "", $0)
+              gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+              gsub(/\047[[:space:]]*(#.*)?$/, "", $0)
+              gsub(/[[:space:]]*#.*$/, "", $0)
+              sub(/[[:space:]]+$/, "", $0)
+              print
+              exit
+            }
+          ' .github/review-policy.yml)
+          expected_author="${expected_author:-nathanjohnpayne}"
+
+          if ! actual_author=$(gh api user --jq .login); then
+            echo "::error::AUTHOR_MERGE_TOKEN could not authenticate to GitHub. Refusing automatic merge."
+            exit 1
+          fi
+          if [ "$actual_author" != "$expected_author" ]; then
+            echo "::error::AUTHOR_MERGE_TOKEN resolves to '$actual_author', expected '$expected_author'. Refusing automatic merge."
+            exit 1
+          fi
+
+          echo "Automatic merge token verified for author identity: $actual_author"
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
       - name: Check if CodeRabbit is enabled
+        if: steps.author_merge_token.outputs.enabled == 'true'
         id: cr
         run: |
           CONFIG=".github/review-policy.yml"
@@ -470,7 +510,7 @@ jobs:
           fi
 
       - name: Wait for CodeRabbit review
-        if: steps.cr.outputs.enabled == 'true'
+        if: steps.author_merge_token.outputs.enabled == 'true' && steps.cr.outputs.enabled == 'true'
         env:
           GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -524,9 +564,10 @@ jobs:
           esac
 
       - name: Re-verify blocking labels right before merge
+        if: steps.author_merge_token.outputs.enabled == 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTHOR_MERGE_TOKEN }}
         run: |
           # Guard against the TOCTOU race between the trigger-time label
           # snapshot and the actual merge. The job's top-level `if:` expression
@@ -553,18 +594,19 @@ jobs:
           # present. Also check `policy-violation`, which is applied by the
           # block-self-approval job earlier in this same workflow run (and
           # again, the `if:` at job start wouldn't have seen it).
-          LABELS=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json labels --jq '[.labels[].name] | join(",")')
-          echo "Labels at merge time: [$LABELS]"
-          case ",$LABELS," in
-            *,needs-external-review,*|*,needs-human-review,*|*,policy-violation,*)
-              echo "::error::Blocking label present at merge time: $LABELS. Aborting auto-merge."
+          LABELS=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json labels --jq '.labels[].name')
+          printf 'Labels at merge time:\n%s\n' "$LABELS"
+          for blocking_label in needs-external-review needs-human-review policy-violation human-hold; do
+            if printf '%s\n' "$LABELS" | grep -Fxq "$blocking_label"; then
+              echo "::error::Blocking label present at merge time: $blocking_label. Aborting auto-merge."
               exit 1
-              ;;
-          esac
+            fi
+          done
           echo "No blocking labels present — proceeding to merge."
 
       - name: Enable auto-merge
-        run: gh pr merge --squash --auto "$PR_URL" || gh pr merge --squash "$PR_URL" || true
+        if: steps.author_merge_token.outputs.enabled == 'true'
+        run: gh pr merge --squash --auto "$PR_URL" || gh pr merge --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTHOR_MERGE_TOKEN }}

--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -9,8 +9,8 @@ name: Auto-clear blocking labels
 # `gh pr edit <N> --remove-label needs-external-review` after agents
 # have done all the actual review work.
 #
-# Scope: ONLY removes `needs-external-review`. `needs-human-review`
-# and `policy-violation` remain manual-only by design (see
+# Scope: ONLY removes `needs-external-review`. `needs-human-review`,
+# `policy-violation`, and `human-hold` remain manual-only by design (see
 # REVIEW_POLICY.md § Agent prohibitions). The doctrine carve-out for
 # this workflow ships in #196.
 
@@ -57,10 +57,9 @@ on:
 permissions:
   pull-requests: write
   contents: read
-  checks: read
   # codex-review-check.sh drills statusCheckRollup →
   # checkSuite.workflowRun, which needs `actions: read` in addition
-  # to `checks: read`. Without it the GraphQL fails with `Resource
+  # to the `checks` scope. Without it the GraphQL fails with `Resource
   # not accessible by integration` and the gate evaluation aborts
   # with rc=3, leaving `needs-external-review` stuck on every
   # consumer PR after Codex approves. Surfaced on
@@ -73,7 +72,13 @@ permissions:
   # (failed label read, failed label removal, codex-review-check.sh
   # rc=3, contract-drift rc). Without a visible check-run, flake
   # recurrences are invisible unless someone happens to look at the
-  # workflow run log.
+  # workflow run log. `write` supersets `read`, so this single entry
+  # also covers codex-review-check.sh's check-reading need — do NOT
+  # re-add a separate `checks: read` key: a duplicate `checks:` map
+  # key is a startup-failure-level workflow file error (#324 shipped
+  # exactly that regression; the parser rejected the file and every
+  # trigger produced a zero-job failed run, so the label never
+  # auto-cleared).
   checks: write
 
 jobs:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       # Check out the BASE ref (the target branch's tip), NOT the PR
       # HEAD. This workflow runs under pull_request_target which has
@@ -67,6 +67,23 @@ jobs:
             exit 1
           fi
           echo "::notice::Approving $PR_URL as $ACTING_AS (PR author: $PR_AUTHOR)"
+
+          has_human_hold() {
+            local labels
+            if ! labels=$(gh pr view "$PR_URL" --json labels --jq '.labels[].name'); then
+              echo "::error::Failed to read labels for $PR_URL while checking human-hold."
+              exit 1
+            fi
+            printf '%s\n' "$labels" | grep -Fxq human-hold
+          }
+
+          # `human-hold` is a human-remove-only hard freeze. Re-read
+          # labels at runtime so a hold added while this job is queued
+          # or waiting cannot be bypassed by the trigger-time payload.
+          if has_human_hold; then
+            echo "::notice::PR carries human-hold; skipping Dependabot auto-merge until the human removes the label."
+            exit 0
+          fi
 
           # Self-approval guard. The real condition is "the reviewer
           # token resolves to the PR's own author" — GitHub blocks
@@ -136,6 +153,10 @@ jobs:
           # returns exit 1 for all merge failures without a
           # distinguishing exit code, so we pattern-match stderr for
           # the documented auto-merge-unavailable GraphQL messages.
+          if has_human_hold; then
+            echo "::notice::PR carries human-hold immediately before --auto; skipping Dependabot auto-merge until the human removes the label."
+            exit 0
+          fi
           set +e
           AUTO_STDERR=$(gh pr merge --squash --auto "$PR_URL" 2>&1 1>/dev/null)
           AUTO_RC=$?
@@ -147,6 +168,10 @@ jobs:
           echo "$AUTO_STDERR" >&2
           if echo "$AUTO_STDERR" | grep -qiE 'auto[- ]?merge is not available|not in the correct state to enable auto[- ]?merge|auto[- ]?merge.*disabled|enablePullRequestAutoMerge'; then
             echo "::notice::--auto unavailable on this repo (likely no branch protection); falling back to immediate squash."
+            if has_human_hold; then
+              echo "::notice::PR carries human-hold immediately before fallback squash; skipping Dependabot auto-merge until the human removes the label."
+              exit 0
+            fi
             gh pr merge --squash "$PR_URL"
           else
             echo "::error::gh pr merge --auto failed for a non-auto-merge-unavailable reason. See stderr above. Not falling back to immediate squash; surface to audit."

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -1,7 +1,7 @@
 name: Weekly PR Audit
 
 # Cron-driven retroactive check that the previous week's merged PRs
-# satisfied the review policy. Five checks per merged PR:
+# satisfied the review policy. Six checks per merged PR:
 #
 #   1. Self-Review section present in PR body (Dependabot exempted)
 #   2. external-review-labeled PRs have either an APPROVED CLI
@@ -10,6 +10,7 @@ name: Weekly PR Audit
 #   3. No bot self-approval (reviewer identity approving its own PR)
 #   4. needs-human-review label not still present at merge time
 #   5. policy-violation label not still present at merge time
+#   6. human-hold label not still present at merge time
 #
 # Violations are aggregated into a single audit issue per run.
 # See REVIEW_POLICY.md, .github/review-policy.yml, and #36 for
@@ -115,6 +116,36 @@ jobs:
 
             const violations = [];
 
+            async function labelWasPresentAtMerge(pr, labelName) {
+              const events = await github.paginate(
+                github.rest.issues.listEvents,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  per_page: 100,
+                }
+              );
+              const mergedAt = new Date(pr.merged_at).getTime();
+              let present = false;
+              for (const event of events.sort(
+                (a, b) => new Date(a.created_at) - new Date(b.created_at)
+              )) {
+                if (new Date(event.created_at).getTime() > mergedAt) {
+                  continue;
+                }
+                if (!event.label || event.label.name !== labelName) {
+                  continue;
+                }
+                if (event.event === 'labeled') {
+                  present = true;
+                } else if (event.event === 'unlabeled') {
+                  present = false;
+                }
+              }
+              return present;
+            }
+
             for (const pr of mergedPRs) {
               const prViolations = [];
               const isDependabot = pr.user.login === 'dependabot[bot]';
@@ -152,9 +183,10 @@ jobs:
               // Skip for Dependabot PRs. Dependabot doesn't author a
               // body with the Self-Review template, and the
               // pre-merge gate in pr-review-policy.yml already
-              // skips Dependabot via `if: github.actor != 'dependabot[bot]'`
-              // (line 14). The audit was previously flagging every
-              // Dependabot PR as a false positive — see #20.
+              // skips Dependabot via the pull request author login
+              // (not github.actor, which can drift on reruns). The
+              // audit was previously flagging every Dependabot PR as
+              // a false positive — see #20.
               if (!isDependabot) {
                 if (!pr.body || !pr.body.match(/^## Self-Review/m)) {
                   prViolations.push('Missing `## Self-Review` section');
@@ -202,9 +234,11 @@ jobs:
               //      the sync script's branch-naming convention
               //      (`mergepath-sync/<short-sha>`) and never used for
               //      hand-authored work.
-              //   4. PR title matches `(mergepath@[0-9a-f]{7,40})` — the
-              //      canonical title format the sync script emits,
-              //      identifying the upstream commit.
+              //   4. PR title contains `mergepath@[0-9a-f]{7,40}` — the
+              //      canonical title marker the sync script emits,
+              //      identifying the upstream commit. Per-commit sync PRs
+              //      use `(mergepath@<sha>)`; `--sync-all` PRs use
+              //      `to mergepath@<sha>`.
               //
               // Hand-creating all four signals at once is possible but is
               // an explicit, traceable action that would surface during
@@ -218,7 +252,7 @@ jobs:
                 pr.head && pr.head.ref &&
                 pr.head.ref.startsWith('mergepath-sync/');
               const hasMergepathMarker =
-                /\(mergepath@[0-9a-f]{7,40}\)/.test(pr.title || '');
+                /\bmergepath@[0-9a-f]{7,40}\b/.test(pr.title || '');
               const isMergepathSyncPR =
                 isTrustedSyncAuthor &&
                 isSameRepoHead &&
@@ -439,8 +473,9 @@ jobs:
               // resolves escalation by removing the label (which unblocks the
               // label-gate check). If the label is still present at merge time,
               // it means the label gate was bypassed.
-              const hadHumanLabel = pr.labels.some(
-                l => l.name === 'needs-human-review'
+              const hadHumanLabel = await labelWasPresentAtMerge(
+                pr,
+                'needs-human-review'
               );
 
               if (hadHumanLabel) {
@@ -450,13 +485,26 @@ jobs:
               }
 
               // Check 5: Had policy-violation label — should not have been merged
-              const hadPolicyViolation = pr.labels.some(
-                l => l.name === 'policy-violation'
+              const hadPolicyViolation = await labelWasPresentAtMerge(
+                pr,
+                'policy-violation'
               );
 
               if (hadPolicyViolation) {
                 prViolations.push(
                   'Merged with `policy-violation` label still present'
+                );
+              }
+
+              // Check 6: Had human-hold label — should not have been merged.
+              const hadHumanHold = await labelWasPresentAtMerge(
+                pr,
+                'human-hold'
+              );
+
+              if (hadHumanHold) {
+                prViolations.push(
+                  'Merged with `human-hold` label still present — human hard hold was bypassed'
                 );
               }
 

--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -38,6 +38,7 @@ jobs:
               'needs-external-review',
               'needs-human-review',
               'policy-violation',
+              'human-hold',
             ];
             const prLabels = context.payload.pull_request.labels.map(l => l.name);
             const blockers = prLabels.filter(l => blockingLabels.includes(l));

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -193,13 +193,22 @@ perm_block=$(
 )
 # `actions: read` added in #310 — codex-review-check.sh's GraphQL
 # drill into statusCheckRollup.checkSuite.workflowRun requires it
-# in addition to `checks: read`. See the inline rationale comment
-# next to the new permission in auto-clear-blocking-labels.yml.
+# in addition to the `checks` scope. See the inline rationale comment
+# next to the permission in auto-clear-blocking-labels.yml.
 # `checks: write` added in #324 — the "Surface infra failure as
 # check-run" step posts a failed check-run when this workflow hits
 # an infrastructure error, so flake recurrences are visible on the
-# PR's checks tab without grepping workflow logs.
-expected_perms=$'actions: read\nchecks: read\nchecks: write\ncontents: read\npull-requests: write'
+# PR's checks tab without grepping workflow logs. It is the SINGLE
+# `checks` entry: `write` supersets `read`, so a separate
+# `checks: read` must NOT coexist with it. #324 shipped exactly that
+# duplicate `checks:` map key; this text-based assertion happily
+# matched both lines and stayed green, while GitHub's workflow parser
+# rejected the duplicate-key file and every trigger produced a
+# zero-job startup failure (the label never auto-cleared). The
+# expected set below now codifies the single-key shape so re-adding
+# `checks: read` fails this check instead of silently breaking the
+# workflow at runtime.
+expected_perms=$'actions: read\nchecks: write\ncontents: read\npull-requests: write'
 if [ "$perm_block" = "$expected_perms" ]; then
   pass=$((pass + 1))
   echo "  PASS: workflow permissions exactly match the least-privilege set"
@@ -242,7 +251,8 @@ fi
 # satisfy the match even if the executable line regressed).
 if grep -qE 'gh pr edit .+--remove-label needs-external-review' "$WORKFLOW" && \
    ! grep -qE 'gh pr edit .+--remove-label needs-human-review' "$WORKFLOW" && \
-   ! grep -qE 'gh pr edit .+--remove-label policy-violation' "$WORKFLOW"; then
+   ! grep -qE 'gh pr edit .+--remove-label policy-violation' "$WORKFLOW" && \
+   ! grep -qE 'gh pr edit .+--remove-label human-hold' "$WORKFLOW"; then
   pass=$((pass + 1))
   echo "  PASS: scope discipline — only needs-external-review is auto-removed (executable line)"
 else

--- a/scripts/ci/check_bootstrap_sh
+++ b/scripts/ci/check_bootstrap_sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# scripts/ci/check_bootstrap_sh — CI entry point for scripts/bootstrap.sh tests.
+#
+# Wraps tests/test_bootstrap_sh.sh so the repo_lint workflow catches
+# regressions in the legacy per-repo config restore helper.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_SCRIPT="$REPO_ROOT/tests/test_bootstrap_sh.sh"
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+  echo "check_bootstrap_sh: ERROR (missing $TEST_SCRIPT)" >&2
+  exit 1
+fi
+
+bash "$TEST_SCRIPT"

--- a/scripts/ci/check_canonical_bugs_263caf3
+++ b/scripts/ci/check_canonical_bugs_263caf3
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 # check_canonical_bugs_263caf3
 #
-# Regression coverage for two canonical-surface bugs found by
+# Regression coverage for canonical-surface bugs found by
 # nathanpayne-codex while doing the Phase 4b external reviews on
 # the 263caf3 propagation wave (matchline#232, nathanpaynedotcom#368,
 # overridebroadway#59, device-source-of-truth#86,
 # friends-and-family-billing#270, device-platform-reporting#80,
-# swipewatch#51, tadlockpsychiatry#54). Both are upstream canonical
+# swipewatch#51, tadlockpsychiatry#54), plus follow-up regressions in
+# the same review-policy/gate surface. These are upstream canonical
 # defects that affect every consumer, not consumer-local drift.
 #
 #   Bug 1: scripts/request-label-removal.sh aborted under `set -e`
@@ -29,6 +30,22 @@
 #          approve through the merge gate. The fix excludes BOTH
 #          `$author` AND `$same_agent_reviewer`.
 #
+#   Bug 5: scripts/coderabbit-wait.sh counted CodeRabbit Potential
+#          issue comments as active even after CodeRabbit replied to
+#          the same inline thread with its `review_comment_addressed`
+#          marker. The review-thread state was already resolved, but
+#          the helper still returned exit 2 from the status-context
+#          fast-path and stalled otherwise mergeable PRs.
+#
+#   Bug 6: scripts/coderabbit-wait.sh trusted a SUCCESS CodeRabbit
+#          StatusContext even when the current-head PR-level CodeRabbit
+#          comment was a newer rate-limit notice. The helper returned
+#          cleared even though CodeRabbit explicitly had not reviewed
+#          the PR. The inverse matters too: an old rate-limit comment
+#          must not suppress a newer terminal SUCCESS status. CodeRabbit
+#          edits its summary comment in place, so the regression uses
+#          updated_at/freshness rather than created_at alone.
+#
 # This check exercises the jq filter literals in isolation against
 # in-memory fixtures so a future edit can't silently regress either
 # guard. Inline-literal pattern matches check_workflow_parsers /
@@ -41,8 +58,9 @@ cd "$ROOT"
 
 LABEL_REMOVAL_SCRIPT="scripts/request-label-removal.sh"
 CODEX_CHECK_SCRIPT="scripts/codex-review-check.sh"
+CODERABBIT_WAIT_SCRIPT="scripts/coderabbit-wait.sh"
 
-for f in "$LABEL_REMOVAL_SCRIPT" "$CODEX_CHECK_SCRIPT"; do
+for f in "$LABEL_REMOVAL_SCRIPT" "$CODEX_CHECK_SCRIPT" "$CODERABBIT_WAIT_SCRIPT"; do
   if [ ! -f "$f" ]; then
     echo "check_canonical_bugs_263caf3: FAIL — missing $f"
     exit 1
@@ -578,6 +596,790 @@ else
   fail=$((fail + 1))
   echo "  FAIL: large-body parser regressed — header silently lost (rc=$rc, got='$got')" >&2
   echo "        body size was ${#LARGE_BODY} bytes; r2 producer-pipe shape would fail here." >&2
+fi
+
+echo
+echo "Bug 3 regression: codex-review-check.sh exact blocking-label match"
+
+# Inline-literal pattern: this is the jq predicate used by
+# scripts/codex-review-check.sh's blocking-label preflight. It must
+# match exact label names, not substrings inside a CSV serialization.
+CODEX_LABEL_FILTER='any(.labels[].name; . == $label)'
+
+run_label_filter() {
+  # Args: $1 = PR JSON, $2 = label to test.
+  echo "$1" | jq -e --arg label "$2" "$CODEX_LABEL_FILTER" >/dev/null
+}
+
+LABELS_EXACT='{"labels":[{"name":"human-hold"}]}'
+LABELS_COMMA='{"labels":[{"name":"team,human-hold"}]}'
+LABELS_OTHER='{"labels":[{"name":"needs-human-review"},{"name":"policy-violation"}]}'
+LABELS_EMPTY='{"labels":[]}'
+
+set +e
+run_label_filter "$LABELS_EXACT" "human-hold"
+rc=$?
+set -e
+if [ "$rc" = "0" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: exact human-hold label matches"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: exact human-hold label did not match" >&2
+fi
+
+set +e
+run_label_filter "$LABELS_COMMA" "human-hold"
+rc=$?
+set -e
+if [ "$rc" != "0" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: label 'team,human-hold' does NOT false-match human-hold"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: comma-containing label false-matched human-hold" >&2
+fi
+
+set +e
+run_label_filter "$LABELS_OTHER" "policy-violation"
+rc=$?
+set -e
+if [ "$rc" = "0" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: exact policy-violation label matches"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: exact policy-violation label did not match" >&2
+fi
+
+set +e
+run_label_filter "$LABELS_EMPTY" "human-hold"
+rc=$?
+set -e
+if [ "$rc" != "0" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: empty labels do not match human-hold"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: empty labels unexpectedly matched human-hold" >&2
+fi
+
+if grep -Fq '[.labels[].name] | join(",")' "$CODEX_CHECK_SCRIPT"; then
+  fail=$((fail + 1))
+  echo "  FAIL: codex-review-check.sh still serializes labels as CSV before matching" >&2
+else
+  pass=$((pass + 1))
+  echo "  PASS: codex-review-check.sh no longer serializes labels as CSV before matching"
+fi
+
+if grep -Fq 'any(.labels[].name; . == $label)' "$CODEX_CHECK_SCRIPT"; then
+  pass=$((pass + 1))
+  echo "  PASS: codex-review-check.sh uses the exact-name jq predicate"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: codex-review-check.sh is missing the exact-name jq predicate" >&2
+fi
+
+echo
+echo "Bug 4 regression: codex.enabled=false ignores Codex bot clearance (#362)"
+
+# #362: codex-review-check.sh used to read Codex bot reviews and 👍
+# reactions even when `.github/review-policy.yml` had `codex.enabled:
+# false`. In that posture Phase 4a is unavailable, so gate (c) must
+# clear ONLY through the Phase 4b substitute branch.
+
+run_gate_c_enabled_model() {
+  # Args:
+  #   $1 = codex_enabled (true|false)
+  #   $2 = latest_thumbs_up_time
+  #   $3 = codex_review_time
+  #   $4 = unaddressed_p01_count
+  #   $5 = allow_phase_4b_substitute (true|false)
+  #   $6 = phase_4b_time
+  local codex_enabled="$1"
+  local latest_thumbs_up_time="$2"
+  local codex_review_time="$3"
+  local unaddressed_count="$4"
+  local allow_phase_4b="$5"
+  local phase_4b_time="$6"
+  local cleared=false
+  local latest_codex_signal_time=""
+
+  if [ "$codex_enabled" = "true" ]; then
+    if [ -n "$latest_thumbs_up_time" ] && [ -n "$codex_review_time" ]; then
+      if [[ "$latest_thumbs_up_time" > "$codex_review_time" ]]; then
+        cleared=true
+      elif [ "$unaddressed_count" -eq 0 ]; then
+        cleared=true
+      fi
+    elif [ -n "$latest_thumbs_up_time" ]; then
+      cleared=true
+    elif [ -n "$codex_review_time" ] && [ "$unaddressed_count" -eq 0 ]; then
+      cleared=true
+    fi
+
+    latest_codex_signal_time="$latest_thumbs_up_time"
+    if [ -n "$codex_review_time" ] && { [ -z "$latest_codex_signal_time" ] || [[ "$codex_review_time" > "$latest_codex_signal_time" ]]; }; then
+      latest_codex_signal_time="$codex_review_time"
+    fi
+  fi
+
+  if [ "$cleared" != "true" ] && [ "$allow_phase_4b" = "true" ] && [ -n "$phase_4b_time" ]; then
+    if [ -z "$latest_codex_signal_time" ] || [[ "$phase_4b_time" > "$latest_codex_signal_time" ]]; then
+      cleared=true
+    fi
+  fi
+
+  printf '%s\n' "$cleared"
+}
+
+got=$(run_gate_c_enabled_model false "2026-05-21T12:00:00Z" "" 0 true "")
+if [ "$got" = "false" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: codex.enabled=false + bot 👍 alone does not clear gate (c)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: codex.enabled=false still let bot 👍 clear gate (c)" >&2
+fi
+
+got=$(run_gate_c_enabled_model false "" "2026-05-21T12:00:00Z" 0 true "")
+if [ "$got" = "false" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: codex.enabled=false + clean Codex COMMENTED review alone does not clear gate (c)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: codex.enabled=false still let a Codex COMMENTED review clear gate (c)" >&2
+fi
+
+got=$(run_gate_c_enabled_model false "2026-05-21T12:00:00Z" "" 0 true "2026-05-21T11:00:00Z")
+if [ "$got" = "true" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: codex.enabled=false + Phase 4b APPROVED clears even when an ignored bot signal is newer"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: codex.enabled=false did not accept Phase 4b substitute clearance" >&2
+fi
+
+got=$(run_gate_c_enabled_model true "2026-05-21T12:00:00Z" "" 0 true "")
+if [ "$got" = "true" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: codex.enabled=true still accepts bot 👍 clearance"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: codex.enabled=true stopped accepting bot 👍 clearance" >&2
+fi
+
+if grep -Fq 'CODEX_ENABLED=$(codex_field enabled)' "$CODEX_CHECK_SCRIPT" && \
+   grep -Fq 'codex.enabled=false — ignoring Codex bot review/reaction signals' "$CODEX_CHECK_SCRIPT" && \
+   grep -Fq 'same-agent Codex 👍 fallback unavailable because codex.enabled=false' "$CODEX_CHECK_SCRIPT"; then
+  pass=$((pass + 1))
+  echo "  PASS: production script parses codex.enabled and disables both Codex clearance paths"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: production script is missing the codex.enabled enforcement hooks" >&2
+fi
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+scenario="${CODEX_ENABLED_FIXTURE:-}"
+
+reviews_json() {
+  case "$scenario" in
+    disabled_bot_only|enabled_bot)
+      cat <<'JSON'
+[
+  {"user":{"login":"nathanpayne-claude"},"state":"APPROVED","commit_id":"oldsha","submitted_at":"2026-05-21T11:00:00Z"}
+]
+JSON
+      ;;
+    disabled_4b)
+      cat <<'JSON'
+[
+  {"user":{"login":"nathanpayne-claude"},"state":"APPROVED","commit_id":"headsha","submitted_at":"2026-05-21T11:00:00Z"}
+]
+JSON
+      ;;
+    *)
+      printf '[]\n'
+      ;;
+  esac
+}
+
+reactions_json() {
+  case "$scenario" in
+    disabled_bot_only|disabled_4b|enabled_bot)
+      reaction_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      printf '[{"user":{"login":"chatgpt-codex-connector[bot]"},"content":"+1","created_at":"%s"}]\n' "$reaction_time"
+      ;;
+    *)
+      printf '[]\n'
+      ;;
+  esac
+}
+
+case "$1" in
+  api)
+    shift
+    if [ "${1:-}" = "--paginate" ]; then
+      shift
+      case "${1:-}" in
+        repos/nathanjohnpayne/mergepath/issues/99999/timeline) printf '[]\n' ;;
+        repos/nathanjohnpayne/mergepath/pulls/99999/reviews) reviews_json ;;
+        repos/nathanjohnpayne/mergepath/pulls/99999/comments) printf '[]\n' ;;
+        repos/nathanjohnpayne/mergepath/issues/99999/reactions) reactions_json ;;
+        *) printf 'unexpected paginated endpoint: %s\n' "${1:-}" >&2; exit 9 ;;
+      esac
+      exit 0
+    fi
+
+    case "${1:-}" in
+      repos/nathanjohnpayne/mergepath/pulls/99999)
+        cat <<'JSON'
+{"head":{"sha":"headsha"},"user":{"login":"nathanjohnpayne"},"body":"Authoring-Agent: codex","base":{"ref":"main"},"labels":[]}
+JSON
+        ;;
+      repos/nathanjohnpayne/mergepath/commits/headsha)
+        if [ "${2:-}" = "--jq" ]; then
+          printf '2026-05-21T11:30:00Z\n'
+        else
+          printf '{"commit":{"committer":{"date":"2026-05-21T11:30:00Z"}}}\n'
+        fi
+        ;;
+      repos/nathanjohnpayne/mergepath/branches/main/protection/required_status_checks)
+        exit 1
+        ;;
+      *) printf 'unexpected endpoint: %s\n' "${1:-}" >&2; exit 9 ;;
+    esac
+    ;;
+  pr)
+    shift
+    case "${1:-}" in
+      view)
+        printf '{"statusCheckRollup":[]}\n'
+        ;;
+      *) printf 'unexpected pr command: %s\n' "${1:-}" >&2; exit 9 ;;
+    esac
+    ;;
+  repo)
+    shift
+    case "${1:-}" in
+      view) printf 'nathanjohnpayne/mergepath\n' ;;
+      *) printf 'unexpected repo command: %s\n' "${1:-}" >&2; exit 9 ;;
+    esac
+    ;;
+  *) printf 'unexpected gh command: %s\n' "${1:-}" >&2; exit 9 ;;
+esac
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+CODEX_FIXTURE_ROOT="$SCRATCH/codex-enabled-root"
+mkdir -p "$CODEX_FIXTURE_ROOT/.github"
+
+write_codex_enabled_policy() {
+  cat > "$CODEX_FIXTURE_ROOT/.github/review-policy.yml" <<EOF_POLICY
+available_reviewers:
+  - nathanpayne-claude
+  - nathanpayne-cursor
+  - nathanpayne-codex
+codex:
+  enabled: $1
+  bot_login: "chatgpt-codex-connector[bot]"
+  require_ci_green: true
+  allow_phase_4b_substitute: true
+EOF_POLICY
+}
+
+run_codex_check_fixture() {
+  # Args: $1 = codex.enabled value, $2 = CODEX_ENABLED_FIXTURE scenario.
+  write_codex_enabled_policy "$1"
+  (
+    cd "$CODEX_FIXTURE_ROOT"
+    PATH="$SCRATCH:$PATH" \
+      GH_TOKEN=fixture-token \
+      CODEX_ENABLED_FIXTURE="$2" \
+      "$ROOT/$CODEX_CHECK_SCRIPT" 99999 nathanjohnpayne/mergepath
+  )
+}
+
+set +e
+out=$(run_codex_check_fixture false disabled_bot_only 2>&1)
+rc=$?
+set -e
+if [ "$rc" = "1" ] && echo "$out" | grep -q "codex.enabled=false and no Phase 4b substitute APPROVED"; then
+  pass=$((pass + 1))
+  echo "  PASS: actual codex-review-check blocks disabled Codex despite fresh bot 👍"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: actual codex-review-check did not block disabled Codex bot-only clearance (rc=$rc)" >&2
+  echo "$out" | sed 's/^/    /' >&2
+fi
+
+set +e
+out=$(run_codex_check_fixture false disabled_4b 2>&1)
+rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "Phase 4b substitute"; then
+  pass=$((pass + 1))
+  echo "  PASS: actual codex-review-check accepts Phase 4b substitute when Codex is disabled"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: actual codex-review-check rejected disabled-Codex Phase 4b substitute (rc=$rc)" >&2
+  echo "$out" | sed 's/^/    /' >&2
+fi
+
+set +e
+out=$(run_codex_check_fixture true enabled_bot 2>&1)
+rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "👍 reaction"; then
+  pass=$((pass + 1))
+  echo "  PASS: actual codex-review-check still accepts bot 👍 when Codex is enabled"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: actual codex-review-check rejected enabled-Codex bot clearance (rc=$rc)" >&2
+  echo "$out" | sed 's/^/    /' >&2
+fi
+
+# ── Bug 5 regression: CodeRabbit addressed marker clears finding ─────
+#
+# Keep these jq filters in lockstep with scripts/coderabbit-wait.sh's
+# count_potential_issues() and count_potential_issues_for_sha(). The
+# helper should hold on root Potential issue / ⚠️ comments unless
+# CodeRabbit itself has replied to that root with the hidden addressed
+# marker. Agent replies alone — even if they claim a fix — are not a
+# clearance signal.
+
+echo
+echo "Bug 5 regression: coderabbit-wait ignores CodeRabbit-addressed findings"
+
+COUNT_CODERABBIT_BY_REVIEW_JQ='
+  [ .[]
+    | select(.user.login == $bot)
+    | select(.in_reply_to_id != null)
+    | select((.body // "") | test("review_comment_addressed"; "i"))
+    | .in_reply_to_id
+  ] as $addressed_root_ids
+  | [ .[]
+    | select(.user.login == $bot)
+    | select(.pull_request_review_id == $review_id)
+    | select(.in_reply_to_id == null)
+    | select((.body // "") | test("Potential issue|⚠️"; "i"))
+    | select(.id as $id | ($addressed_root_ids | index($id)) == null)
+  ] | length
+'
+
+COUNT_CODERABBIT_BY_SHA_JQ='
+  [ .[]
+    | select(.user.login == $bot)
+    | select(.in_reply_to_id != null)
+    | select((.body // "") | test("review_comment_addressed"; "i"))
+    | .in_reply_to_id
+  ] as $addressed_root_ids
+  | [ .[]
+    | select(.user.login == $bot)
+    | select(.commit_id == $sha)
+    | select(.in_reply_to_id == null)
+    | select((.body // "") | test("Potential issue|⚠️"; "i"))
+    | select(.id as $id | ($addressed_root_ids | index($id)) == null)
+  ] | length
+'
+
+coderabbit_count_by_review() {
+  local review_id=$1
+  jq --arg bot "coderabbitai[bot]" --argjson review_id "$review_id" \
+    "$COUNT_CODERABBIT_BY_REVIEW_JQ"
+}
+
+coderabbit_count_by_sha() {
+  local sha=$1
+  jq --arg bot "coderabbitai[bot]" --arg sha "$sha" \
+    "$COUNT_CODERABBIT_BY_SHA_JQ"
+}
+
+coderabbit_addressed_fixture='[
+  {
+    "id": 101,
+    "user": {"login": "coderabbitai[bot]"},
+    "pull_request_review_id": 9001,
+    "commit_id": "abc123",
+    "body": "_⚠️ Potential issue_\n\nThis should be counted until addressed."
+  },
+  {
+    "id": 102,
+    "user": {"login": "nathanpayne-codex"},
+    "in_reply_to_id": 101,
+    "commit_id": "abc123",
+    "body": "Fixed in the latest commit."
+  },
+  {
+    "id": 103,
+    "user": {"login": "coderabbitai[bot]"},
+    "in_reply_to_id": 101,
+    "commit_id": "abc123",
+    "body": "Confirmed.\n<!-- <review_comment_addressed> -->"
+  }
+]'
+
+review_count=$(echo "$coderabbit_addressed_fixture" | coderabbit_count_by_review 9001)
+sha_count=$(echo "$coderabbit_addressed_fixture" | coderabbit_count_by_sha abc123)
+if [ "$review_count" = "0" ] && [ "$sha_count" = "0" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: CodeRabbit addressed marker clears review- and SHA-scoped counts"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: addressed CodeRabbit finding still counted (review=$review_count sha=$sha_count)" >&2
+fi
+
+coderabbit_agent_reply_only_fixture='[
+  {
+    "id": 201,
+    "user": {"login": "coderabbitai[bot]"},
+    "pull_request_review_id": 9002,
+    "commit_id": "def456",
+    "body": "_⚠️ Potential issue_\n\nThis should still be counted."
+  },
+  {
+    "id": 202,
+    "user": {"login": "nathanpayne-codex"},
+    "in_reply_to_id": 201,
+    "commit_id": "def456",
+    "body": "Fixed in the latest commit."
+  }
+]'
+
+review_count=$(echo "$coderabbit_agent_reply_only_fixture" | coderabbit_count_by_review 9002)
+sha_count=$(echo "$coderabbit_agent_reply_only_fixture" | coderabbit_count_by_sha def456)
+if [ "$review_count" = "1" ] && [ "$sha_count" = "1" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: agent reply alone does not clear CodeRabbit Potential issue"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: agent reply unexpectedly cleared finding (review=$review_count sha=$sha_count)" >&2
+fi
+
+coderabbit_spoofed_marker_fixture='[
+  {
+    "id": 301,
+    "user": {"login": "coderabbitai[bot]"},
+    "pull_request_review_id": 9003,
+    "commit_id": "fed789",
+    "body": "_⚠️ Potential issue_\n\nThis should still be counted."
+  },
+  {
+    "id": 302,
+    "user": {"login": "nathanpayne-codex"},
+    "in_reply_to_id": 301,
+    "commit_id": "fed789",
+    "body": "<!-- <review_comment_addressed> -->"
+  }
+]'
+
+review_count=$(echo "$coderabbit_spoofed_marker_fixture" | coderabbit_count_by_review 9003)
+sha_count=$(echo "$coderabbit_spoofed_marker_fixture" | coderabbit_count_by_sha fed789)
+if [ "$review_count" = "1" ] && [ "$sha_count" = "1" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: non-CodeRabbit addressed marker spoof does not clear finding"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: non-CodeRabbit marker unexpectedly cleared finding (review=$review_count sha=$sha_count)" >&2
+fi
+
+coderabbit_mixed_fixture='[
+  {
+    "id": 401,
+    "user": {"login": "coderabbitai[bot]"},
+    "pull_request_review_id": 9004,
+    "commit_id": "beef00",
+    "body": "_⚠️ Potential issue_\n\nAddressed root."
+  },
+  {
+    "id": 402,
+    "user": {"login": "coderabbitai[bot]"},
+    "in_reply_to_id": 401,
+    "commit_id": "beef00",
+    "body": "<!-- <review_comment_addressed> -->"
+  },
+  {
+    "id": 403,
+    "user": {"login": "coderabbitai[bot]"},
+    "pull_request_review_id": 9004,
+    "commit_id": "beef00",
+    "body": "_⚠️ Potential issue_\n\nStill open root."
+  }
+]'
+
+review_count=$(echo "$coderabbit_mixed_fixture" | coderabbit_count_by_review 9004)
+sha_count=$(echo "$coderabbit_mixed_fixture" | coderabbit_count_by_sha beef00)
+if [ "$review_count" = "1" ] && [ "$sha_count" = "1" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: mixed addressed/unaddressed findings count only the open root"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: mixed fixture count incorrect (review=$review_count sha=$sha_count)" >&2
+fi
+
+echo
+echo "Bug 6 regression: coderabbit-wait does not fast-clear rate-limit notices"
+
+cat > "$SCRATCH/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$1" in
+  api)
+    shift
+    if [ "${1:-}" = "--paginate" ]; then
+      shift
+      case "${1:-}" in
+        repos/nathanjohnpayne/mergepath/issues/12345/timeline)
+          printf '[]\n'
+          ;;
+        repos/nathanjohnpayne/mergepath/commits/headsha/statuses)
+          status_created_at="${STUB_STATUS_CREATED_AT:-2999-01-01T00:00:00Z}"
+          cat <<JSON
+[
+  {
+    "context": "CodeRabbit",
+    "state": "success",
+    "created_at": "$status_created_at",
+    "creator": {"login": "coderabbitai[bot]"}
+  }
+]
+JSON
+          ;;
+        repos/nathanjohnpayne/mergepath/issues/12345/comments)
+          if [ "${STUB_ISSUE_COMMENTS_EMPTY:-0}" = "1" ]; then
+            printf '[]\n'
+            exit 0
+          fi
+          comment_created_at="${STUB_COMMENT_CREATED_AT:-2998-01-01T00:00:00Z}"
+          comment_updated_at="${STUB_COMMENT_UPDATED_AT:-2999-01-01T00:00:00Z}"
+          comment_body_suffix="${STUB_COMMENT_BODY_SUFFIX- Reviewing files that changed from base and headsha.}"
+          cat <<JSON
+[
+  {
+    "id": 6101,
+    "created_at": "$comment_created_at",
+    "updated_at": "$comment_updated_at",
+    "user": {"login": "coderabbitai[bot]"},
+    "body": "> [!WARNING]\n> ## Rate limit exceeded\n>\n> Please wait **10 minutes** before requesting another review.$comment_body_suffix"
+  }
+]
+JSON
+          ;;
+        repos/nathanjohnpayne/mergepath/pulls/12345/comments)
+          if [ "${STUB_INLINE_POTENTIAL:-0}" = "1" ]; then
+            inline_created_at="${STUB_INLINE_CREATED_AT:-2999-01-01T00:00:00Z}"
+            cat <<JSON
+[
+  {
+    "id": 7201,
+    "created_at": "$inline_created_at",
+    "updated_at": "$inline_created_at",
+    "commit_id": "headsha",
+    "in_reply_to_id": null,
+    "user": {"login": "coderabbitai[bot]"},
+    "body": "_⚠️ Potential issue_\\n\\nFresh inline finding."
+  }
+]
+JSON
+          else
+            printf '[]\n'
+          fi
+          ;;
+        repos/nathanjohnpayne/mergepath/pulls/12345/reviews)
+          printf '[]\n'
+          ;;
+        *)
+          printf 'unexpected paginated endpoint: %s\n' "${1:-}" >&2
+          exit 9
+          ;;
+      esac
+      exit 0
+    fi
+
+    case "${1:-}" in
+      repos/nathanjohnpayne/mergepath/pulls/12345)
+        cat <<'JSON'
+{"head":{"sha":"headsha"}}
+JSON
+        ;;
+      repos/nathanjohnpayne/mergepath/commits/headsha)
+        if [ "${2:-}" = "--jq" ]; then
+          printf '2999-01-01T00:00:00Z\n'
+        else
+          cat <<'JSON'
+{"commit":{"committer":{"date":"2999-01-01T00:00:00Z"}}}
+JSON
+        fi
+        ;;
+      *)
+        printf 'unexpected endpoint: %s\n' "${1:-}" >&2
+        exit 9
+        ;;
+    esac
+    ;;
+  *)
+    printf 'unexpected gh command: %s\n' "$1" >&2
+    exit 9
+    ;;
+esac
+GH_STUB
+chmod +x "$SCRATCH/gh"
+
+CODERABBIT_FASTPATH_ROOT="$SCRATCH/coderabbit-fastpath-root"
+mkdir -p "$CODERABBIT_FASTPATH_ROOT/.github"
+cat > "$CODERABBIT_FASTPATH_ROOT/.github/review-policy.yml" <<'YAML'
+coderabbit:
+  bot_login: "coderabbitai[bot]"
+  max_wait_seconds: 300
+  max_rate_limit_retries: 2
+  wallclock_freshness_window_seconds: 1800
+  trust_status_context_for_clearance: true
+YAML
+
+set +e
+out=$(
+  cd "$CODERABBIT_FASTPATH_ROOT" &&
+    PATH="$SCRATCH:$PATH" \
+    GH_TOKEN=fixture-token \
+    CODERABBIT_WAIT_SKIP_IDENTITY_CHECK=1 \
+    "$ROOT/$CODERABBIT_WAIT_SCRIPT" 12345 nathanjohnpayne/mergepath 2>&1
+)
+rc=$?
+set -e
+if [ "$rc" = "5" ] &&
+   echo "$out" | grep -q '"status": "rate_limit_stalled"' &&
+   echo "$out" | grep -q "StatusContext success ignored"; then
+  pass=$((pass + 1))
+  echo "  PASS: StatusContext success does not clear a current-head rate-limit comment"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: StatusContext success incorrectly cleared or masked a rate-limit comment (rc=$rc)" >&2
+  echo "$out" | sed 's/^/    /' >&2
+fi
+
+set +e
+out=$(
+  cd "$CODERABBIT_FASTPATH_ROOT" &&
+    PATH="$SCRATCH:$PATH" \
+    GH_TOKEN=fixture-token \
+    CODERABBIT_WAIT_SKIP_IDENTITY_CHECK=1 \
+    STUB_COMMENT_CREATED_AT="2998-01-01T00:00:00Z" \
+    STUB_COMMENT_UPDATED_AT="2999-01-01T00:00:00Z" \
+    STUB_STATUS_CREATED_AT="2999-01-01T00:00:01Z" \
+    STUB_COMMENT_BODY_SUFFIX="" \
+    "$ROOT/$CODERABBIT_WAIT_SCRIPT" 12345 nathanjohnpayne/mergepath 2>&1
+)
+rc=$?
+set -e
+if [ "$rc" = "0" ] &&
+   echo "$out" | grep -q '"status": "cleared"' &&
+   echo "$out" | grep -q "does not reference current HEAD headsha"; then
+  pass=$((pass + 1))
+  echo "  PASS: StatusContext success clears despite an unscoped non-HEAD rate-limit comment"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: unscoped non-HEAD rate-limit comment incorrectly suppressed StatusContext success (rc=$rc)" >&2
+  echo "$out" | sed 's/^/    /' >&2
+fi
+
+set +e
+out=$(
+  cd "$CODERABBIT_FASTPATH_ROOT" &&
+    PATH="$SCRATCH:$PATH" \
+    GH_TOKEN=fixture-token \
+    CODERABBIT_WAIT_SKIP_IDENTITY_CHECK=1 \
+    STUB_COMMENT_CREATED_AT="2998-01-01T00:00:00Z" \
+    STUB_COMMENT_UPDATED_AT="2999-01-01T00:00:02Z" \
+    STUB_STATUS_CREATED_AT="2999-01-01T00:00:01Z" \
+    STUB_COMMENT_BODY_SUFFIX="" \
+    "$ROOT/$CODERABBIT_WAIT_SCRIPT" 12345 nathanjohnpayne/mergepath 2>&1
+)
+rc=$?
+set -e
+if [ "$rc" = "0" ] &&
+   echo "$out" | grep -q '"status": "cleared"' &&
+   echo "$out" | grep -q "does not reference current HEAD headsha"; then
+  pass=$((pass + 1))
+  echo "  PASS: newer unscoped non-HEAD rate-limit comment does not suppress StatusContext success"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: fresh unscoped non-HEAD rate-limit comment incorrectly suppressed StatusContext success (rc=$rc)" >&2
+  echo "$out" | sed 's/^/    /' >&2
+fi
+
+set +e
+out=$(
+  cd "$CODERABBIT_FASTPATH_ROOT" &&
+    PATH="$SCRATCH:$PATH" \
+    GH_TOKEN=fixture-token \
+    CODERABBIT_WAIT_SKIP_IDENTITY_CHECK=1 \
+    STUB_COMMENT_CREATED_AT="2998-01-01T00:00:00Z" \
+    STUB_COMMENT_UPDATED_AT="2999-01-01T00:00:00Z" \
+    STUB_STATUS_CREATED_AT="2999-01-01T00:00:01Z" \
+    "$ROOT/$CODERABBIT_WAIT_SCRIPT" 12345 nathanjohnpayne/mergepath 2>&1
+)
+rc=$?
+set -e
+if [ "$rc" = "0" ] &&
+   echo "$out" | grep -q '"status": "cleared"' &&
+   echo "$out" | grep -q "references current HEAD headsha but fresh_at=2999-01-01T00:00:00Z is older than status_created=2999-01-01T00:00:01Z"; then
+  pass=$((pass + 1))
+  echo "  PASS: newer StatusContext success clears despite an older current-head rate-limit comment"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: stale current-head rate-limit comment incorrectly suppressed a newer StatusContext success (rc=$rc)" >&2
+  echo "$out" | sed 's/^/    /' >&2
+fi
+
+set +e
+out=$(
+  cd "$CODERABBIT_FASTPATH_ROOT" &&
+    PATH="$SCRATCH:$PATH" \
+    GH_TOKEN=fixture-token \
+    CODERABBIT_WAIT_SKIP_IDENTITY_CHECK=1 \
+    STUB_ISSUE_COMMENTS_EMPTY=1 \
+    STUB_INLINE_POTENTIAL=1 \
+    STUB_INLINE_CREATED_AT="2998-12-31T23:59:59Z" \
+    "$ROOT/$CODERABBIT_WAIT_SCRIPT" 12345 nathanjohnpayne/mergepath 2>&1
+)
+rc=$?
+set -e
+if [ "$rc" = "0" ] &&
+   echo "$out" | grep -q '"status": "cleared"'; then
+  pass=$((pass + 1))
+  echo "  PASS: StatusContext fast path ignores pre-head inline findings remapped to HEAD"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: stale pre-head inline finding incorrectly blocked StatusContext fast path (rc=$rc)" >&2
+  echo "$out" | sed 's/^/    /' >&2
+fi
+
+set +e
+out=$(
+  cd "$CODERABBIT_FASTPATH_ROOT" &&
+    PATH="$SCRATCH:$PATH" \
+    GH_TOKEN=fixture-token \
+    CODERABBIT_WAIT_SKIP_IDENTITY_CHECK=1 \
+    STUB_ISSUE_COMMENTS_EMPTY=1 \
+    STUB_INLINE_POTENTIAL=1 \
+    STUB_INLINE_CREATED_AT="2999-01-01T00:00:01Z" \
+    "$ROOT/$CODERABBIT_WAIT_SCRIPT" 12345 nathanjohnpayne/mergepath 2>&1
+)
+rc=$?
+set -e
+if [ "$rc" = "2" ] &&
+   echo "$out" | grep -q '"status": "findings"' &&
+   echo "$out" | grep -q '"potential_issue_count": 1'; then
+  pass=$((pass + 1))
+  echo "  PASS: StatusContext fast path still reports fresh current-head inline findings"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: fresh current-head inline finding was not reported (rc=$rc)" >&2
+  echo "$out" | sed 's/^/    /' >&2
 fi
 
 echo

--- a/scripts/ci/check_onepassword_headless_proof_workflow
+++ b/scripts/ci/check_onepassword_headless_proof_workflow
@@ -1,0 +1,433 @@
+#!/usr/bin/env bash
+# Validate the 1Password headless proof workflow's safety-critical shape.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WORKFLOW="$ROOT/.github/workflows/onepassword-headless-proof.yml"
+SETUP_SCRIPT="$ROOT/scripts/onepassword-headless-proof-setup.sh"
+
+fail() {
+  echo "check_onepassword_headless_proof_workflow: FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$WORKFLOW" ]] || fail "missing $WORKFLOW"
+[[ -f "$SETUP_SCRIPT" ]] || fail "missing $SETUP_SCRIPT"
+
+workflow_triggers() {
+  local file="$1"
+  ruby -ryaml -e '
+    file = ARGV.fetch(0)
+    begin
+      doc = YAML.safe_load(File.read(file), aliases: false)
+    rescue Psych::Exception => e
+      warn "YAML parse failed for #{file}: #{e.message}"
+      exit 2
+    end
+
+    unless doc.is_a?(Hash)
+      exit
+    end
+
+    # Psych parses the GitHub Actions key `on` as boolean true under YAML 1.1.
+    on_value = if doc.key?("on")
+                 doc["on"]
+               else
+                 doc[true]
+               end
+
+    triggers =
+      case on_value
+      when Hash
+        on_value.keys
+      when Array
+        on_value
+      when String, Symbol
+        [on_value]
+      when NilClass
+        []
+      else
+        [on_value]
+      end
+
+    triggers.map(&:to_s).each { |trigger| puts trigger }
+  ' "$file"
+}
+
+is_workflow_dispatch_only() {
+  local file="$1"
+  local triggers count
+  triggers=$(workflow_triggers "$file")
+  count=$(printf '%s\n' "$triggers" | sed '/^$/d' | wc -l | tr -d ' ')
+  [ "$count" -eq 1 ] && [ "$triggers" = "workflow_dispatch" ]
+}
+
+assert_workflow_dispatch_only() {
+  local file="$1"
+  local triggers
+  if ! is_workflow_dispatch_only "$file"; then
+    triggers=$(workflow_triggers "$file" | paste -sd ', ' -)
+    fail "workflow must be manual-only: expected only workflow_dispatch under on:, found [${triggers:-none}]"
+  fi
+}
+
+assert_rejects_non_manual_trigger_fixture() {
+  local file="$1"
+  local desc="$2"
+  if is_workflow_dispatch_only "$file"; then
+    fail "trigger allowlist failed to reject $desc fixture"
+  fi
+}
+
+workflow_checkout_persist_credentials_disabled() {
+  local file="$1"
+  ruby -ryaml -e '
+    file = ARGV.fetch(0)
+    begin
+      doc = YAML.safe_load(File.read(file), aliases: false) || {}
+    rescue Psych::Exception => e
+      warn "YAML parse failed for #{file}: #{e.message}"
+      exit 2
+    end
+
+    jobs = doc["jobs"]
+    exit 1 unless jobs.is_a?(Hash)
+
+    checkouts = jobs.values.flat_map do |job|
+      steps = job.is_a?(Hash) ? job["steps"] : nil
+      next [] unless steps.is_a?(Array)
+
+      steps.select do |step|
+        step.is_a?(Hash) && step["uses"].to_s.start_with?("actions/checkout@")
+      end
+    end
+    exit 1 if checkouts.empty?
+
+    ok = checkouts.all? do |checkout|
+      with_block = checkout["with"]
+      value = with_block.is_a?(Hash) ? with_block["persist-credentials"] : nil
+      value == false || value.to_s == "false"
+    end
+    exit(ok ? 0 : 1)
+  ' "$file"
+}
+
+assert_checkout_disables_credential_persistence() {
+  local file="$1"
+  if ! workflow_checkout_persist_credentials_disabled "$file"; then
+    fail "workflow checkout must disable credential persistence on the actions/checkout step"
+  fi
+}
+
+assert_rejects_checkout_credential_fixture() {
+  local file="$1"
+  local desc="$2"
+  if workflow_checkout_persist_credentials_disabled "$file"; then
+    fail "checkout credential guard failed to reject $desc fixture"
+  fi
+}
+
+assert_workflow_dispatch_only "$WORKFLOW"
+
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/onepassword-proof-workflow-check.XXXXXX")"
+trap 'rm -rf "$SCRATCH"' EXIT
+cat >"$SCRATCH/dispatch-only.yml" <<'YAML'
+name: proof
+on:
+  workflow_dispatch:
+YAML
+cat >"$SCRATCH/pull-request-target.yml" <<'YAML'
+name: proof
+on:
+  workflow_dispatch:
+  pull_request_target:
+YAML
+cat >"$SCRATCH/quoted-pull-request-target.yml" <<'YAML'
+name: proof
+on:
+  workflow_dispatch:
+  "pull_request_target":
+YAML
+cat >"$SCRATCH/flow-pull-request-target.yml" <<'YAML'
+name: proof
+on: { workflow_dispatch: null, "pull_request_target": null }
+YAML
+cat >"$SCRATCH/schedule.yml" <<'YAML'
+name: proof
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * *'
+YAML
+cat >"$SCRATCH/workflow-run.yml" <<'YAML'
+name: proof
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["repo-lint"]
+    types: [completed]
+YAML
+cat >"$SCRATCH/checkout-persist-disabled.yml" <<'YAML'
+name: proof
+on:
+  workflow_dispatch:
+jobs:
+  op-service-account-proof:
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+YAML
+cat >"$SCRATCH/checkout-persist-decoy.yml" <<'YAML'
+name: proof
+on:
+  workflow_dispatch:
+jobs:
+  op-service-account-proof:
+    steps:
+      - name: Decoy
+        run: 'echo "persist-credentials: false"'
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+YAML
+cat >"$SCRATCH/checkout-persist-second-missing.yml" <<'YAML'
+name: proof
+on:
+  workflow_dispatch:
+jobs:
+  op-service-account-proof:
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+YAML
+cat >"$SCRATCH/checkout-persist-other-job-missing.yml" <<'YAML'
+name: proof
+on:
+  workflow_dispatch:
+jobs:
+  op-service-account-proof:
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+  later-proof:
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+YAML
+
+assert_workflow_dispatch_only "$SCRATCH/dispatch-only.yml"
+assert_rejects_non_manual_trigger_fixture "$SCRATCH/pull-request-target.yml" "pull_request_target"
+assert_rejects_non_manual_trigger_fixture "$SCRATCH/quoted-pull-request-target.yml" "quoted pull_request_target"
+assert_rejects_non_manual_trigger_fixture "$SCRATCH/flow-pull-request-target.yml" "flow-style pull_request_target"
+assert_rejects_non_manual_trigger_fixture "$SCRATCH/schedule.yml" "schedule"
+assert_rejects_non_manual_trigger_fixture "$SCRATCH/workflow-run.yml" "workflow_run"
+assert_checkout_disables_credential_persistence "$SCRATCH/checkout-persist-disabled.yml"
+assert_rejects_checkout_credential_fixture "$SCRATCH/checkout-persist-decoy.yml" "decoy persist-credentials"
+assert_rejects_checkout_credential_fixture "$SCRATCH/checkout-persist-second-missing.yml" "second checkout without persist-credentials"
+assert_rejects_checkout_credential_fixture "$SCRATCH/checkout-persist-other-job-missing.yml" "checkout in another job without persist-credentials"
+
+assert_checkout_disables_credential_persistence "$WORKFLOW"
+grep -q 'OP_SERVICE_ACCOUNT_TOKEN: \${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}' "$WORKFLOW" \
+  || fail "workflow must read OP_SERVICE_ACCOUNT_TOKEN from Actions secrets"
+grep -q 'OP_PREFLIGHT_REVIEWER_PAT_REF: \${{ vars.OP_PREFLIGHT_REVIEWER_PAT_REF }}' "$WORKFLOW" \
+  || fail "workflow must read reviewer PAT reference from Actions variables"
+grep -q 'OP_PREFLIGHT_CANARY_REF: \${{ vars.OP_PREFLIGHT_CANARY_REF }}' "$WORKFLOW" \
+  || fail "workflow must read canary reference from Actions variables"
+grep -q 'OP_PREFLIGHT_CANARY_SHA256: \${{ secrets.OP_PREFLIGHT_CANARY_SHA256 }}' "$WORKFLOW" \
+  || fail "workflow must compare canary via secret SHA-256 digest"
+grep -q 'OP_PREFLIGHT_REVIEWER_PAT_REF must be an op:// secret reference' "$WORKFLOW" \
+  || fail "workflow must validate reviewer PAT reference shape"
+grep -q 'OP_PREFLIGHT_CANARY_REF must be an op:// secret reference' "$WORKFLOW" \
+  || fail "workflow must validate canary reference shape"
+grep -q 'OP_PREFLIGHT_REVIEWER_PAT_REF cannot point to Private or Personal vaults' "$WORKFLOW" \
+  || fail "workflow must reject reviewer PAT references in Private/Personal vaults"
+grep -q 'OP_PREFLIGHT_CANARY_REF cannot point to Private or Personal vaults' "$WORKFLOW" \
+  || fail "workflow must reject canary references in Private/Personal vaults"
+grep -q 'op read "$OP_PREFLIGHT_CANARY_REF"' "$WORKFLOW" \
+  || fail "workflow must perform a scoped op read canary proof"
+grep -q 'scripts/op-preflight.sh --agent codex --mode review' "$WORKFLOW" \
+  || fail "workflow must exercise op-preflight token mode"
+grep -q 'scripts/op-preflight.sh --agent codex --check' "$WORKFLOW" \
+  || fail "workflow must exercise op-preflight --check after token-mode fill"
+grep -q 'gh api user --jq .login' "$WORKFLOW" \
+  || fail "workflow must verify the exported reviewer PAT identity"
+grep -q 'nathanpayne-codex' "$WORKFLOW" \
+  || fail "workflow must compare the reviewer PAT identity to nathanpayne-codex"
+grep -q 'OP_PREFLIGHT_NEGATIVE_SCOPE_REF' "$SETUP_SCRIPT" \
+  || fail "setup helper must require a negative-scope sentinel ref"
+grep -q -- '--negative-scope-ref' "$SETUP_SCRIPT" \
+  || fail "setup helper must expose a CLI flag for the negative-scope sentinel"
+grep -q 'validate_service_account_ref "negative scope ref"' "$SETUP_SCRIPT" \
+  || fail "setup helper must reject Private/Personal negative-scope refs"
+grep -q 'op read "$value" >/dev/null' "$SETUP_SCRIPT" \
+  || fail "setup helper must verify the negative-scope sentinel exists locally"
+grep -q 'negative_scope_check "shared-vault negative sentinel"' "$SETUP_SCRIPT" \
+  || fail "setup helper must prove a shared-vault negative-scope sentinel"
+grep -q 'Reviewer PAT identity OK' "$SETUP_SCRIPT" \
+  || fail "setup helper must verify reviewer PAT identity locally"
+
+if grep -Eq 'echo "\$canary"|echo "\$\{canary' "$WORKFLOW"; then
+  fail "workflow must not print the canary value"
+fi
+
+run_setup_helper_smoke_tests() {
+  local stub_dir active_file
+  stub_dir="$SCRATCH/setup-stubs"
+  active_file="$SCRATCH/gh-active"
+  mkdir -p "$stub_dir"
+  printf '%s\n' "nathanpayne-codex" >"$active_file"
+
+  cat >"$stub_dir/op" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" != "read" ]; then
+  echo "unexpected op command: $*" >&2
+  exit 64
+fi
+
+ref="${2:-}"
+if [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
+  case "$ref" in
+    op://Proof/Canary/password) printf '%s\n' "canary-value" ;;
+    op://Proof/nathanpayne-codex\ reviewer\ PAT/token) printf '%s\n' "reviewer-pat-codex" ;;
+    op://Proof/nathanpayne-claude\ reviewer\ PAT/token) printf '%s\n' "reviewer-pat-claude" ;;
+    *) exit 1 ;;
+  esac
+else
+  case "$ref" in
+    op://ScopeSentinel/Out\ Of\ Scope/password) printf '%s\n' "sentinel-value" ;;
+    *) exit 1 ;;
+  esac
+fi
+SH
+  chmod +x "$stub_dir/op"
+
+  cat >"$stub_dir/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+active_file="${GH_STUB_ACTIVE_FILE:?}"
+case "${1:-}" in
+  config)
+    if [ "${2:-}" = "get" ]; then
+      cat "$active_file"
+      exit 0
+    fi
+    ;;
+  auth)
+    if [ "${2:-}" = "switch" ] && [ "${3:-}" = "-u" ] && [ -n "${4:-}" ]; then
+      printf '%s\n' "$4" >"$active_file"
+      exit 0
+    fi
+    ;;
+  api)
+    if [ "${2:-}" = "user" ]; then
+      case "${GH_TOKEN:-}" in
+        reviewer-pat-codex) printf '%s\n' "nathanpayne-codex" ;;
+        reviewer-pat-claude) printf '%s\n' "nathanpayne-claude" ;;
+        *) printf '%s\n' "unknown-token" ;;
+      esac
+      exit 0
+    fi
+    ;;
+  secret|variable)
+    if [ "${2:-}" = "set" ]; then
+      cat >/dev/null
+      exit 0
+    fi
+    ;;
+  workflow)
+    if [ "${2:-}" = "run" ]; then
+      exit 0
+    fi
+    ;;
+  run)
+    if [ "${2:-}" = "list" ]; then
+      printf '%s\n' "[]"
+      exit 0
+    fi
+    ;;
+esac
+
+echo "unexpected gh command: $*" >&2
+exit 64
+SH
+  chmod +x "$stub_dir/gh"
+
+  local out err rc
+  out="$SCRATCH/setup-success.out"
+  err="$SCRATCH/setup-success.err"
+  PATH="$stub_dir:$PATH" \
+    GH_STUB_ACTIVE_FILE="$active_file" \
+    OP_SERVICE_ACCOUNT_TOKEN="service-token" \
+    "$SETUP_SCRIPT" \
+      --yes \
+      --skip-run \
+      --no-watch \
+      --reviewer-pat-ref "op://Proof/nathanpayne-codex reviewer PAT/token" \
+      --canary-ref "op://Proof/Canary/password" \
+      --negative-scope-ref "op://ScopeSentinel/Out Of Scope/password" \
+      >"$out" 2>"$err" \
+    || fail "setup helper smoke test should succeed; stderr=$(cat "$err")"
+  grep -q 'Reviewer PAT identity OK: nathanpayne-codex' "$err" \
+    || fail "setup helper smoke test did not verify reviewer identity"
+  grep -q 'Scope check OK: service account cannot read shared-vault negative sentinel' "$err" \
+    || fail "setup helper smoke test did not prove the shared-vault sentinel"
+
+  rc=0
+  PATH="$stub_dir:$PATH" \
+    GH_STUB_ACTIVE_FILE="$active_file" \
+    OP_SERVICE_ACCOUNT_TOKEN="service-token" \
+    "$SETUP_SCRIPT" \
+      --yes \
+      --skip-run \
+      --no-watch \
+      --reviewer-pat-ref "op://Proof/nathanpayne-codex reviewer PAT/token" \
+      --canary-ref "op://Proof/Canary/password" \
+      >"$SCRATCH/setup-missing-sentinel.out" 2>"$SCRATCH/setup-missing-sentinel.err" \
+    || rc=$?
+  [ "$rc" -ne 0 ] || fail "setup helper must reject missing negative-scope sentinel"
+  grep -q 'OP_PREFLIGHT_NEGATIVE_SCOPE_REF or --negative-scope-ref is required' "$SCRATCH/setup-missing-sentinel.err" \
+    || fail "setup helper missing-sentinel diagnostic not found"
+
+  rc=0
+  PATH="$stub_dir:$PATH" \
+    GH_STUB_ACTIVE_FILE="$active_file" \
+    OP_SERVICE_ACCOUNT_TOKEN="service-token" \
+    "$SETUP_SCRIPT" \
+      --yes \
+      --skip-run \
+      --no-watch \
+      --reviewer-pat-ref "op://Proof/nathanpayne-codex reviewer PAT/token" \
+      --canary-ref "op://Proof/Canary/password" \
+      --negative-scope-ref "op://Private/Out Of Scope/password" \
+      >"$SCRATCH/setup-private-sentinel.out" 2>"$SCRATCH/setup-private-sentinel.err" \
+    || rc=$?
+  [ "$rc" -ne 0 ] || fail "setup helper must reject Private negative-scope sentinel"
+  grep -q 'negative scope ref cannot point to Private or Personal vaults' "$SCRATCH/setup-private-sentinel.err" \
+    || fail "setup helper Private-sentinel diagnostic not found"
+
+  rc=0
+  PATH="$stub_dir:$PATH" \
+    GH_STUB_ACTIVE_FILE="$active_file" \
+    OP_SERVICE_ACCOUNT_TOKEN="service-token" \
+    "$SETUP_SCRIPT" \
+      --yes \
+      --skip-run \
+      --no-watch \
+      --reviewer-pat-ref "op://Proof/nathanpayne-claude reviewer PAT/token" \
+      --canary-ref "op://Proof/Canary/password" \
+      --negative-scope-ref "op://ScopeSentinel/Out Of Scope/password" \
+      >"$SCRATCH/setup-wrong-reviewer.out" 2>"$SCRATCH/setup-wrong-reviewer.err" \
+    || rc=$?
+  [ "$rc" -ne 0 ] || fail "setup helper must reject mispointed reviewer PAT"
+  grep -q 'reviewer PAT ref resolved to nathanpayne-claude, expected nathanpayne-codex' "$SCRATCH/setup-wrong-reviewer.err" \
+    || fail "setup helper reviewer-identity diagnostic not found"
+}
+
+run_setup_helper_smoke_tests
+
+echo "check_onepassword_headless_proof_workflow: PASS"

--- a/scripts/ci/check_op_firebase_deploy_integration
+++ b/scripts/ci/check_op_firebase_deploy_integration
@@ -32,12 +32,18 @@
 #        log: "source credential: explicit GOOGLE_APPLICATION_CREDENTIALS ..."
 #   1. project SA key present → rank 2 wins
 #        log: "source credential: project Firebase-vault SA key ..."
-#   2. project SA absent + preflight ADC present → rank 3 wins
+#   2. preflight-cached project SA key present → rank 2 wins without
+#      re-reading 1Password
+#        log: "source credential: preflight-cached project Firebase-vault SA key ..."
+#   3. preflight-cached project SA key for a different project is
+#      ignored, then current project SA key wins
+#        log: "source credential: project Firebase-vault SA key ..."
+#   4. project SA absent + preflight ADC present → rank 3 wins
 #        log: "source credential: preflight-injected ADC ..."
-#   3. project SA absent + preflight absent + shared op ADC reachable
+#   5. project SA absent + preflight absent + shared op ADC reachable
 #      → rank 4 wins
 #        log: "source credential: shared 1Password ADC ..."
-#   4. all op sources absent + local ADC file present → rank 5 wins
+#   6. all op sources absent + local ADC file present → rank 5 wins
 #        log: "source credential: local ADC file ..."
 #
 # Not covered (deliberate): the usability-fallback walk (rank-N
@@ -463,7 +469,102 @@ run_case \
   provision_project_sa
 
 # ----------------------------------------------------------------------
-# Case 2 — project SA absent, preflight ADC present (rank 3 wins)
+# Case 2 — preflight-cached project SA key present (rank 2 wins
+#          without re-reading 1Password)
+# ----------------------------------------------------------------------
+provision_preflight_cached_project_sa() {
+  local case_dir="$1" bin_dir="$2" tmp_dir="$3" home_dir="$4" project="$5"
+
+  local preflight_sa_path="$tmp_dir/preflight-firebase-sa.json"
+  write_fake_sa_key "$preflight_sa_path" \
+    "firebase-deployer@${project}.iam.gserviceaccount.com"
+
+  # Any op call means the cached preflight SA marker was not honored.
+  cat >"$bin_dir/op" <<'STUB'
+#!/usr/bin/env bash
+echo "FATAL: op should not be called when preflight-cached Firebase SA is valid: $*" >&2
+exit 99
+STUB
+  chmod +x "$bin_dir/op"
+
+  cat >"$case_dir/case-env.sh" <<ENV
+export GOOGLE_APPLICATION_CREDENTIALS="$preflight_sa_path"
+export OP_PREFLIGHT_FIREBASE_SA_TMPFILE="$preflight_sa_path"
+export OP_PREFLIGHT_FIREBASE_PROJECT="$project"
+unset OP_PREFLIGHT_ADC_TMPFILE
+ENV
+}
+
+run_case_with_env \
+  "case2_preflight_cached_project_sa" \
+  "source credential: preflight-cached project Firebase-vault SA key" \
+  "merge-path-test" \
+  provision_preflight_cached_project_sa
+
+# ----------------------------------------------------------------------
+# Case 3 — preflight-cached project SA key for a different project is
+#          ignored, then current project SA key wins
+# ----------------------------------------------------------------------
+provision_mismatched_preflight_cached_project_sa() {
+  local case_dir="$1" bin_dir="$2" tmp_dir="$3" home_dir="$4" project="$5"
+
+  local preflight_sa_path="$tmp_dir/preflight-other-project-sa.json"
+  write_fake_sa_key "$preflight_sa_path" \
+    "firebase-deployer@other-project.iam.gserviceaccount.com"
+
+  local sa_payload_dir="$case_dir/op-payloads"
+  mkdir -p "$sa_payload_dir"
+  write_fake_sa_key "$sa_payload_dir/project-sa.json" \
+    "firebase-deployer@${project}.iam.gserviceaccount.com"
+
+  cat >"$bin_dir/op" <<STUB
+#!/usr/bin/env bash
+case "\$1" in
+  document)
+    shift
+    if [ "\$1" = "get" ]; then
+      shift
+      out_path=""
+      while [ \$# -gt 0 ]; do
+        if [ "\$1" = "--out-file" ]; then
+          shift; out_path="\$1"
+        fi
+        shift || true
+      done
+      if [ -n "\$out_path" ]; then
+        cp "$sa_payload_dir/project-sa.json" "\$out_path"
+        exit 0
+      fi
+      exit 1
+    fi
+    exit 1
+    ;;
+  read)
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$bin_dir/op"
+
+  cat >"$case_dir/case-env.sh" <<ENV
+export GOOGLE_APPLICATION_CREDENTIALS="$preflight_sa_path"
+export OP_PREFLIGHT_FIREBASE_SA_TMPFILE="$preflight_sa_path"
+export OP_PREFLIGHT_FIREBASE_PROJECT="other-project"
+unset OP_PREFLIGHT_ADC_TMPFILE
+ENV
+}
+
+run_case_with_env \
+  "case3_mismatched_preflight_cached_project_sa" \
+  "source credential: project Firebase-vault SA key" \
+  "merge-path-test" \
+  provision_mismatched_preflight_cached_project_sa
+
+# ----------------------------------------------------------------------
+# Case 4 — project SA absent, preflight ADC present (rank 3 wins)
 # ----------------------------------------------------------------------
 provision_preflight_adc() {
   local case_dir="$1" bin_dir="$2" tmp_dir="$3" home_dir="$4" project="$5"
@@ -498,13 +599,13 @@ ENV
 }
 
 run_case_with_env \
-  "case2_preflight_adc_present" \
+  "case4_preflight_adc_present" \
   "source credential: preflight-injected ADC" \
   "merge-path-test" \
   provision_preflight_adc
 
 # ----------------------------------------------------------------------
-# Case 3 — project SA absent, preflight absent, shared 1Password ADC
+# Case 5 — project SA absent, preflight absent, shared 1Password ADC
 # reachable (rank 4 wins)
 # ----------------------------------------------------------------------
 provision_shared_op_adc() {
@@ -539,13 +640,13 @@ STUB
 }
 
 run_case \
-  "case3_shared_op_adc_present" \
+  "case5_shared_op_adc_present" \
   "source credential: shared 1Password ADC" \
   "merge-path-test" \
   provision_shared_op_adc
 
 # ----------------------------------------------------------------------
-# Case 4 — all op sources absent, local ADC file present (rank 5 wins)
+# Case 6 — all op sources absent, local ADC file present (rank 5 wins)
 # ----------------------------------------------------------------------
 provision_local_adc() {
   local case_dir="$1" bin_dir="$2" tmp_dir="$3" home_dir="$4" project="$5"
@@ -564,7 +665,7 @@ STUB
 }
 
 run_case \
-  "case4_local_adc_present" \
+  "case6_local_adc_present" \
   "source credential: local ADC file" \
   "merge-path-test" \
   provision_local_adc

--- a/scripts/ci/check_op_preflight_contract
+++ b/scripts/ci/check_op_preflight_contract
@@ -18,6 +18,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 TESTS=(
   "tests/test_op_preflight_check.sh"
+  "tests/test_op_preflight_token_mode.sh"
   "tests/test_helper_autosource.sh"
 )
 

--- a/scripts/ci/check_pr_audit_codex_clearance
+++ b/scripts/ci/check_pr_audit_codex_clearance
@@ -168,6 +168,28 @@ else
   echo "  FAIL: $WORKFLOW must call pulls.listReviews via github.paginate with per_page:100 (PR #255 P2)" >&2
 fi
 
+# Structural assertion: merge-time label checks must be derived from
+# issue label events, not from pr.labels. `pr.labels` is current state
+# at audit time, so a blocking label present during merge but removed
+# afterward would be missed.
+if grep -qF 'async function labelWasPresentAtMerge' "$WORKFLOW" && \
+   grep -qF 'github.rest.issues.listEvents,' "$WORKFLOW" && \
+   grep -qF "await labelWasPresentAtMerge(" "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW reconstructs blocking-label state from issue events at merge time"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW must reconstruct blocking-label state from issue events at merge time" >&2
+fi
+
+if grep -qF "l => l.name === 'human-hold'" "$WORKFLOW"; then
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW still checks human-hold via current pr.labels" >&2
+else
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW no longer checks human-hold via current pr.labels"
+fi
+
 echo
 if [ "$fail" -gt 0 ]; then
   echo "check_pr_audit_codex_clearance: $fail FAIL / $pass PASS" >&2

--- a/scripts/ci/check_pr_audit_sync_exemption
+++ b/scripts/ci/check_pr_audit_sync_exemption
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# check_pr_audit_sync_exemption — regression coverage for the
+# propagation-PR exemption in .github/workflows/pr-audit.yml.
+#
+# Issue #374 Pattern C: sync-all PRs use titles like
+# "sync: bulk reconcile to mergepath@b12e7d7" while the audit used to
+# require the parenthesized per-commit form "(mergepath@b12e7d7)".
+# The title marker is corroborating only; the trusted author,
+# same-repo head, and mergepath-sync/* branch guards remain required.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+WORKFLOW=".github/workflows/pr-audit.yml"
+
+if [ ! -e "$WORKFLOW" ]; then
+  echo "check_pr_audit_sync_exemption: missing $WORKFLOW" >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "check_pr_audit_sync_exemption: SKIP — node not on PATH" >&2
+  exit 0
+fi
+
+RUNNER=$(cat <<'NODE_EOF'
+const authorIdentity = 'nathanjohnpayne';
+const context = { repo: { owner: 'nathanjohnpayne', repo: 'matchline' } };
+
+function isMergepathSyncPR(pr) {
+  const isTrustedSyncAuthor =
+    pr.user && pr.user.login === authorIdentity;
+  const isSameRepoHead =
+    pr.head && pr.head.repo &&
+    pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
+  const hasSyncBranchName =
+    pr.head && pr.head.ref &&
+    pr.head.ref.startsWith('mergepath-sync/');
+  const hasMergepathMarker =
+    /\bmergepath@[0-9a-f]{7,40}\b/.test(pr.title || '');
+  return Boolean(
+    isTrustedSyncAuthor &&
+    isSameRepoHead &&
+    hasSyncBranchName &&
+    hasMergepathMarker
+  );
+}
+
+function pr({ title, author = authorIdentity, headRef = 'mergepath-sync/sync-all-b12e7d7', headRepo = 'nathanjohnpayne/matchline' }) {
+  return {
+    title,
+    user: { login: author },
+    head: {
+      ref: headRef,
+      repo: { full_name: headRepo },
+    },
+  };
+}
+
+const cases = [
+  {
+    name: 'sync-all title without parentheses is exempt when all provenance guards match',
+    expected: true,
+    pr: pr({ title: 'sync: bulk reconcile to mergepath@b12e7d7' }),
+  },
+  {
+    name: 'per-commit parenthesized title remains exempt',
+    expected: true,
+    pr: pr({ title: 'sync: update helper (mergepath@b12e7d7)', headRef: 'mergepath-sync/b12e7d7' }),
+  },
+  {
+    name: 'ordinary branch mentioning mergepath marker is not exempt',
+    expected: false,
+    pr: pr({ title: 'docs: mention mergepath@b12e7d7 in notes', headRef: 'feature/mentions-mergepath' }),
+  },
+  {
+    name: 'wrong author with sync branch and marker is not exempt',
+    expected: false,
+    pr: pr({ title: 'sync: bulk reconcile to mergepath@b12e7d7', author: 'nathanpayne-codex' }),
+  },
+  {
+    name: 'fork head with sync branch and marker is not exempt',
+    expected: false,
+    pr: pr({ title: 'sync: bulk reconcile to mergepath@b12e7d7', headRepo: 'somebody/matchline' }),
+  },
+  {
+    name: 'sync branch without mergepath marker is not exempt',
+    expected: false,
+    pr: pr({ title: 'sync: bulk reconcile latest templates' }),
+  },
+];
+
+let failures = 0;
+for (const tc of cases) {
+  const actual = isMergepathSyncPR(tc.pr);
+  if (actual === tc.expected) {
+    console.log(`  PASS: ${tc.name}`);
+  } else {
+    failures += 1;
+    console.error(`  FAIL: ${tc.name} (expected=${tc.expected}, actual=${actual})`);
+  }
+}
+
+process.exit(failures === 0 ? 0 : 1);
+NODE_EOF
+)
+
+pass=0
+fail=0
+
+if node -e "$RUNNER"; then
+  pass=$((pass + 1))
+else
+  fail=$((fail + 1))
+fi
+
+if grep -qF '\bmergepath@[0-9a-f]{7,40}\b' "$WORKFLOW"; then
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW accepts mergepath@<sha> title markers with or without parentheses"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW must use the relaxed mergepath@<sha> title marker regex" >&2
+fi
+
+if grep -qF '\(mergepath@[0-9a-f]{7,40}\)' "$WORKFLOW"; then
+  fail=$((fail + 1))
+  echo "  FAIL: $WORKFLOW still carries the old parenthesis-required marker regex" >&2
+else
+  pass=$((pass + 1))
+  echo "  PASS: $WORKFLOW no longer requires parentheses around mergepath@<sha>"
+fi
+
+echo
+if [ "$fail" -gt 0 ]; then
+  echo "check_pr_audit_sync_exemption: $fail FAIL / $pass PASS" >&2
+  exit 1
+fi
+echo "check_pr_audit_sync_exemption: PASS ($pass test groups)"

--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -55,6 +55,35 @@ assert_eq() {
   fi
 }
 
+workflow_guard_block_contains_exit() {
+  local file="$1" guard="$2" required="$3"
+  WORKFLOW_GUARD="$guard" WORKFLOW_REQUIRED="$required" awk '
+    BEGIN {
+      guard = ENVIRON["WORKFLOW_GUARD"]
+      required = ENVIRON["WORKFLOW_REQUIRED"]
+    }
+    /^[[:space:]]*#/ {
+      next
+    }
+    index($0, guard) {
+      in_block = 1
+      saw_guard = 1
+    }
+    in_block && index($0, required) {
+      saw_required = 1
+    }
+    in_block && /^[[:space:]]*exit[[:space:]]+1([[:space:]]|$)/ {
+      saw_exit = 1
+    }
+    in_block && /^[[:space:]]*fi[[:space:]]*$/ {
+      exit
+    }
+    END {
+      exit (saw_guard && saw_required && saw_exit) ? 0 : 1
+    }
+  ' "$file"
+}
+
 # Classify a phase_4b_default value read from review-policy.yml.
 # Echoes "valid" or "invalid".
 #
@@ -70,6 +99,13 @@ assert_eq() {
 classify_phase_4b() {
   case "$1" in
     ""|fallback-only|complex-changes|always) echo "valid" ;;
+    *) echo "invalid" ;;
+  esac
+}
+
+classify_boolean() {
+  case "$1" in
+    ""|true|false) echo "valid" ;;
     *) echo "invalid" ;;
   esac
 }
@@ -224,6 +260,74 @@ fi
 rm -f "$manifest_fixture" "$manifest_notype"
 
 echo
+echo "codex_field (codex block scalar) tests — for codex.enabled (#362)"
+
+real_policy="$ROOT/.github/review-policy.yml"
+
+# Inline copy of the same awk codex_field uses inside
+# scripts/codex-review-check.sh. Keeping the test in lockstep with the
+# parser shape — if the parser changes, this awk literal needs the same
+# update. Documented inline rather than sourced from the script because
+# sourcing codex-review-check.sh runs its full top-level logic.
+codex_field_awk='
+  /^codex:/ {in_block=1; next}
+  in_block && /^[^[:space:]#]/ {in_block=0}
+  in_block && $1 == field":" {
+    sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+    gsub(/^["\047]/, "", $0)
+    gsub(/["\047][[:space:]]*(#.*)?$/, "", $0)
+    gsub(/[[:space:]]*#.*$/, "", $0)
+    sub(/[[:space:]]+$/, "", $0)
+    print
+    exit
+  }
+'
+
+got=$(printf 'codex:\n  enabled: false\n' | awk -v field="enabled" "$codex_field_awk")
+assert_eq "codex_field reads codex.enabled=false" "false" "$got"
+
+got=$(printf 'codex:\n  enabled: true   # Codex app lane on\n' | awk -v field="enabled" "$codex_field_awk")
+assert_eq "codex_field strips trailing comments from codex.enabled" "true" "$got"
+
+got=$(printf 'enabled: false\ncodex:\n  enabled: true\n' | awk -v field="enabled" "$codex_field_awk")
+assert_eq "codex_field ignores same-named top-level field" "true" "$got"
+
+got=$(printf 'codex:\n  enabled: "false"\n' | awk -v field="enabled" "$codex_field_awk")
+assert_eq "codex_field strips double quotes" "false" "$got"
+
+got=$(printf "%s\n" "codex:" "  enabled: 'false'" | awk -v field="enabled" "$codex_field_awk")
+assert_eq "codex_field strips single quotes" "false" "$got"
+
+got=$(printf 'coderabbit:\n  enabled: false\n' | awk -v field="enabled" "$codex_field_awk")
+assert_eq "codex_field returns empty when codex block missing" "" "$got"
+
+real_has_codex_enabled=0
+if awk '
+  /^codex:/ {in_block=1; next}
+  in_block && /^[^[:space:]#]/ {in_block=0}
+  in_block && $1 == "enabled:" {found=1}
+  END {exit found ? 0 : 1}
+' "$real_policy"; then
+  real_has_codex_enabled=1
+fi
+
+got=$(awk -v field="enabled" "$codex_field_awk" "$real_policy")
+if [ -z "$got" ] && [ "$real_has_codex_enabled" -eq 1 ]; then
+  fail=$((fail + 1))
+  echo "  FAIL: real .github/review-policy.yml contains codex.enabled, but codex_field returned empty" >&2
+elif [ "$(classify_boolean "$got")" = "valid" ]; then
+  pass=$((pass + 1))
+  if [ -z "$got" ]; then
+    echo "  PASS: real .github/review-policy.yml has no codex.enabled (valid — defaults to true)"
+  else
+    echo "  PASS: real .github/review-policy.yml has a valid codex.enabled value ('$got')"
+  fi
+else
+  fail=$((fail + 1))
+  echo "  FAIL: real .github/review-policy.yml codex.enabled is set to an unrecognized value (got '$got'; expected true / false, or absent for the true default)" >&2
+fi
+
+echo
 echo "policy_field (top-level scalar) tests — for phase_4b_default (#185)"
 
 # Inline copy of the same awk policy_field uses inside
@@ -234,8 +338,8 @@ echo "policy_field (top-level scalar) tests — for phase_4b_default (#185)"
 policy_field_awk='
   /^[^[:space:]]/ && $1 == field":" {
     sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
-    gsub(/^"/, "", $0)
-    gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+    gsub(/^["\047]/, "", $0)
+    gsub(/["\047][[:space:]]*(#.*)?$/, "", $0)
     gsub(/[[:space:]]*#.*$/, "", $0)
     sub(/[[:space:]]+$/, "", $0)
     print
@@ -263,6 +367,10 @@ assert_eq "policy_field reads field amid other top-level fields" "fallback-only"
 # Fixture: field with double quotes (matches the parser's quote-stripping).
 got=$(printf '%s\n' 'phase_4b_default: "complex-changes"' | awk -v field="phase_4b_default" "$policy_field_awk")
 assert_eq "policy_field strips surrounding quotes" "complex-changes" "$got"
+
+# Fixture: field with single quotes (same quote-stripping path).
+got=$(printf "%s\n" "phase_4b_default: 'complex-changes'" | awk -v field="phase_4b_default" "$policy_field_awk")
+assert_eq "policy_field strips single quotes" "complex-changes" "$got"
 
 # Regression: nested same-named key under a parent block must NOT match
 # (Codex P2 on PR #189 — top-level lookup should be anchored to the
@@ -314,6 +422,212 @@ elif [ "$(classify_phase_4b "$got")" = "valid" ]; then
 else
   fail=$((fail + 1))
   echo "  FAIL: real .github/review-policy.yml phase_4b_default is set to an unrecognized value (got '$got'; expected one of fallback-only / complex-changes / always, or absent for the fallback-only default)"
+fi
+
+echo
+echo "agent-review.yml blocking-label exact-match regression (#370)"
+
+# The pre-merge recheck must treat GitHub labels as an array of exact
+# names. A CSV join plus `case "*,human-hold,*"` false-matches a legal
+# label literally named `team,human-hold`, which can block unrelated PRs.
+workflow_label_query=$(grep -F -- "--jq '.labels[].name'" ".github/workflows/agent-review.yml" || true)
+if [ -n "$workflow_label_query" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: agent-review pre-merge recheck reads labels one per line"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: agent-review pre-merge recheck must read labels one per line with --jq '.labels[].name'" >&2
+fi
+
+legacy_csv_join=$(grep -F -- "--jq '[.labels[].name] | join(\",\")'" ".github/workflows/agent-review.yml" || true)
+if [ -z "$legacy_csv_join" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: agent-review pre-merge recheck does not collapse labels into CSV"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: agent-review pre-merge recheck still collapses labels into CSV" >&2
+  echo "$legacy_csv_join" | sed 's/^/    /' >&2
+fi
+
+exact_label_match=$(grep -F 'grep -Fxq "$blocking_label"' ".github/workflows/agent-review.yml" || true)
+if [ -n "$exact_label_match" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: agent-review pre-merge recheck uses fixed-string whole-line label matching"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: agent-review pre-merge recheck must use grep -Fxq for exact label names" >&2
+fi
+
+echo
+echo "agent-review.yml author-token auto-merge regression (#359)"
+
+agent_review_workflow=".github/workflows/agent-review.yml"
+if grep -Fq "secrets.AUTHOR_MERGE_TOKEN" "$agent_review_workflow"; then
+  pass=$((pass + 1))
+  echo "  PASS: agent-review auto-merge references AUTHOR_MERGE_TOKEN"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: agent-review auto-merge must use an author-owned AUTHOR_MERGE_TOKEN, not the reviewer assignment token" >&2
+fi
+
+if grep -Fq "AUTHOR_MERGE_TOKEN resolves to" "$agent_review_workflow"; then
+  pass=$((pass + 1))
+  echo "  PASS: agent-review verifies AUTHOR_MERGE_TOKEN identity before merge"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: agent-review must verify AUTHOR_MERGE_TOKEN resolves to author_identity before merge" >&2
+fi
+
+author_identity_awk='
+  /^[^[:space:]]/ && $1 == "author_identity:" {
+    sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
+    gsub(/^"/, "", $0)
+    gsub(/^\047/, "", $0)
+    gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+    gsub(/\047[[:space:]]*(#.*)?$/, "", $0)
+    gsub(/[[:space:]]*#.*$/, "", $0)
+    sub(/[[:space:]]+$/, "", $0)
+    print
+    exit
+  }
+'
+got=$(printf '%s\n' "author_identity: nathanjohnpayne" | awk "$author_identity_awk")
+assert_eq "author_identity parser reads bare value" "nathanjohnpayne" "$got"
+
+got=$(printf '%s\n' 'author_identity: "nathanjohnpayne"' | awk "$author_identity_awk")
+assert_eq "author_identity parser strips double quotes" "nathanjohnpayne" "$got"
+
+got=$(printf '%s\n' "author_identity: 'nathanjohnpayne'" | awk "$author_identity_awk")
+assert_eq "author_identity parser strips single quotes" "nathanjohnpayne" "$got"
+
+enable_auto_merge_block=$(awk '
+  /- name: Enable auto-merge/ {in_block=1}
+  in_block && /- name:/ && $0 !~ /- name: Enable auto-merge/ {exit}
+  in_block {print}
+' "$agent_review_workflow")
+if printf '%s\n' "$enable_auto_merge_block" | grep -Fq 'GH_TOKEN: ${{ secrets.AUTHOR_MERGE_TOKEN }}'; then
+  pass=$((pass + 1))
+  echo "  PASS: Enable auto-merge step runs under AUTHOR_MERGE_TOKEN"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: Enable auto-merge step must set GH_TOKEN from AUTHOR_MERGE_TOKEN" >&2
+fi
+
+if printf '%s\n' "$enable_auto_merge_block" | grep -Fq 'REVIEWER_ASSIGNMENT_TOKEN'; then
+  fail=$((fail + 1))
+  echo "  FAIL: Enable auto-merge step still references REVIEWER_ASSIGNMENT_TOKEN" >&2
+else
+  pass=$((pass + 1))
+  echo "  PASS: Enable auto-merge step does not use REVIEWER_ASSIGNMENT_TOKEN"
+fi
+
+if printf '%s\n' "$enable_auto_merge_block" | grep -Fq '|| true'; then
+  fail=$((fail + 1))
+  echo "  FAIL: Enable auto-merge step must not swallow merge failures with '|| true'" >&2
+else
+  pass=$((pass + 1))
+  echo "  PASS: Enable auto-merge step does not swallow merge failures with '|| true'"
+fi
+
+echo
+echo "dependabot-auto-merge.yml PR-author gate regression (#370)"
+
+dependabot_workflow=".github/workflows/dependabot-auto-merge.yml"
+if grep -Fq "github.event.pull_request.user.login == 'dependabot[bot]'" "$dependabot_workflow"; then
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot auto-merge gates on pull_request.user.login"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot auto-merge must gate on github.event.pull_request.user.login" >&2
+fi
+
+if grep -Fq "github.actor == 'dependabot[bot]'" "$dependabot_workflow"; then
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot auto-merge still gates on github.actor" >&2
+else
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot auto-merge does not gate on github.actor"
+fi
+
+echo
+echo "dependabot-auto-merge.yml reviewer-token fail-closed regression (#374 Pattern A)"
+
+if workflow_guard_block_contains_exit \
+  "$dependabot_workflow" \
+  'if [ -z "${GH_TOKEN:-}" ]; then' \
+  'GH_TOKEN is empty. REVIEWER_ASSIGNMENT_TOKEN secret is not set'; then
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot auto-merge exits when REVIEWER_ASSIGNMENT_TOKEN is empty"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot auto-merge must fail closed when REVIEWER_ASSIGNMENT_TOKEN/GH_TOKEN is empty" >&2
+fi
+
+if grep -Fq 'ACTING_AS=$(gh api user --jq .login' "$dependabot_workflow" &&
+   workflow_guard_block_contains_exit \
+     "$dependabot_workflow" \
+     'if [ -z "$ACTING_AS" ]; then' \
+     'gh api user returned empty'; then
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot auto-merge exits when REVIEWER_ASSIGNMENT_TOKEN cannot resolve an identity"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot auto-merge must fail closed when REVIEWER_ASSIGNMENT_TOKEN cannot resolve an identity" >&2
+fi
+
+if workflow_guard_block_contains_exit \
+  "$dependabot_workflow" \
+  'if [ "$ACTING_AS" = "$PR_AUTHOR" ]; then' \
+  'GitHub blocks self-approval'; then
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot auto-merge exits when the reviewer token resolves to the PR author"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot auto-merge must fail closed when REVIEWER_ASSIGNMENT_TOKEN resolves to the PR author" >&2
+fi
+
+if workflow_guard_block_contains_exit \
+  "$dependabot_workflow" \
+  "if ! printf '%s\\n' \"\$ALLOWED\" | grep -Fxq \"\$ACTING_AS\"; then" \
+  'NOT in $POLICY available_reviewers'; then
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot auto-merge exits when the reviewer token is not allowlisted"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot auto-merge must fail closed when REVIEWER_ASSIGNMENT_TOKEN is not in available_reviewers" >&2
+fi
+
+if grep -Fq "!contains(github.event.pull_request.labels.*.name, 'human-hold')" "$dependabot_workflow"; then
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot auto-merge must not skip the whole job on trigger-time human-hold state" >&2
+else
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot auto-merge leaves human-hold enforcement to the runtime re-read"
+fi
+
+if grep -Fq "has_human_hold()" "$dependabot_workflow"; then
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot auto-merge centralizes human-hold runtime checks"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot auto-merge must define a reusable has_human_hold runtime check" >&2
+fi
+
+if grep -Fq 'if ! labels=$(gh pr view "$PR_URL" --json labels --jq' "$dependabot_workflow"; then
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot human-hold lookup fails closed on label-read errors"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot human-hold lookup must fail closed when gh pr view cannot read labels" >&2
+fi
+
+hold_recheck_count=$(grep -Fc "if has_human_hold; then" "$dependabot_workflow" || true)
+if [ "$hold_recheck_count" -ge 3 ]; then
+  pass=$((pass + 1))
+  echo "  PASS: Dependabot auto-merge checks human-hold before queued work and both merge paths"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: Dependabot auto-merge must check human-hold before queued work, --auto, and fallback squash (got $hold_recheck_count checks)" >&2
 fi
 
 echo

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -248,10 +248,12 @@ fetch_api_array() {
 }
 
 # Fetch the CodeRabbit `StatusContext` check on the current HEAD SHA.
-# Emits one of: success | failure | pending | error | missing
-# on stdout. `missing` covers both the no-statuses-yet case and any
-# transient API hiccup (network, 5xx, etc.) — caller treats it as
-# "fall through to the existing comment-driven path."
+# Emits compact JSON with:
+#   { "state": "success|failure|pending|error|missing", "created_at": "..." }
+#
+# `missing` covers both the no-statuses-yet case and any transient API
+# hiccup (network, 5xx, etc.) — caller treats it as "fall through to
+# the existing comment-driven path."
 #
 # Two defensive guards (CodeRabbit ⚠️ Critical on PR #224 round 1):
 #
@@ -272,8 +274,8 @@ fetch_api_array() {
 # `/commits/{sha}/status` rolls up state but omits per-status creator
 # fields, which would defeat guard 1. Confirmed empirically — see
 # PR #224 round 2.
-check_status_context() {
-  local resp state
+check_status_context_record() {
+  local resp
   # Pagination (CodeRabbit ⚠️ Minor @ line 267 on PR #224 round 2):
   # `/commits/{ref}/statuses` defaults to per_page=30 and returns
   # statuses in reverse chronological order. Without `--paginate`, a
@@ -284,23 +286,26 @@ check_status_context() {
   # the context+creator filter runs.
   resp=$(gh api --paginate "repos/$REPO/commits/$HEAD_SHA/statuses" 2>/dev/null \
     | jq -s 'add // []' 2>/dev/null) || {
-    echo "missing"
+    jq -nc '{state: "missing", created_at: ""}'
     return
   }
-  state=$(echo "$resp" | jq -r --arg bot "$BOT_LOGIN" '
+  echo "$resp" | jq -c --arg bot "$BOT_LOGIN" '
     [ .[]?
       | select(.context == "CodeRabbit")
       | select((.creator.login // "") == $bot)
     ]
     | sort_by(.created_at)
     | last
-    | .state // ""
-  ')
-  if [ -z "$state" ]; then
-    echo "missing"
-    return
-  fi
-  echo "$state"
+    | if . == null then
+        {state: "missing", created_at: ""}
+      else
+        {state: (.state // "missing"), created_at: (.created_at // "")}
+      end
+  '
+}
+
+check_status_context() {
+  check_status_context_record | jq -r '.state'
 }
 
 # --- fetch PR metadata ------------------------------------------------------
@@ -358,6 +363,7 @@ if [ -n "$LATEST_FORCE_PUSH_TIME" ] && [[ "$LATEST_FORCE_PUSH_TIME" > "$HEAD_ANC
   HEAD_ANCHOR="$LATEST_FORCE_PUSH_TIME"
   ANCHOR_SOURCE="head_ref_force_pushed @ $LATEST_FORCE_PUSH_TIME"
 fi
+HEAD_IDENTITY_ANCHOR="$HEAD_ANCHOR"
 
 # Layer 2 — wallclock freshness floor.
 EPOCH_NOW=$(date +%s)
@@ -422,7 +428,9 @@ classify_comment() {
 }
 
 # Scan the PR-level `issues/{pr}/comments` endpoint for the latest
-# CodeRabbit comment on or after HEAD_ANCHOR. Emits JSON to stdout.
+# CodeRabbit comment on or after HEAD_ANCHOR. CodeRabbit edits its
+# summary comment in place, so freshness is max(created_at, updated_at)
+# rather than created_at alone. Emits JSON to stdout.
 # Empty object {} if nothing qualifying yet.
 #
 # Only the issues endpoint is the terminal-state source. CodeRabbit's
@@ -443,9 +451,10 @@ scan_latest_comment() {
   latest=$(echo "$issue_comments" | jq --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" '
     [ .[]
       | select(.user.login == $bot)
-      | select(.created_at >= $after)
+      | . + {fresh_at: ([.created_at, (.updated_at // .created_at)] | max)}
+      | select(.fresh_at >= $after)
     ]
-    | sort_by(.created_at)
+    | sort_by(.fresh_at)
     | last // null
   ')
 
@@ -453,18 +462,24 @@ scan_latest_comment() {
     echo '{}'
     return
   fi
-  echo "$latest" | jq '{id, created_at, endpoint: "issues", body}'
+  echo "$latest" | jq '{id, created_at, updated_at, fresh_at, endpoint: "issues", body}'
 }
 
-# Count "Potential issue" / ⚠️ markers in the pulls inline comment list,
-# scoped to the LATEST CodeRabbit review on the current HEAD. The
-# naive "all bot comments after HEAD_ANCHOR" shape would keep stale
-# findings from an earlier review round (same HEAD, pre-retry) in the
-# count forever, so a PR could stay permanently in the `findings`
-# state even after the next review comes back clean. Mirror the
-# latest-review-scoping pattern codex-review-request.sh uses via
-# `pull_request_review_id`. See propagation-round Codex finding
-# (P1) on device-platform-reporting#51.
+# Count unaddressed "Potential issue" / ⚠️ markers in the pulls inline
+# comment list, scoped to the LATEST CodeRabbit review on the current
+# HEAD. The naive "all bot comments after HEAD_ANCHOR" shape would keep
+# stale findings from an earlier review round (same HEAD, pre-retry) in
+# the count forever, so a PR could stay permanently in the `findings`
+# state even after the next review comes back clean. Mirror the latest-
+# review-scoping pattern codex-review-request.sh uses via
+# `pull_request_review_id`. See propagation-round Codex finding (P1)
+# on device-platform-reporting#51.
+#
+# CodeRabbit may later reply to a finding thread with its hidden
+# `review_comment_addressed` marker after an agent fixes/rebuts the
+# finding. Treat that bot-authored marker as authoritative for this
+# helper's advisory gate; ordinary human/agent replies do not clear a
+# finding by themselves.
 count_potential_issues() {
   local reviews pulls_comments latest_review_id
   reviews=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/reviews" "reviews")
@@ -488,50 +503,121 @@ count_potential_issues() {
     --argjson review_id "$latest_review_id" '
     [ .[]
       | select(.user.login == $bot)
+      | select(.in_reply_to_id != null)
+      | select((.body // "") | test("review_comment_addressed"; "i"))
+      | .in_reply_to_id
+    ] as $addressed_root_ids
+    | [ .[]
+      | select(.user.login == $bot)
       | select(.pull_request_review_id == $review_id)
+      | select(.in_reply_to_id == null)
       | select((.body // "") | test("Potential issue|⚠️"; "i"))
+      | select(.id as $id | ($addressed_root_ids | index($id)) == null)
     ] | length
   '
 }
 
-# SHA-scoped variant of count_potential_issues, used by the
-# StatusContext fast-path. Counts CodeRabbit inline findings whose
-# `commit_id` (the SHA GitHub considers the comment currently anchored
-# to, after rebases / new commits) equals the given SHA — independent
-# of HEAD_ANCHOR's wallclock floor.
+# SHA-scoped variant of count_potential_issues, used by the StatusContext
+# fast-path. Counts CodeRabbit inline findings whose `commit_id` (the SHA
+# GitHub considers the comment currently anchored to, after rebases / new
+# commits) equals the given SHA and whose creation time is not older than
+# HEAD_IDENTITY_ANCHOR.
 #
 # Why this is needed (codex CHANGES_REQUESTED on PR #224 round 2 +
 # CodeRabbit ⚠️ Major @ line 581): the freshness-anchored count_potential_
-# issues filters reviews with `submitted_at >= HEAD_ANCHOR`. Once the
-# same unchanged HEAD sits longer than `coderabbit.wallclock_freshness_
-# window_seconds` (default 1800s / 30 min), HEAD_ANCHOR advances past
-# the prior CodeRabbit review's submitted_at, latest_review_id becomes
-# null, and the helper returns 0 — false-clearing the fast-path even
-# while the same SHA still has unresolved Potential issue/⚠️ inline
-# findings. The fast-path is the only caller that has authoritative
-# per-SHA scope (from the StatusContext check) and should leverage it.
+# issues filters reviews with `submitted_at >= HEAD_ANCHOR`. Once the same
+# unchanged HEAD sits longer than `coderabbit.wallclock_freshness_window_
+# seconds` (default 1800s / 30 min), HEAD_ANCHOR advances past the prior
+# CodeRabbit review's submitted_at, latest_review_id becomes null, and the
+# helper returns 0 — false-clearing the fast-path even while the same SHA
+# still has unresolved Potential issue/⚠️ inline findings. The fast-path is
+# the only caller that has authoritative per-SHA scope (from the StatusContext
+# check) and should leverage it.
 #
-# Filter shape: inline review comments where the bot author posted a
-# comment whose `commit_id == HEAD_SHA` (i.e., GitHub still considers
+# Why still keep a non-wallclock freshness floor: GitHub can preserve or
+# remap inline review comments across a rebase/force-push so an old comment
+# appears to have `commit_id == HEAD_SHA`. HEAD_IDENTITY_ANCHOR is captured
+# before the moving wallclock floor is applied, so stale pre-head inline
+# comments are ignored without losing genuine old-but-still-current findings
+# on an unchanged head.
+#
+# Filter shape: root inline review comments where the bot author posted
+# a comment whose `commit_id == HEAD_SHA` (i.e., GitHub still considers
 # it applicable to HEAD after any rebases) and whose body contains a
-# `Potential issue` / `⚠️` marker. Resolved-thread state is NOT
-# consulted — same scope as count_potential_issues — so an addressed-
-# but-not-resolved finding will still count. That's the conservative
-# interpretation: "if there's any current-HEAD finding I haven't
-# explicitly resolved, hold the gate."
+# `Potential issue` / `⚠️` marker, excluding roots CodeRabbit itself
+# later marked with `review_comment_addressed`. Resolved-thread state is
+# not consulted directly; the explicit bot marker is the narrow signal
+# that a current-head finding has been addressed without relying on
+# GitHub conversation-resolution state.
 count_potential_issues_for_sha() {
   local sha=$1
   local pulls_comments
   pulls_comments=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/comments" "pulls comments")
   echo "$pulls_comments" | jq \
     --arg bot "$BOT_LOGIN" \
-    --arg sha "$sha" '
+    --arg sha "$sha" \
+    --arg after "$HEAD_IDENTITY_ANCHOR" '
     [ .[]
       | select(.user.login == $bot)
+      | select(.in_reply_to_id != null)
+      | select((.body // "") | test("review_comment_addressed"; "i"))
+      | .in_reply_to_id
+    ] as $addressed_root_ids
+    | [ .[]
+      | select(.user.login == $bot)
       | select(.commit_id == $sha)
+      | select((.created_at // "") >= $after)
+      | select(.in_reply_to_id == null)
       | select((.body // "") | test("Potential issue|⚠️"; "i"))
+      | select(.id as $id | ($addressed_root_ids | index($id)) == null)
     ] | length
   '
+}
+
+iso_on_or_after() {
+  local lhs=$1 rhs=$2 rc
+  if [ -z "$lhs" ] || [ "$lhs" = "null" ] || [ -z "$rhs" ] || [ "$rhs" = "null" ]; then
+    return 0
+  fi
+
+  jq -en --arg lhs "$lhs" --arg rhs "$rhs" \
+    '($lhs | fromdateiso8601) >= ($rhs | fromdateiso8601)' >/dev/null 2>&1
+  rc=$?
+  case "$rc" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+status_context_fast_path_blocked_by_comment() {
+  local status_created_at=$1
+  local latest class comment_id comment_fresh_at comment_body
+  latest=$(scan_latest_comment)
+  if [ "$(echo "$latest" | jq 'length')" = "0" ]; then
+    return 1
+  fi
+
+  class=$(classify_comment "$(echo "$latest" | jq -r '.body')")
+  case "$class" in
+    rate_limit|in_progress)
+      comment_id=$(echo "$latest" | jq -r '.id')
+      comment_fresh_at=$(echo "$latest" | jq -r '.fresh_at // .updated_at // .created_at')
+      comment_body=$(echo "$latest" | jq -r '.body')
+      if printf '%s' "$comment_body" | grep -Fq "$HEAD_SHA"; then
+        if iso_on_or_after "$comment_fresh_at" "$status_created_at"; then
+          log "StatusContext success ignored because latest CodeRabbit comment id=$comment_id class=$class explicitly references current HEAD $HEAD_SHA and fresh_at=$comment_fresh_at is not older than status_created=$status_created_at"
+          return 0
+        fi
+        log "StatusContext success remains authoritative because latest CodeRabbit comment id=$comment_id class=$class explicitly references current HEAD $HEAD_SHA but fresh_at=$comment_fresh_at is older than status_created=$status_created_at"
+        return 1
+      fi
+      log "StatusContext success remains authoritative because latest CodeRabbit comment id=$comment_id class=$class does not reference current HEAD $HEAD_SHA"
+      return 1
+      ;;
+  esac
+
+  return 1
 }
 
 post_retry_trigger() {
@@ -702,11 +788,15 @@ emit_status_context_verdict() {
 # poll burned the full 300s budget on every clean fix-up push because
 # CodeRabbit doesn't re-narrate when there's nothing new to flag.
 if [ "$TRUST_STATUS_CONTEXT" = "true" ]; then
-  INITIAL_CTX=$(check_status_context)
+  INITIAL_CTX_RECORD=$(check_status_context_record)
+  INITIAL_CTX=$(echo "$INITIAL_CTX_RECORD" | jq -r '.state')
+  INITIAL_CTX_CREATED=$(echo "$INITIAL_CTX_RECORD" | jq -r '.created_at')
   log "initial CodeRabbit StatusContext = $INITIAL_CTX on $HEAD_SHA"
   if [ "$INITIAL_CTX" = "success" ]; then
-    log "StatusContext success — entering fast-path verdict (scans inline findings before clearance)"
-    emit_status_context_verdict "$INITIAL_CTX"
+    if ! status_context_fast_path_blocked_by_comment "$INITIAL_CTX_CREATED"; then
+      log "StatusContext success — entering fast-path verdict (scans inline findings before clearance)"
+      emit_status_context_verdict "$INITIAL_CTX"
+    fi
   fi
 fi
 
@@ -723,10 +813,14 @@ while :; do
   # API call than `scan_latest_comment` so it's worth doing first each
   # iteration; falls through to the comment scan if not success/failure.
   if [ "$TRUST_STATUS_CONTEXT" = "true" ]; then
-    LOOP_CTX=$(check_status_context)
+    LOOP_CTX_RECORD=$(check_status_context_record)
+    LOOP_CTX=$(echo "$LOOP_CTX_RECORD" | jq -r '.state')
+    LOOP_CTX_CREATED=$(echo "$LOOP_CTX_RECORD" | jq -r '.created_at')
     if [ "$LOOP_CTX" = "success" ]; then
-      log "CodeRabbit StatusContext flipped to success mid-loop on $HEAD_SHA — entering fast-path verdict"
-      emit_status_context_verdict "$LOOP_CTX"
+      if ! status_context_fast_path_blocked_by_comment "$LOOP_CTX_CREATED"; then
+        log "CodeRabbit StatusContext flipped to success mid-loop on $HEAD_SHA — entering fast-path verdict"
+        emit_status_context_verdict "$LOOP_CTX"
+      fi
     fi
   fi
 
@@ -742,9 +836,10 @@ while :; do
   COMMENT_BODY=$(echo "$LATEST" | jq -r '.body')
   COMMENT_ENDPOINT=$(echo "$LATEST" | jq -r '.endpoint')
   COMMENT_CREATED=$(echo "$LATEST" | jq -r '.created_at')
+  COMMENT_FRESH_AT=$(echo "$LATEST" | jq -r '.fresh_at // .updated_at // .created_at')
 
   CLASS=$(classify_comment "$COMMENT_BODY")
-  log "latest CodeRabbit comment id=$COMMENT_ID endpoint=$COMMENT_ENDPOINT class=$CLASS created=$COMMENT_CREATED"
+  log "latest CodeRabbit comment id=$COMMENT_ID endpoint=$COMMENT_ENDPOINT class=$CLASS created=$COMMENT_CREATED fresh_at=$COMMENT_FRESH_AT"
 
   case "$CLASS" in
     rate_limit)
@@ -771,17 +866,17 @@ while :; do
       SLEEP_FOR=$((WINDOW_SECONDS + RATE_LIMIT_BUFFER_SECONDS))
       # Clamp against remaining budget — if the published rate-limit
       # window exceeds max_wait_seconds anyway, there's no point
-      # burning through the entire sleep only to time out on the next
-      # iteration. Time out immediately instead so the caller sees a
-      # prompt, well-formed timeout rather than a stalled process.
-      # See #140 round-2 Codex finding (P2, line 392).
+      # burning through the entire sleep. Surface it as the same hard
+      # rate-limit stalled state callers already treat as non-advisory
+      # instead of a generic timeout that auto-merge may skip past.
+      # See #140 round-2 Codex finding (P2, line 392), then #386.
       NOW_EPOCH=$(date +%s)
       ELAPSED=$((NOW_EPOCH - START_EPOCH))
       REMAINING=$((MAX_WAIT_SECONDS - ELAPSED))
       if [ "$SLEEP_FOR" -ge "$REMAINING" ]; then
-        log "rate-limit window (${SLEEP_FOR}s) exceeds remaining budget (${REMAINING}s) — timing out"
+        log "rate-limit window (${SLEEP_FOR}s) exceeds remaining budget (${REMAINING}s) — stalling"
         RATE_LIMIT_REVIEW=$(echo "$LATEST" | jq '{id, created_at, endpoint, body_excerpt: (.body[0:200])}')
-        emit_json_and_exit "timeout" 4 "$RATE_LIMIT_REVIEW" 0
+        emit_json_and_exit "rate_limit_stalled" 5 "$RATE_LIMIT_REVIEW" 0
       fi
       log "rate-limited; sleeping ${SLEEP_FOR}s (window=${WINDOW_SECONDS}s + ${RATE_LIMIT_BUFFER_SECONDS}s buffer)"
       sleep "$SLEEP_FOR"

--- a/scripts/codex-review-check.sh
+++ b/scripts/codex-review-check.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# scripts/codex-review-check.sh — Phase 4a merge gate
+# scripts/codex-review-check.sh — Phase 4 external-review merge gate
 #
-# Verifies that a pull request is ready to merge under the Phase 4a
-# automated external review flow. Read-only. Never merges, labels, or
-# comments on the PR.
+# Verifies that a pull request is ready to merge under the Phase 4
+# external-review flow. Read-only. Never merges, labels, or comments
+# on the PR.
 #
 # Usage:
 #   scripts/codex-review-check.sh <PR_NUMBER> [REPO]
@@ -25,8 +25,9 @@
 #       nathanpayne-cursor, nathanpayne-codex) is present on the PR,
 #       from an account != the PR author.
 #
-#   (c) Codex (or a Phase 4b substitute reviewer) has cleared on or
-#       after the current HEAD commit via one of three signals:
+#   (c) Codex (when codex.enabled=true) or a Phase 4b substitute
+#       reviewer has cleared on or after the current HEAD commit via
+#       one of three signals:
 #
 #         - A COMMENTED review from the Codex bot on the current HEAD
 #           with NO unaddressed P0/P1 inline findings, OR
@@ -50,6 +51,9 @@
 #       App never emits APPROVED — it uses COMMENTED with inline
 #       findings, or no review at all when it reacts 👍. See #29 for
 #       live observational evidence from the PR #53 bootstrap.
+#       When codex.enabled=false, this script ignores Codex bot
+#       reviews/reactions entirely and gate (c) can clear only through
+#       the Phase 4b substitute branch when enabled.
 #
 # "Unaddressed" heuristic for v1:
 #   A P0/P1 finding is considered unaddressed if it exists on the
@@ -159,8 +163,8 @@ codex_field() {
     in_block && /^[^[:space:]#]/ {in_block=0}
     in_block && $1 == field":" {
       sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
-      gsub(/^"/, "", $0)
-      gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+      gsub(/^["\047]/, "", $0)
+      gsub(/["\047][[:space:]]*(#.*)?$/, "", $0)
       gsub(/[[:space:]]*#.*$/, "", $0)
       sub(/[[:space:]]+$/, "", $0)
       print
@@ -183,8 +187,8 @@ policy_field() {
   awk -v field="$field" '
     /^[^[:space:]]/ && $1 == field":" {
       sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
-      gsub(/^"/, "", $0)
-      gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+      gsub(/^["\047]/, "", $0)
+      gsub(/["\047][[:space:]]*(#.*)?$/, "", $0)
       gsub(/[[:space:]]*#.*$/, "", $0)
       sub(/[[:space:]]+$/, "", $0)
       print
@@ -211,6 +215,16 @@ export PHASE_4B_DEFAULT
 
 BOT_LOGIN=$(codex_field bot_login)
 BOT_LOGIN=${BOT_LOGIN:-"chatgpt-codex-connector[bot]"}
+
+CODEX_ENABLED=$(codex_field enabled)
+CODEX_ENABLED=${CODEX_ENABLED:-true}
+case "$CODEX_ENABLED" in
+  true|false) ;;
+  *)
+    echo "ERROR: codex.enabled must be true|false; got '$CODEX_ENABLED'" >&2
+    exit 3
+    ;;
+esac
 
 REACTION_FRESHNESS_SECONDS=$(codex_field reaction_freshness_window_seconds)
 REACTION_FRESHNESS_SECONDS=${REACTION_FRESHNESS_SECONDS:-1800}
@@ -500,20 +514,26 @@ log "reaction_threshold = $REACTION_THRESHOLD (source: $REACTION_THRESHOLD_SOURC
 # agent-review.yml when two reviewers have opposing opinionated states —
 # a human must resolve it. `policy-violation` is applied by
 # block-self-approval when a reviewer bot tries to approve its own PR.
-# Both block merge categorically and are not resolvable by Phase 4a flow.
+# `human-hold` is a manual hard freeze. All three block merge
+# categorically and are not resolvable by Phase 4a flow.
 #
 # Note: `needs-external-review` is NOT a blocking label from this script's
 # perspective — it's the signal that this script should run, not a block.
 # Gate (c) resolves whether the external review is actually complete.
-PR_LABELS=$(echo "$PR_JSON" | jq -r '[.labels[].name] | join(",")')
-case ",$PR_LABELS," in
-  *,needs-human-review,*)
-    fail_gate "blocking label 'needs-human-review' present — human disagreement resolution required"
-    ;;
-  *,policy-violation,*)
-    fail_gate "blocking label 'policy-violation' present — policy violation must be resolved"
-    ;;
-esac
+pr_has_label() {
+  local label="$1"
+  echo "$PR_JSON" | jq -e --arg label "$label" 'any(.labels[].name; . == $label)' >/dev/null
+}
+
+if pr_has_label "needs-human-review"; then
+  fail_gate "blocking label 'needs-human-review' present — human disagreement resolution required"
+fi
+if pr_has_label "policy-violation"; then
+  fail_gate "blocking label 'policy-violation' present — policy violation must be resolved"
+fi
+if pr_has_label "human-hold"; then
+  fail_gate "blocking label 'human-hold' present — human hard hold must be released"
+fi
 
 # --- gate (a): CI checks green ---------------------------------------------
 
@@ -527,8 +547,8 @@ log "gate (a): checking CI state"
 # filter out checks that are EXPECTED to be failing during Phase 4a flow:
 #
 #   - "Label Gate" (from the "PR Review Policy" workflow) fails by design
-#     whenever `needs-external-review`, `needs-human-review`, or
-#     `policy-violation` is present on the PR. During Phase 4a, the first
+#     whenever `needs-external-review`, `needs-human-review`,
+#     `policy-violation`, or `human-hold` is present on the PR. During Phase 4a, the first
 #     of those labels is always set by pr-review-policy.yml, so Label Gate
 #     will fail. It's the enforcement mechanism for "don't merge until
 #     external review clears" — NOT a code-quality signal. We verify
@@ -610,7 +630,7 @@ BAD_CHECKS=$(echo "$ROLLUP_JSON" | jq --argjson required_names "${REQUIRED_JSON:
     # Filter out the known "expected to fail during Phase 4a" check.
     # Label Gate lives in the "PR Review Policy" workflow and fails by
     # design whenever needs-external-review / needs-human-review /
-    # policy-violation is set. That enforcement is what Phase 4a is
+    # policy-violation / human-hold is set. That enforcement is what Phase 4a is
     # trying to unblock; we verify clearance separately in gate (c).
     | select(
         (.workflow != "PR Review Policy") or
@@ -722,12 +742,12 @@ if [ -z "$APPROVING_REVIEWER" ]; then
   # rule.) Same-agent PRs at Phase 4 would otherwise be unable to clear
   # gate (b) by branch 1 unless a second agent (cursor / codex CLI)
   # reviews independently. In a single-agent session that's friction
-  # with no policy benefit — Codex's external review IS the cross-agent
-  # signal. Accept a fresh Codex 👍 reaction on the PR issue as a
-  # substitute for branch 1, BUT ONLY when the PR's Authoring-Agent
-  # matches an entry in available_reviewers (otherwise this would
-  # weaken gate (b) for cross-agent PRs that
-  # genuinely need a reviewer-identity APPROVED).
+  # with no policy benefit when Codex is enabled — Codex's external
+  # review IS the cross-agent signal. Accept a fresh Codex 👍 reaction
+  # on the PR issue as a substitute for branch 1, BUT ONLY when
+  # codex.enabled=true AND the PR's Authoring-Agent matches an entry in
+  # available_reviewers (otherwise this would weaken gate (b) for
+  # cross-agent PRs that genuinely need a reviewer-identity APPROVED).
   #
   # Freshness: same REACTION_THRESHOLD that gate (c) uses, computed
   # earlier in the script. Reaction must be at-or-after the threshold,
@@ -738,7 +758,9 @@ if [ -z "$APPROVING_REVIEWER" ]; then
   # still permitted — branch 2 is opt-in via the matching Authoring-
   # Agent header. If you want strict cross-agent enforcement, omit the
   # Authoring-Agent line; gate (b) then falls back to branch 1 only.
-  if [ -n "$SAME_AGENT_REVIEWER" ]; then
+  if [ -n "$SAME_AGENT_REVIEWER" ] && [ "$CODEX_ENABLED" != "true" ]; then
+    log "gate (b): same-agent Codex 👍 fallback unavailable because codex.enabled=false"
+  elif [ -n "$SAME_AGENT_REVIEWER" ]; then
     log "gate (b): no reviewer-identity APPROVED, but same-agent author/reviewer detected (Authoring-Agent: $AUTHORING_AGENT → $SAME_AGENT_REVIEWER); checking for Codex 👍 fallback per #170"
     REACTIONS_FOR_GATE_B=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/reactions" "reactions")
     GATE_B_THUMBS_UP=$(echo "$REACTIONS_FOR_GATE_B" | jq -r \
@@ -758,15 +780,28 @@ if [ -z "$APPROVING_REVIEWER" ]; then
   fi
 
   if [ -z "$APPROVING_REVIEWER" ]; then
-    fail_gate "no reviewer identity in available_reviewers has a latest-state APPROVED review, and same-agent + Codex 👍 fallback (branch 2) did not apply (Authoring-Agent: ${AUTHORING_AGENT:-not set}; matched reviewer: ${SAME_AGENT_REVIEWER:-none}; threshold: $REACTION_THRESHOLD)"
+    fail_gate "no reviewer identity in available_reviewers has a latest-state APPROVED review, and same-agent + Codex 👍 fallback (branch 2) did not apply (codex.enabled=$CODEX_ENABLED; Authoring-Agent: ${AUTHORING_AGENT:-not set}; matched reviewer: ${SAME_AGENT_REVIEWER:-none}; threshold: $REACTION_THRESHOLD)"
   fi
 else
   log "gate (b): latest-state APPROVED by $APPROVING_REVIEWER"
 fi
 
-# --- gate (c): Codex cleared on current HEAD -------------------------------
+# --- gate (c): Codex / Phase 4b cleared on current HEAD --------------------
 
-log "gate (c): checking Codex clearance on $HEAD_SHA"
+log "gate (c): checking external clearance on $HEAD_SHA (codex.enabled=$CODEX_ENABLED)"
+
+CLEARED=false
+CLEARANCE_REASON=""
+CODEX_REVIEW='null'
+CODEX_REVIEW_ID=""
+COMMENTS_JSON='[]'
+UNADDRESSED_P01='[]'
+UNADDRESSED_COUNT=0
+REACTIONS_JSON='[]'
+LATEST_THUMBS_UP_TIME=""
+CODEX_REVIEW_TIME=""
+
+if [ "$CODEX_ENABLED" = "true" ]; then
 
 # Latest Codex review on the current HEAD commit (if any). Codex always
 # uses COMMENTED state regardless of findings — do NOT filter on state.
@@ -859,9 +894,6 @@ CODEX_REVIEW_TIME=$(echo "$CODEX_REVIEW" | jq -r 'if . == null then "" else .sub
 # pull_request_review_id to scope findings (addressed in round 1's
 # finding 2), so an older review's stale comments are never counted.
 
-CLEARED=false
-CLEARANCE_REASON=""
-
 if [ -n "$LATEST_THUMBS_UP_TIME" ] && [ -n "$CODEX_REVIEW_TIME" ]; then
   # Both signals present on HEAD — compare timestamps. ISO 8601 sorts
   # chronologically under lexicographic string comparison.
@@ -884,6 +916,10 @@ elif [ -n "$CODEX_REVIEW_TIME" ]; then
     CLEARED=true
     CLEARANCE_REASON="COMMENTED review from $BOT_LOGIN @ $CODEX_REVIEW_TIME on $HEAD_SHA with no unaddressed P0/P1 findings"
   fi
+fi
+
+else
+  log "gate (c): codex.enabled=false — ignoring Codex bot review/reaction signals; requiring Phase 4b substitute clearance when allowed"
 fi
 
 # Phase 4b substitute (#218): if Codex hasn't cleared via 👍 or a
@@ -973,7 +1009,13 @@ if [ "$CLEARED" != "true" ] && [ "$ALLOW_PHASE_4B_SUBSTITUTE" = "true" ]; then
 fi
 
 if [ "$CLEARED" != "true" ]; then
-  if [ -z "$LATEST_THUMBS_UP_TIME" ] && [ -z "$CODEX_REVIEW_TIME" ]; then
+  if [ "$CODEX_ENABLED" != "true" ]; then
+    if [ "$ALLOW_PHASE_4B_SUBSTITUTE" = "true" ]; then
+      fail_gate "codex.enabled=false and no Phase 4b substitute APPROVED on $HEAD_SHA from a non-author identity in available_reviewers"
+    else
+      fail_gate "codex.enabled=false and codex.allow_phase_4b_substitute=false, so no gate (c) clearance path is available"
+    fi
+  elif [ -z "$LATEST_THUMBS_UP_TIME" ] && [ -z "$CODEX_REVIEW_TIME" ]; then
     if [ "$ALLOW_PHASE_4B_SUBSTITUTE" = "true" ]; then
       fail_gate "Codex has not cleared current HEAD and no Phase 4b substitute APPROVED on $HEAD_SHA from a non-author identity in available_reviewers (no review on HEAD, no +1 reaction from $BOT_LOGIN on or after reaction threshold $REACTION_THRESHOLD: $REACTION_THRESHOLD_SOURCE)"
     else
@@ -989,5 +1031,5 @@ log "gate (c): cleared — $CLEARANCE_REASON"
 
 # --- all gates pass ---------------------------------------------------------
 
-log "all merge gates pass — PR $REPO#$PR_NUMBER is mergeable under Phase 4a"
+log "all merge gates pass — PR $REPO#$PR_NUMBER is mergeable under Phase 4 external review"
 exit 0

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # gh-pr-guard.sh — PreToolUse hook for Claude Code
 #
-# Gates four operations:
+# Gates five operations:
 #   1. gh pr create — blocks unless (a) the keyring's active gh
 #      account is the AUTHOR identity (nathanjohnpayne by default;
 #      override via GH_PR_GUARD_EXPECTED_AUTHOR), AND (b) the command
@@ -24,7 +24,11 @@
 #      blocks). Originated downstream (matchline #170/#171) and is
 #      unified into the canonical hook here so propagation no longer
 #      clobbers the feature — see the propagation-wave retro.
-#   4. gh pr merge (non-admin) — blocks when the target PR carries
+#   4. gh pr merge (any flavor) — blocks when the target PR carries
+#      `human-hold`, with no CODEX_CLEARED / BREAK_GLASS_* bypass.
+#      This is the human-controlled hard freeze: agents may add the
+#      label, but only the human releases it.
+#   5. gh pr merge (non-admin) — blocks when the target PR carries
 #      the `needs-external-review` label unless CODEX_CLEARED=1
 #      (agent must have just run scripts/codex-review-check.sh
 #      successfully). This enforces REVIEW_POLICY.md § Phase 4a
@@ -42,13 +46,15 @@
 #     - gh pr review <PR#> --comment / --approve / --request-changes
 #     - gh issue comment <issue#> --body "..."
 #
-#   For all three, the keyring's active account must be the agent's
-#   REVIEWER identity (nathanpayne-<agent>, default nathanpayne-claude;
-#   override via GH_PR_GUARD_EXPECTED_REVIEWER). Posting these as the
-#   AUTHOR identity (nathanjohnpayne) breaks the audit-trail
-#   convention REVIEW_POLICY.md depends on — reviewer comments must
-#   attribute to the reviewer. The check fires before the keyring
-#   write so misattributed comments never land.
+#   For all three, the keyring's active account must exactly match the
+#   operating agent's REVIEWER identity. The expected reviewer resolves
+#   as: explicit GH_PR_GUARD_EXPECTED_REVIEWER override, else
+#   nathanpayne-$MERGEPATH_AGENT, else nathanpayne-claude.
+#   Posting these as the AUTHOR identity (nathanjohnpayne), or as the
+#   wrong reviewer identity after cross-session keyring drift, breaks
+#   the audit-trail convention REVIEW_POLICY.md depends on — reviewer
+#   comments must attribute to the reviewer. The check fires before
+#   the keyring write so misattributed comments never land.
 #
 #   `gh issue create` is intentionally NOT in this set. It was briefly
 #   guarded (#317, after the mergepath#315 misattribution) but that
@@ -134,6 +140,13 @@
 #   branches.
 #
 # Design notes:
+#
+#   - Compound Bash tool calls that contain multiple command-position
+#     `gh` invocations now fail closed when any invocation is a
+#     guarded write (pr create/merge/comment/review or issue
+#     comment). This is deliberately conservative: split multi-step
+#     GitHub work into separate Bash tool calls so each write gets
+#     the same single-command guard path (#348).
 #
 #   - The CODEX_CLEARED check is a hook-layer defense-in-depth.
 #     The authoritative merge gate is scripts/codex-review-check.sh;
@@ -329,6 +342,189 @@ while IFS= read -r -d '' tok; do
   TOKENS+=("$tok")
 done < "$TMP_TOKENS"
 
+# #348 defense: the main parser below intentionally identifies one
+# `gh` invocation and then routes it through the existing per-command
+# policy. That was enough for single commands, but a compound shell
+# input could put an allow-listed `gh` first and a guarded write second
+# (`gh issue close 1 && gh pr merge --admin 2`). The first command hit
+# an allow-exit and the second write never reached the guard. Keep the
+# per-command parser unchanged for normal commands, but fail closed when
+# one Bash tool call contains multiple command-position gh invocations
+# and any of them is a guarded write.
+is_guard_separator() {
+  case "$1" in
+    "&&"|"||"|";"|"|"|"|&"|"&"|"("|")")
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+prefix_flag_takes_value() {
+  case "$1:$2" in
+    sudo:-u|sudo:-g|sudo:-U|sudo:-h|sudo:-p|sudo:-r|sudo:-s|sudo:-t|sudo:-c|sudo:-D)
+      return 0
+      ;;
+    time:-f|time:-o)
+      return 0
+      ;;
+    nice:-n)
+      return 0
+      ;;
+    ionice:-c|ionice:-n|ionice:-p)
+      return 0
+      ;;
+    env:-u|env:-S)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+guarded_gh_invocation_label() {
+  local gh_index="$1"
+  local parent=""
+  local skip_global_as=""
+  local k
+  local tok
+
+  for k in "${!TOKENS[@]}"; do
+    if [ "$k" -le "$gh_index" ]; then
+      continue
+    fi
+
+    tok="${TOKENS[$k]}"
+    if is_guard_separator "$tok"; then
+      return 1
+    fi
+
+    if [ "$skip_global_as" = "repo" ]; then
+      skip_global_as=""
+      continue
+    fi
+
+    if [ -z "$parent" ]; then
+      case "$tok" in
+        pr|issue)
+          parent="$tok"
+          continue
+          ;;
+        -R|--repo)
+          skip_global_as="repo"
+          continue
+          ;;
+        -R=*|--repo=*)
+          continue
+          ;;
+        -*)
+          continue
+          ;;
+        *)
+          return 1
+          ;;
+      esac
+    fi
+
+    case "$tok" in
+      -R|--repo)
+        skip_global_as="repo"
+        continue
+        ;;
+      -R=*|--repo=*)
+        continue
+        ;;
+      -*)
+        continue
+        ;;
+    esac
+
+    case "$parent:$tok" in
+      pr:create|pr:merge|pr:comment|pr:review)
+        printf 'gh pr %s\n' "$tok"
+        return 0
+        ;;
+      issue:comment)
+        printf 'gh issue comment\n'
+        return 0
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  done
+
+  return 1
+}
+
+COMPOUND_GH_COUNT=0
+COMPOUND_GUARDED_COUNT=0
+COMPOUND_GUARDED_EXAMPLES=""
+SCAN_AT_COMMAND_POSITION=1
+SCAN_SKIP_PREFIX_VALUE=0
+SCAN_CURRENT_PREFIX=""
+for i in "${!TOKENS[@]}"; do
+  tok="${TOKENS[$i]}"
+
+  if is_guard_separator "$tok"; then
+    SCAN_AT_COMMAND_POSITION=1
+    SCAN_SKIP_PREFIX_VALUE=0
+    SCAN_CURRENT_PREFIX=""
+    continue
+  fi
+
+  if [ "$SCAN_SKIP_PREFIX_VALUE" -eq 1 ]; then
+    SCAN_SKIP_PREFIX_VALUE=0
+    continue
+  fi
+
+  if [ "$SCAN_AT_COMMAND_POSITION" -eq 0 ]; then
+    continue
+  fi
+
+  case "$tok" in
+    [A-Za-z_]*=*)
+      continue
+      ;;
+    sudo|eval|time|nohup|env|command|exec|nice|ionice)
+      SCAN_CURRENT_PREFIX="$tok"
+      continue
+      ;;
+    -*)
+      if prefix_flag_takes_value "$SCAN_CURRENT_PREFIX" "$tok"; then
+        SCAN_SKIP_PREFIX_VALUE=1
+      fi
+      continue
+      ;;
+    gh)
+      COMPOUND_GH_COUNT=$((COMPOUND_GH_COUNT + 1))
+      if guarded_label=$(guarded_gh_invocation_label "$i"); then
+        COMPOUND_GUARDED_COUNT=$((COMPOUND_GUARDED_COUNT + 1))
+        if [ -z "$COMPOUND_GUARDED_EXAMPLES" ]; then
+          COMPOUND_GUARDED_EXAMPLES="$guarded_label"
+        elif ! printf '%s\n' "$COMPOUND_GUARDED_EXAMPLES" | grep -Fxq "$guarded_label"; then
+          COMPOUND_GUARDED_EXAMPLES="${COMPOUND_GUARDED_EXAMPLES}
+$guarded_label"
+        fi
+      fi
+      SCAN_AT_COMMAND_POSITION=0
+      continue
+      ;;
+    *)
+      SCAN_AT_COMMAND_POSITION=0
+      continue
+      ;;
+  esac
+done
+
+if [ "$COMPOUND_GH_COUNT" -gt 1 ] && [ "$COMPOUND_GUARDED_COUNT" -gt 0 ]; then
+  echo "BLOCKED: compound gh command contains a guarded write (#348)." >&2
+  echo "  Detected $COMPOUND_GH_COUNT command-position gh invocations in one Bash call." >&2
+  echo "  Guarded write(s) present:" >&2
+  printf '%s\n' "$COMPOUND_GUARDED_EXAMPLES" | sed 's/^/    - /' >&2
+  echo "  Split this into separate Bash tool calls so gh-pr-guard can evaluate each gh write independently." >&2
+  exit 2
+fi
+
 # --- detect the pr subcommand, capturing any global -R/--repo ---
 #
 # Walk tokens to find `gh` IN COMMAND POSITION, then identify the
@@ -347,7 +543,7 @@ done < "$TMP_TOKENS"
 #       - prefix commands         sudo, eval, time, nohup, env,
 #                                 command, exec, nice, ionice
 #       - flags of those prefixes -X
-#       - compound separators     ;  &&  ||  |  &  (
+#       - compound separators     ;  &&  ||  |  |&  &  (
 #       - gh                      → transition to phase 2
 #     Any other token is treated as the START of a non-gh command,
 #     and we transition to IN_UNRELATED_ARGS to skip its arguments.
@@ -368,8 +564,9 @@ done < "$TMP_TOKENS"
 # is harmless: the EFFECTIVE_* values are only consulted by the
 # create/merge guards, which only run when SAW_GH=1.)
 #
-# Tokens BETWEEN `gh` and `pr` are global gh flags. The only global
-# value-taking flag we explicitly handle is -R/--repo; everything
+# Tokens BETWEEN `gh` and `pr` (and parent-level tokens between
+# `pr`/`issue` and the subcommand) may contain inherited gh flags. The
+# only value-taking flag we explicitly handle is -R/--repo; everything
 # else starting with - is assumed boolean and skipped.
 INLINE_CODEX_CLEARED=""
 INLINE_BREAK_GLASS_ADMIN=""
@@ -434,6 +631,26 @@ for i in "${!TOKENS[@]}"; do
           ;;
       esac
     fi
+    # SAW_PR=1 OR SAW_ISSUE=1 — parent-level gh flags may still
+    # appear before the subcommand, e.g. `gh pr -R owner/repo merge`.
+    case "$tok" in
+      -R|--repo)
+        SKIP_GLOBAL_AS="repo"
+        continue
+        ;;
+      -R=*)
+        GLOBAL_REPO="${tok#-R=}"
+        continue
+        ;;
+      --repo=*)
+        GLOBAL_REPO="${tok#--repo=}"
+        continue
+        ;;
+      -*)
+        continue
+        ;;
+    esac
+
     # SAW_PR=1 OR SAW_ISSUE=1 — this token IS the subcommand.
     PR_SUBCOMMAND="$tok"
     PR_SUBCOMMAND_INDEX=$i
@@ -465,7 +682,7 @@ for i in "${!TOKENS[@]}"; do
   # to the gh process. nathanpayne-codex caught this on swipewatch
   # propagation PR #33 round 5 — privilege escalation potential.
   case "$tok" in
-    "&&"|"||"|";"|"|"|"&"|"("|")")
+    "&&"|"||"|";"|"|"|"|&"|"&"|"("|")")
       AT_COMMAND_POSITION=1
       CURRENT_PREFIX=""
       # Clear inline env vars ONLY when the segment that just ended
@@ -554,29 +771,13 @@ for i in "${!TOKENS[@]}"; do
       # Per-prefix value-flag map. nathanpayne-codex caught the
       # original bug (sudo -u, time -f, nice -n) on PR #66
       # round 6; the per-prefix scoping prevents the obvious
-      # over-fix from breaking `time -p`.
-      case "$CURRENT_PREFIX:$tok" in
-        sudo:-u|sudo:-g|sudo:-U|sudo:-h|sudo:-p|sudo:-r|sudo:-s|sudo:-t|sudo:-c|sudo:-D)
-          SKIP_PREFIX_VALUE=1
-          continue
-          ;;
-        time:-f|time:-o)
-          SKIP_PREFIX_VALUE=1
-          continue
-          ;;
-        nice:-n)
-          SKIP_PREFIX_VALUE=1
-          continue
-          ;;
-        ionice:-c|ionice:-n|ionice:-p)
-          SKIP_PREFIX_VALUE=1
-          continue
-          ;;
-        env:-u|env:-S)
-          SKIP_PREFIX_VALUE=1
-          continue
-          ;;
-      esac
+      # over-fix from breaking `time -p`. Keep this shared with
+      # the #348 compound pre-scan so both walks classify prefixes
+      # identically.
+      if prefix_flag_takes_value "$CURRENT_PREFIX" "$tok"; then
+        SKIP_PREFIX_VALUE=1
+        continue
+      fi
       # Otherwise: boolean flag of the current prefix (or a flag
       # of an unknown prefix, which we conservatively assume is
       # boolean to avoid eating `gh`). Stay in command position.
@@ -632,10 +833,10 @@ fi
 # --- byline guard for pr comment / pr review / issue comment ---
 #
 # These three subcommands share a single policy: the keyring's active
-# account must be the agent's REVIEWER identity (not the author
-# identity). Posting any of them under nathanjohnpayne mis-attributes
-# the byline in a way that breaks the audit-trail invariant
-# REVIEW_POLICY.md depends on.
+# account must exactly match the operating agent's REVIEWER identity.
+# Posting any of them under nathanjohnpayne OR the wrong reviewer
+# identity mis-attributes the byline in a way that breaks the
+# audit-trail invariant REVIEW_POLICY.md depends on.
 #
 # `gh issue create` is deliberately excluded — it was briefly guarded
 # here (#317, after the mergepath#315 misattribution) but reverted,
@@ -645,7 +846,18 @@ fi
 # The `gh pr review --approve` self-approve sub-guard runs after this
 # block — only if we made it past the basic byline check does the
 # self-approve question even arise.
-EXPECTED_REVIEWER="${GH_PR_GUARD_EXPECTED_REVIEWER:-nathanpayne-claude}"
+if [ -n "${GH_PR_GUARD_EXPECTED_REVIEWER:-}" ]; then
+  EXPECTED_REVIEWER="$GH_PR_GUARD_EXPECTED_REVIEWER"
+  EXPECTED_REVIEWER_SOURCE="GH_PR_GUARD_EXPECTED_REVIEWER"
+else
+  EXPECTED_REVIEWER_AGENT="${MERGEPATH_AGENT:-claude}"
+  EXPECTED_REVIEWER="nathanpayne-$EXPECTED_REVIEWER_AGENT"
+  if [ -n "${MERGEPATH_AGENT:-}" ]; then
+    EXPECTED_REVIEWER_SOURCE="MERGEPATH_AGENT"
+  else
+    EXPECTED_REVIEWER_SOURCE="default"
+  fi
+fi
 if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS_ISSUE_COMMENT" -eq 1 ]; then
   if [ "${BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK:-0}" != "1" ]; then
     ACTIVE_GH_USER=$(gh config get -h github.com user 2>/dev/null || echo "")
@@ -655,27 +867,27 @@ if [ "$PR_SUBCOMMAND" = "comment" ] || [ "$PR_SUBCOMMAND" = "review" ] || [ "$IS
       echo "  Run 'gh auth login' for the $EXPECTED_REVIEWER identity, then retry." >&2
       exit 2
     fi
-    # Block when active is the author identity. Any other identity is
-    # allowed through here (the reviewer-vs-author split is the
-    # load-bearing distinction in this codebase); a downstream consumer
-    # that wires up a third identity per agent can override
-    # GH_PR_GUARD_EXPECTED_REVIEWER to match.
     EXPECTED_AUTHOR_FOR_BLOCK="${GH_PR_GUARD_EXPECTED_AUTHOR:-nathanjohnpayne}"
-    if [ "$ACTIVE_GH_USER" = "$EXPECTED_AUTHOR_FOR_BLOCK" ]; then
+    if [ "$ACTIVE_GH_USER" != "$EXPECTED_REVIEWER" ]; then
       cmd_label=""
       case "$PR_SUBCOMMAND" in
         comment) cmd_label="gh pr comment" ;;
         review)  cmd_label="gh pr review" ;;
       esac
       [ "$IS_ISSUE_COMMENT" -eq 1 ] && cmd_label="gh issue comment"
-      echo "BLOCKED: $cmd_label is about to run under active account '$ACTIVE_GH_USER' (the AUTHOR identity)." >&2
+      if [ "$ACTIVE_GH_USER" = "$EXPECTED_AUTHOR_FOR_BLOCK" ]; then
+        active_role="the AUTHOR identity"
+      else
+        active_role="not the expected reviewer identity"
+      fi
+      echo "BLOCKED: $cmd_label is about to run under active account '$ACTIVE_GH_USER' ($active_role)." >&2
       echo "" >&2
       echo "  Reviewer-byline commands (pr comment / pr review / issue comment)" >&2
-      echo "  must attribute to the agent's REVIEWER identity ('$EXPECTED_REVIEWER' by default)," >&2
-      echo "  not the author identity. Posting as '$EXPECTED_AUTHOR_FOR_BLOCK' breaks the audit-" >&2
-      echo "  trail convention REVIEW_POLICY.md depends on." >&2
+      echo "  must attribute to the operating agent's REVIEWER identity ('$EXPECTED_REVIEWER' for this hook invocation, from $EXPECTED_REVIEWER_SOURCE)." >&2
+      echo "  Posting as '$ACTIVE_GH_USER' breaks the audit-trail convention REVIEW_POLICY.md depends on." >&2
       echo "" >&2
       echo "  Fix once: gh auth switch -u $EXPECTED_REVIEWER" >&2
+      echo "  Or set MERGEPATH_AGENT=<agent> / GH_PR_GUARD_EXPECTED_REVIEWER=$ACTIVE_GH_USER only if that is this agent's true reviewer identity." >&2
       echo "  Or wrap the single call: scripts/gh-as-reviewer.sh -- $cmd_label ..." >&2
       echo "  See REVIEW_POLICY.md § Operation-to-Identity Matrix." >&2
       exit 2
@@ -1125,6 +1337,17 @@ fi
 # gate further down — never re-join it into a delimited string.
 MERGE_STATE=$(printf '%s\n' "$GH_OUTPUT" | sed -n '1p')
 LABELS=$(printf '%s\n' "$GH_OUTPUT" | sed -n '2,$p')
+
+# `human-hold` is a human-controlled hard freeze. Check it before
+# mergeStateStatus, --admin, or needs-external-review handling so no
+# agent-side bypass variable can release the hold. The only release
+# path is the human removing the label.
+if printf '%s\n' "$LABELS" | grep -Fxq "human-hold"; then
+  echo "BLOCKED: PR carries 'human-hold'." >&2
+  echo "  This is a human-remove-only hard hold and supersedes all merge gates." >&2
+  echo "  Ask the human to remove the label before merging; no agent bypass is available." >&2
+  exit 2
+fi
 
 # mergeStateStatus check (#171 layer 2). API enum (full set per
 # GitHub GraphQL `MergeStateStatus`):

--- a/scripts/hooks/label-removal-guard.sh
+++ b/scripts/hooks/label-removal-guard.sh
@@ -2,16 +2,18 @@
 # label-removal-guard.sh — PreToolUse hook for Claude Code.
 #
 # Blocks `gh pr edit ... --remove-label <label>` calls (and the
-# add-label inverse for the same labels) for the human-action labels
+# add-label inverse for most of those labels) for the human-action labels
 # defined in REVIEW_POLICY.md § Agent prohibitions:
 #
 #   - needs-external-review
 #   - needs-human-review
 #   - policy-violation
+#   - human-hold (remove-blocked, add-allowed)
 #
 # Rationale: agents must never remove these labels, even when a human
 # authorizes it in chat. One-time chat authorization does not extrapolate
-# into standing permission. The sanctioned path is
+# into standing permission. `human-hold` is the lone asymmetric label:
+# adding a hold is fail-safe, but removing one is human-only. The sanctioned path is
 # `scripts/request-label-removal.sh <PR#> <label>`, which posts a
 # templated ask + optional iMessage ping, after which the human clears
 # the label from any device.
@@ -128,8 +130,9 @@ except ValueError:
   # gh-pr-guard.sh's tokenization failure path. (CodeRabbit Major, #271.)
   echo "BLOCKED: label-removal-guard could not tokenize the gh command (malformed shell quoting)." >&2
   echo "  The command matched the 'gh pr edit' screen but cannot be parsed to verify it" >&2
-  echo "  does not remove a human-action label (needs-external-review / needs-human-review /" >&2
-  echo "  policy-violation). Fix the quoting and retry." >&2
+  echo "  does not modify a protected human-action label (needs-external-review /" >&2
+  echo "  needs-human-review / policy-violation) or remove human-hold. Fix the" >&2
+  echo "  quoting and retry." >&2
   exit 2
 fi
 
@@ -165,12 +168,14 @@ done
 [ "$saw_edit" -eq 1 ] || exit 0
 
 # Scan tokens AFTER `edit` for --remove-label or --add-label values.
-# Both forms are blocked: removing a label bypasses human gating;
-# adding one (e.g. spuriously re-applying policy-violation) is also a
-# human action.
+# For needs-external-review / needs-human-review / policy-violation,
+# both forms are blocked: removing a label bypasses human gating; adding
+# one spuriously creates a human-action state. `human-hold` is different:
+# agents may add it because adding a hold is fail-safe, but removal is
+# human-only.
 #
 # Two block triggers:
-#   1. Literal value matches the prohibited set.
+#   1. Literal value matches a prohibited set for that flag.
 #   2. Value undergoes shell expansion (contains $, backtick, or starts
 #      with $') — Codex P1 on PR #172. The hook receives the literal
 #      command string before bash expands variables, so a value like
@@ -180,10 +185,12 @@ done
 #      label. Block any expansion-bearing value with a message
 #      directing the agent to use a literal label name (so the hook
 #      can see what's being modified) or scripts/request-label-removal.sh.
-PROHIBITED_RE='^(needs-external-review|needs-human-review|policy-violation)$'
+ADD_REMOVE_BLOCKED_RE='^(needs-external-review|needs-human-review|policy-violation)$'
+REMOVE_ONLY_BLOCKED_RE='^(human-hold)$'
 EXPANSION_RE='[$`]'
 walk_start=$((edit_index + 1))
 SKIP_AS=""  # "" | "label-flag-value"
+SKIP_ACTION=""  # "" | "add" | "remove"
 
 # Codex r1 on PR #172 caught: gh accepts `--remove-label A,B` as a
 # comma-separated list, but the regex above only matches the entire
@@ -192,13 +199,18 @@ SKIP_AS=""  # "" | "label-flag-value"
 # but bash splits and removes both labels. Check each comma-split
 # segment instead of the whole value.
 check_label_value() {
+  local action="$1"
+  shift
   local raw="$1"
   if [[ "$raw" =~ $EXPANSION_RE ]]; then block_expansion "$raw"; fi
   local IFS=','
   for sub in $raw; do
-    sub="${sub# }"; sub="${sub% }"   # trim incidental whitespace
+    sub="$(printf '%s' "$sub" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
     [[ -z "$sub" ]] && continue
-    if [[ "$sub" =~ $PROHIBITED_RE ]]; then block_prohibited "$sub"; fi
+    if [[ "$sub" =~ $ADD_REMOVE_BLOCKED_RE ]]; then block_prohibited "$sub"; fi
+    if [ "$action" = "remove" ] && [[ "$sub" =~ $REMOVE_ONLY_BLOCKED_RE ]]; then
+      block_remove_only "$sub"
+    fi
   done
 }
 
@@ -224,14 +236,31 @@ EOF
   exit 2
 }
 
+block_remove_only() {
+  local label="$1"
+  cat <<EOF >&2
+BLOCKED: agents must not remove the '$label' label on PRs.
+
+Per REVIEW_POLICY.md § Agent prohibitions, '$label' is a human-remove-only
+hard hold. Agents may add it to freeze a PR, but only the human may release it.
+
+When the PR is ready to release:
+  scripts/request-label-removal.sh <PR#> $label
+
+That helper posts a templated ask on the PR (and optionally iMessages
+the human). The human clears the label from any device.
+EOF
+  exit 2
+}
+
 block_expansion() {
   local val="$1"
   cat <<EOF >&2
 BLOCKED: --add-label / --remove-label value '$val' contains shell
 expansion (\$, backtick, or \$'…' quoting). The hook can't see what
 this expands to until bash runs the command — so it cannot verify the
-label isn't one of the prohibited set (needs-external-review,
-needs-human-review, policy-violation).
+label isn't one of the prohibited labels (needs-external-review,
+needs-human-review, policy-violation), or a human-hold removal.
 
 Use a literal label name so the guard can verify it, OR — if you
 intended to remove a prohibited label — run:
@@ -247,16 +276,27 @@ for j in "${!TOKENS[@]}"; do
   tok="${TOKENS[$j]}"
   if [ "$SKIP_AS" = "label-flag-value" ]; then
     SKIP_AS=""
-    check_label_value "$tok"
+    check_label_value "$SKIP_ACTION" "$tok"
+    SKIP_ACTION=""
     continue
   fi
   case "$tok" in
-    --remove-label|--add-label)
+    --remove-label)
       SKIP_AS="label-flag-value"
+      SKIP_ACTION="remove"
       continue
       ;;
-    --remove-label=*|--add-label=*)
-      check_label_value "${tok#*=}"
+    --add-label)
+      SKIP_AS="label-flag-value"
+      SKIP_ACTION="add"
+      continue
+      ;;
+    --remove-label=*)
+      check_label_value "remove" "${tok#*=}"
+      continue
+      ;;
+    --add-label=*)
+      check_label_value "add" "${tok#*=}"
       continue
       ;;
   esac

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -34,7 +34,8 @@
 #
 # Modes:
 #   review  — reviewer PAT + author PAT + SSH key warming (DEFAULT)
-#   deploy  — GCP ADC credential + Cloudflare cache-purge token
+#   deploy  — Firebase project SA key (when .firebaserc is present),
+#             else GCP ADC credential + Cloudflare cache-purge token
 #   all     — everything
 #
 # Flags:
@@ -71,6 +72,18 @@
 #                             "# preflight: cache hit, no biometric
 #                             burned" message replaces it. Refresh
 #                             notices and warnings are unaffected. #282
+#   OP_SERVICE_ACCOUNT_TOKEN  Explicit CI/headless lane. When set,
+#                             review mode reads ONLY the scoped reviewer
+#                             PAT through the 1Password CLI service-
+#                             account auth path. Author PAT, deploy
+#                             secrets, SSH warming, and gh keyring
+#                             repair stay out of scope.
+#   OP_PREFLIGHT_REVIEWER_PAT_REF
+#                             Required op://vault/item/field reference for
+#                             the reviewer PAT in service-account token
+#                             mode. Must point to a service-account-
+#                             accessible vault; Private/Personal vaults
+#                             are rejected before op read.
 #
 # Session file:
 #   Path:        $cache_dir/op-preflight-<agent>.env
@@ -114,6 +127,26 @@ reviewer_pat_item_for() {
   esac
 }
 
+reviewer_pat_ref_for() {
+  local item
+  item="$(reviewer_pat_item_for "$1")" || return 1
+  printf '%s\n' "${OP_PREFLIGHT_REVIEWER_PAT_REF:-op://Private/${item}/token}"
+}
+
+is_op_secret_ref() {
+  case "$1" in
+    op://*/*/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_private_or_personal_ref() {
+  case "$1" in
+    op://Private/*|op://Personal/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 ssh_host_for() {
   case "$1" in
     claude) echo "github-claude" ;;
@@ -137,6 +170,10 @@ TTL_SECONDS="${OP_PREFLIGHT_TTL_SECONDS:-$DEFAULT_TTL_SECONDS}"
 
 # ── GCP ADC ───────────────────────────────────────────────────────────
 DEFAULT_ADC_OP_URI="${GCP_ADC_OP_URI:-op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential}"
+
+# ── Firebase deploy SA key ────────────────────────────────────────────
+SA_NAME="${FIREBASE_DEPLOY_SA_NAME:-firebase-deployer}"
+FIREBASE_SA_VAULT="${FIREBASE_SA_VAULT:-Firebase}"
 
 # ── Cloudflare Cache Purge token (#167) ───────────────────────────────
 # Shared API token with Purge:Edit permission across all domains. Wired
@@ -196,7 +233,7 @@ fi
 if $PURGE_ALL; then
   if [[ -d "$CACHE_DIR" ]]; then
     echo "# Purging all session files under $CACHE_DIR" >&2
-    find "$CACHE_DIR" -maxdepth 1 -type f \( -name 'op-preflight-*.env' -o -name 'op-preflight-*-adc.json' -o -name 'op-preflight-*.ssh-warmed' \) -print -delete >&2
+    find "$CACHE_DIR" -maxdepth 1 -type f \( -name 'op-preflight-*.env' -o -name 'op-preflight-*-adc.json' -o -name 'op-preflight-*-firebase-sa.json' -o -name 'op-preflight-*.ssh-warmed' \) -print -delete >&2
   fi
   exit 0
 fi
@@ -217,13 +254,98 @@ if ! [[ "$TTL_SECONDS" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
+SERVICE_ACCOUNT_TOKEN_MODE=false
+if [[ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
+  SERVICE_ACCOUNT_TOKEN_MODE=true
+fi
+
 # ── Cache paths (deterministic per agent) ─────────────────────────────
 SESSION_FILE="$CACHE_DIR/op-preflight-$AGENT.env"
 ADC_TMPFILE="$CACHE_DIR/op-preflight-$AGENT-adc.json"
+FIREBASE_SA_TMPFILE="$CACHE_DIR/op-preflight-$AGENT-firebase-sa.json"
 SSH_WARM_MARKER="$CACHE_DIR/op-preflight-$AGENT.ssh-warmed"
 BIOMETRIC_LOG="$CACHE_DIR/biometric-log"  # #282: append a one-line
                                           # record on each fresh fetch.
 SSH_WARM_TTL_SECONDS="${OP_PREFLIGHT_SSH_WARM_TTL_SECONDS:-1800}"  # 30 min default; #163
+
+detect_firebase_project() {
+  if [[ -n "${OP_PREFLIGHT_FIREBASE_PROJECT_ID:-}" ]]; then
+    printf '%s\n' "$OP_PREFLIGHT_FIREBASE_PROJECT_ID"
+    return 0
+  fi
+  [[ -f .firebaserc ]] || return 1
+  command -v python3 >/dev/null 2>&1 || return 1
+  python3 - <<'PY'
+import json
+import pathlib
+import sys
+
+try:
+    project = json.loads(pathlib.Path(".firebaserc").read_text())["projects"]["default"]
+except Exception:
+    sys.exit(1)
+if not isinstance(project, str) or not project:
+    sys.exit(1)
+print(project)
+PY
+}
+
+json_string_field_no_python() {
+  local file="${1:-}" field="${2:-}"
+  [[ -n "$file" && -f "$file" && -n "$field" ]] || return 1
+  awk -v field="$field" '
+    { text = text $0 " " }
+    END {
+      pattern = "\"" field "\"[[:space:]]*:[[:space:]]*\"[^\"]+\""
+      if (!match(text, pattern)) {
+        exit 1
+      }
+      matched = substr(text, RSTART, RLENGTH)
+      if (split(matched, parts, "\"") < 4) {
+        exit 1
+      }
+      print parts[4]
+    }
+  ' "$file"
+}
+
+firebaserc_default_project_no_python() {
+  [[ -f .firebaserc ]] || return 1
+  awk '
+    { text = text $0 " " }
+    END {
+      if (!match(text, /"projects"[[:space:]]*:[[:space:]]*\{[^}]*\}/)) {
+        exit 1
+      }
+      projects = substr(text, RSTART, RLENGTH)
+      if (!match(projects, /"default"[[:space:]]*:[[:space:]]*"[^"]+"/)) {
+        exit 1
+      }
+      matched = substr(projects, RSTART, RLENGTH)
+      if (split(matched, parts, "\"") < 4) {
+        exit 1
+      }
+      print parts[4]
+    }
+  ' .firebaserc
+}
+
+detect_firebase_project_no_python() {
+  if [[ -n "${OP_PREFLIGHT_FIREBASE_PROJECT_ID:-}" ]]; then
+    printf '%s\n' "$OP_PREFLIGHT_FIREBASE_PROJECT_ID"
+    return 0
+  fi
+  firebaserc_default_project_no_python
+}
+
+firebase_sa_matches_project_no_python() {
+  local file="${1:-}" project="${2:-}" client_email expected
+  [[ -n "$file" && -f "$file" && -s "$file" && -n "$project" ]] || return 1
+  client_email="$(json_string_field_no_python "$file" "client_email" || true)"
+  expected="${SA_NAME}@${project}.iam.gserviceaccount.com"
+  [[ "$client_email" == "$expected" ]]
+}
+
 # Validate the override is a non-negative integer before any arithmetic
 # context (`[[ "$age" -lt "$SSH_WARM_TTL_SECONDS" ]]` later in the
 # script). A non-numeric override (`OP_PREFLIGHT_SSH_WARM_TTL_SECONDS=foo`)
@@ -237,8 +359,9 @@ if [[ ! "$SSH_WARM_TTL_SECONDS" =~ ^[0-9]+$ ]]; then
 fi
 
 # ── Biometric trigger log (#282) ──────────────────────────────────────
-# Append a one-line record every time we trigger a fresh op fetch (i.e.
-# every time `op inject` or `op read` is invoked for cache population).
+# Append a one-line record every time the interactive lane triggers a
+# fresh op fetch (i.e. every time `op inject` or deploy `op read` is
+# invoked for cache population).
 # Format: `<ISO8601> agent=<agent> mode=<mode> reason=<reason>` so a
 # session audit can correlate biometric prompts against agent behavior.
 # Always-on (independent of OP_PREFLIGHT_QUIET) — the file is local-only
@@ -259,9 +382,14 @@ log_biometric_trigger() {
 
 # ── Purge mode ────────────────────────────────────────────────────────
 if $PURGE; then
-  rm -f "$SESSION_FILE" "$ADC_TMPFILE" "$SSH_WARM_MARKER"
-  echo "# Purged session file + ADC tempfile + SSH-warm marker for agent=$AGENT" >&2
+  rm -f "$SESSION_FILE" "$ADC_TMPFILE" "$FIREBASE_SA_TMPFILE" "$SSH_WARM_MARKER"
+  echo "# Purged session file + ADC tempfile + Firebase SA tempfile + SSH-warm marker for agent=$AGENT" >&2
   exit 0
+fi
+
+if $SERVICE_ACCOUNT_TOKEN_MODE && [[ "$MODE" != "review" ]]; then
+  echo "Error: OP_SERVICE_ACCOUNT_TOKEN mode is scoped to reviewer PAT reads only; mode '$MODE' is out of scope." >&2
+  exit 2
 fi
 
 # ── Dry run ───────────────────────────────────────────────────────────
@@ -270,6 +398,7 @@ if $DRY_RUN; then
   echo "#" >&2
   echo "# Session file:   $SESSION_FILE" >&2
   echo "# ADC tempfile:   $ADC_TMPFILE" >&2
+  echo "# Firebase SA tempfile: $FIREBASE_SA_TMPFILE" >&2
   echo "# TTL seconds:    $TTL_SECONDS" >&2
   if [[ -f "$SESSION_FILE" ]]; then
     # `|| true` so a missing epoch key doesn't take down dry-run under
@@ -292,15 +421,31 @@ if $DRY_RUN; then
   fi
   echo "#" >&2
   if [[ "$MODE" == "review" || "$MODE" == "all" ]]; then
-    echo "# Would read: reviewer PAT ($(reviewer_pat_item_for "$AGENT"))" >&2
-    echo "# Would read: author PAT ($AUTHOR_PAT_ITEM)" >&2
-    if ! $SKIP_SSH; then
+    if $SERVICE_ACCOUNT_TOKEN_MODE; then
+      if [[ -n "${OP_PREFLIGHT_REVIEWER_PAT_REF:-}" ]]; then
+        echo "# Would read: reviewer PAT ($(reviewer_pat_ref_for "$AGENT")) via OP_SERVICE_ACCOUNT_TOKEN" >&2
+      else
+        echo "# Would require: OP_PREFLIGHT_REVIEWER_PAT_REF (service-account-accessible op://vault/item/field)" >&2
+      fi
+      echo "# Would skip: author PAT (out of token-mode scope)" >&2
+      echo "# Would skip: SSH warming (out of token-mode scope)" >&2
+      echo "# Would skip: gh keyring repair (out of token-mode scope)" >&2
+    else
+      echo "# Would read: reviewer PAT ($(reviewer_pat_item_for "$AGENT"))" >&2
+      echo "# Would read: author PAT ($AUTHOR_PAT_ITEM)" >&2
+    fi
+    if ! $SKIP_SSH && ! $SERVICE_ACCOUNT_TOKEN_MODE; then
       echo "# Would warm SSH: $SSH_AUTHOR_HOST (author key)" >&2
       echo "# Would warm SSH: $(ssh_host_for "$AGENT") (reviewer key)" >&2
     fi
   fi
   if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
-    echo "# Would read: GCP ADC ($DEFAULT_ADC_OP_URI)" >&2
+    if firebase_project="$(detect_firebase_project 2>/dev/null || true)" && [[ -n "$firebase_project" ]]; then
+      echo "# Would read: Firebase project SA key (${firebase_project} — Firebase Deployer SA Key in vault ${FIREBASE_SA_VAULT})" >&2
+      echo "# Would fall back to: GCP ADC ($DEFAULT_ADC_OP_URI)" >&2
+    else
+      echo "# Would read: GCP ADC ($DEFAULT_ADC_OP_URI)" >&2
+    fi
     echo "# Would read: Cloudflare cache-purge token ($DEFAULT_CF_TOKEN_OP_URI)" >&2
   fi
   exit 0
@@ -322,6 +467,29 @@ session_is_fresh() {
   now=$(date +%s)
   age=$((now - created_at))
   [[ "$age" -lt "$TTL_SECONDS" ]]
+}
+
+session_is_token_mode() {
+  [[ -f "$SESSION_FILE" ]] || return 1
+  grep -q '^OP_PREFLIGHT_TOKEN_MODE=1$' "$SESSION_FILE" 2>/dev/null
+}
+
+scrub_op_error() {
+  local file="${1:-}" raw token redacted
+  [[ -n "$file" && -f "$file" ]] || return 0
+  raw="$(tr '\n' ' ' < "$file" || true)"
+  token="${OP_SERVICE_ACCOUNT_TOKEN:-}"
+  if [[ -n "$raw" && -n "$token" ]]; then
+    redacted="$(awk -v s="$raw" -v token="$token" 'BEGIN {
+      while ((i = index(s, token)) > 0) {
+        s = substr(s, 1, i - 1) "[redacted]" substr(s, i + length(token))
+      }
+      print s
+    }')"
+  else
+    redacted="$raw"
+  fi
+  printf '%s\n' "${redacted:0:500}"
 }
 
 # Validate that a materialized ADC file still mints a token. Mirrors the
@@ -377,6 +545,28 @@ try:
     urllib.request.urlopen(req, timeout=10)
 except Exception:
     sys.exit(1)
+PY
+}
+
+firebase_sa_matches_project() {
+  local file="${1:-}" project="${2:-}"
+  [[ -n "$file" && -f "$file" && -s "$file" && -n "$project" ]] || return 1
+  command -v python3 >/dev/null 2>&1 || return 1
+  python3 - "$file" "$project" "$SA_NAME" <<'PY'
+import json
+import pathlib
+import sys
+
+path, project, sa_name = sys.argv[1:4]
+expected = f"{sa_name}@{project}.iam.gserviceaccount.com"
+try:
+    cred = json.loads(pathlib.Path(path).read_text())
+except Exception:
+    sys.exit(1)
+
+if cred.get("type") == "service_account" and cred.get("client_email") == expected:
+    sys.exit(0)
+sys.exit(1)
 PY
 }
 
@@ -514,8 +704,10 @@ emit_from_session_file() (
   # stdout+exit; parent stays clean.
   unset OP_PREFLIGHT_REVIEWER_PAT OP_PREFLIGHT_AUTHOR_PAT
   unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
+  unset OP_PREFLIGHT_FIREBASE_SA_TMPFILE OP_PREFLIGHT_FIREBASE_PROJECT
   unset CF_API_TOKEN
   unset OP_PREFLIGHT_DONE OP_PREFLIGHT_AGENT OP_PREFLIGHT_MODE
+  unset OP_PREFLIGHT_TOKEN_MODE OP_PREFLIGHT_REVIEWER_PAT_SOURCE_REF
   unset OP_PREFLIGHT_CREATED_AT_EPOCH OP_PREFLIGHT_TTL_SECONDS
 
   # Source the session file and re-emit only the vars we own, so a
@@ -536,15 +728,34 @@ emit_from_session_file() (
   # unauthenticated. Return non-zero to trigger the refresh path in
   # each case. See #141 round-1 Codex finding (P1, line 223).
   if [[ "$MODE" == "review" || "$MODE" == "all" ]]; then
-    if [[ -z "${OP_PREFLIGHT_REVIEWER_PAT:-}" ]] || [[ -z "${OP_PREFLIGHT_AUTHOR_PAT:-}" ]]; then
+    if $SERVICE_ACCOUNT_TOKEN_MODE && [[ "${OP_PREFLIGHT_TOKEN_MODE:-0}" != "1" ]]; then
       exit 2
+    fi
+    if ! $SERVICE_ACCOUNT_TOKEN_MODE && [[ "${OP_PREFLIGHT_TOKEN_MODE:-0}" == "1" ]]; then
+      exit 2
+    fi
+    if [[ "${OP_PREFLIGHT_TOKEN_MODE:-0}" == "1" ]]; then
+      [[ -n "${OP_PREFLIGHT_REVIEWER_PAT_REF:-}" ]] || exit 2
+      desired_reviewer_ref="$(reviewer_pat_ref_for "$AGENT" 2>/dev/null || true)"
+      is_op_secret_ref "$desired_reviewer_ref" || exit 2
+      is_private_or_personal_ref "$desired_reviewer_ref" && exit 2
+      if [[ "${OP_PREFLIGHT_REVIEWER_PAT_SOURCE_REF:-}" != "$desired_reviewer_ref" ]]; then
+        exit 2
+      fi
+      if [[ "$MODE" == "all" ]] || [[ -z "${OP_PREFLIGHT_REVIEWER_PAT:-}" ]]; then
+        exit 2
+      fi
+    else
+      if [[ -z "${OP_PREFLIGHT_REVIEWER_PAT:-}" ]] || [[ -z "${OP_PREFLIGHT_AUTHOR_PAT:-}" ]]; then
+        exit 2
+      fi
     fi
   fi
   if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
-    # Both `--mode deploy` and `--mode all` require a usable ADC from
-    # the cache to take the fast path. If the session file's ADC field
-    # is missing or the materialized file is unreadable, return 2 to
-    # trigger a full refresh.
+    # Both `--mode deploy` and `--mode all` require a usable deploy
+    # credential from the cache to take the fast path. If the session
+    # file's credential field is missing or the materialized file is
+    # unreadable, return 2 to trigger a full refresh.
     #
     # An earlier iteration of this code treated missing-ADC on
     # `--mode all` as a partial hit (emit PATs, skip ADC) to spare
@@ -559,6 +770,27 @@ emit_from_session_file() (
     if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] || [[ ! -s "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
       exit 2
     fi
+    if [[ -n "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE:-}" && "${GOOGLE_APPLICATION_CREDENTIALS}" == "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE}" ]]; then
+      if [[ "${OP_PREFLIGHT_CHECK_MODE:-0}" == "1" ]]; then
+        current_firebase_project="$(detect_firebase_project_no_python 2>/dev/null || true)"
+        firebase_sa_matches_project_check() {
+          firebase_sa_matches_project_no_python "${GOOGLE_APPLICATION_CREDENTIALS}" "$current_firebase_project"
+        }
+      else
+        current_firebase_project="$(detect_firebase_project 2>/dev/null || true)"
+        firebase_sa_matches_project_check() {
+          firebase_sa_matches_project "${GOOGLE_APPLICATION_CREDENTIALS}" "$current_firebase_project"
+        }
+      fi
+      if [[ -z "$current_firebase_project" || "$current_firebase_project" != "${OP_PREFLIGHT_FIREBASE_PROJECT:-}" ]]; then
+        echo "# WARNING: cached Firebase project SA key is for '${OP_PREFLIGHT_FIREBASE_PROJECT:-unknown}', but current project is '${current_firebase_project:-none}'; refreshing deploy credentials." >&2
+        exit 2
+      fi
+      if ! firebase_sa_matches_project_check; then
+        echo "# WARNING: cached Firebase project SA key file does not match current project '$current_firebase_project'; refreshing deploy credentials." >&2
+        exit 2
+      fi
+    fi
     # --check is the "no external probes" contract — never invoke op,
     # ssh, OR python3. The `adc_is_usable` probe spawns python3 to
     # validate the OAuth2 refresh token, which fires a network call.
@@ -569,14 +801,21 @@ emit_from_session_file() (
     # `--check --mode deploy` still spawned python3.)
     if [[ "${OP_PREFLIGHT_CHECK_MODE:-0}" != "1" ]] && \
        ! adc_is_usable "${GOOGLE_APPLICATION_CREDENTIALS}"; then
-      # File exists but refresh token is rejected. Warn and skip the
-      # export so downstream deploy callers can fall back to local
-      # firebase-login / ADC. OP_PREFLIGHT_DONE stays 1 and PATs are
-      # still emitted below, because preflight itself succeeded —
-      # only the ADC-specific path is degraded, which matches what
-      # the user will see when they run `gcloud auth ...` manually.
-      log_stale_adc_guidance
-      unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
+      # File exists but the credential is unusable. Warn and skip the
+      # export so downstream deploy callers can fall back through their
+      # own resolver. OP_PREFLIGHT_DONE stays 1 and PATs are still
+      # emitted below, because preflight itself succeeded — only the
+      # deploy-credential path is degraded.
+      if [[ -n "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE:-}" && "${GOOGLE_APPLICATION_CREDENTIALS}" == "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE}" ]]; then
+        echo "# WARNING: cached Firebase project SA key is unusable; refreshing deploy credentials." >&2
+        unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
+        unset OP_PREFLIGHT_FIREBASE_SA_TMPFILE OP_PREFLIGHT_FIREBASE_PROJECT
+        exit 2
+      else
+        log_stale_adc_guidance
+        unset GOOGLE_APPLICATION_CREDENTIALS OP_PREFLIGHT_ADC_TMPFILE
+        unset OP_PREFLIGHT_FIREBASE_SA_TMPFILE OP_PREFLIGHT_FIREBASE_PROJECT
+      fi
     fi
   fi
 
@@ -584,10 +823,16 @@ emit_from_session_file() (
     printf 'export OP_PREFLIGHT_REVIEWER_PAT=%q\n' "$OP_PREFLIGHT_REVIEWER_PAT"
   [[ -n "${OP_PREFLIGHT_AUTHOR_PAT:-}" ]] && \
     printf 'export OP_PREFLIGHT_AUTHOR_PAT=%q\n' "$OP_PREFLIGHT_AUTHOR_PAT"
+  [[ "${OP_PREFLIGHT_TOKEN_MODE:-0}" == "1" ]] && \
+    printf 'export OP_PREFLIGHT_TOKEN_MODE=1\n'
   [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] && \
     printf 'export GOOGLE_APPLICATION_CREDENTIALS=%q\n' "$GOOGLE_APPLICATION_CREDENTIALS"
   [[ -n "${OP_PREFLIGHT_ADC_TMPFILE:-}" ]] && \
     printf 'export OP_PREFLIGHT_ADC_TMPFILE=%q\n' "$OP_PREFLIGHT_ADC_TMPFILE"
+  [[ -n "${OP_PREFLIGHT_FIREBASE_SA_TMPFILE:-}" ]] && \
+    printf 'export OP_PREFLIGHT_FIREBASE_SA_TMPFILE=%q\n' "$OP_PREFLIGHT_FIREBASE_SA_TMPFILE"
+  [[ -n "${OP_PREFLIGHT_FIREBASE_PROJECT:-}" ]] && \
+    printf 'export OP_PREFLIGHT_FIREBASE_PROJECT=%q\n' "$OP_PREFLIGHT_FIREBASE_PROJECT"
   [[ -n "${CF_API_TOKEN:-}" ]] && \
     printf 'export CF_API_TOKEN=%q\n' "$CF_API_TOKEN"
   printf 'export OP_PREFLIGHT_DONE=1\n'
@@ -734,12 +979,19 @@ if ! $REFRESH && session_is_fresh; then
     else
       age=$now
     fi
+    CACHE_TOKEN_MODE=false
+    if session_is_token_mode; then
+      CACHE_TOKEN_MODE=true
+    fi
     # Warm SSH keys on the cache-hit path too. The cached PATs are
     # worthless for git push/pull if SSH auth isn't also primed, and
     # the prior implementation skipped this step entirely on cache
     # hit — a repro surfaced on the consumer-repo propagation PRs.
     SUMMARY=()
-    if [[ "$MODE" == "review" || "$MODE" == "all" ]] && ! $SKIP_SSH; then
+    if $CACHE_TOKEN_MODE; then
+      SUMMARY+=("Service-account token cache: reviewer PAT only; SSH/keyring skipped")
+    fi
+    if [[ "$MODE" == "review" || "$MODE" == "all" ]] && ! $SKIP_SSH && ! $CACHE_TOKEN_MODE; then
       warm_ssh_keys
     fi
     if [[ "${OP_PREFLIGHT_QUIET:-0}" == "1" ]]; then
@@ -748,7 +1000,9 @@ if ! $REFRESH && session_is_fresh; then
       # Refresh notices and warnings remain unaffected; only this
       # routine cache-hit block collapses.
       echo "# preflight: cache hit, no biometric burned" >&2
-      warn_active_account_mismatch
+      if ! $CACHE_TOKEN_MODE; then
+        warn_active_account_mismatch
+      fi
     else
       echo "" >&2
       echo "# ── Preflight cached hit (age ${age}s / TTL ${TTL_SECONDS}s) ──" >&2
@@ -757,7 +1011,9 @@ if ! $REFRESH && session_is_fresh; then
         echo "#   $line" >&2
       done
       echo "# Run with --refresh to force a new biometric fetch." >&2
-      warn_active_account_mismatch
+      if ! $CACHE_TOKEN_MODE; then
+        warn_active_account_mismatch
+      fi
       echo "# ──────────────────────────────────────────────────────────" >&2
     fi
     exit 0
@@ -796,78 +1052,164 @@ fi
 EXPORTS=()
 SESSION_LINES=()
 SUMMARY=()
+DEPLOY_BIOMETRIC_LOGGED=false
+
+log_deploy_biometric_once() {
+  if [[ "$MODE" == "deploy" && "$DEPLOY_BIOMETRIC_LOGGED" == "false" ]]; then
+    log_biometric_trigger "$BIOMETRIC_REASON"
+    DEPLOY_BIOMETRIC_LOGGED=true
+  fi
+}
 
 # ── Phase 1: CLI credentials (one biometric prompt + session reuse) ───
 if [[ "$MODE" == "review" || "$MODE" == "all" ]]; then
   reviewer_item="$(reviewer_pat_item_for "$AGENT")"
 
-  # Build an op inject template for both PATs. op inject resolves all
-  # op:// references in a single process — one biometric prompt covers
-  # both reads.
-  tpl_file="$(mktemp "${TMPDIR:-/tmp}/op-preflight-tpl-XXXXXX")"
-  trap 'rm -f "$tpl_file"' EXIT
+  if $SERVICE_ACCOUNT_TOKEN_MODE; then
+    if [[ -z "${OP_PREFLIGHT_REVIEWER_PAT_REF:-}" ]]; then
+      echo "Error: OP_PREFLIGHT_REVIEWER_PAT_REF is required in OP_SERVICE_ACCOUNT_TOKEN mode." >&2
+      echo "       Use a service-account-accessible op://vault/item/field reference; Private/Personal vaults are out of scope." >&2
+      exit 1
+    fi
+    reviewer_ref="$(reviewer_pat_ref_for "$AGENT")"
+    if ! is_op_secret_ref "$reviewer_ref"; then
+      echo "Error: OP_PREFLIGHT_REVIEWER_PAT_REF must be an op:// secret reference." >&2
+      exit 1
+    fi
+    if is_private_or_personal_ref "$reviewer_ref"; then
+      echo "Error: OP_PREFLIGHT_REVIEWER_PAT_REF cannot point to Private or Personal vaults in OP_SERVICE_ACCOUNT_TOKEN mode." >&2
+      exit 1
+    fi
+    echo "# Preflight: reading reviewer PAT via OP_SERVICE_ACCOUNT_TOKEN..." >&2
+    op_err_file="$(mktemp "${TMPDIR:-/tmp}/op-preflight-read-err-XXXXXX")"
+    reviewer_pat=""
+    op_read_rc=0
+    if reviewer_pat="$(op read "$reviewer_ref" 2>"$op_err_file")"; then
+      op_read_rc=0
+    else
+      op_read_rc=$?
+    fi
+    if [[ "$op_read_rc" -ne 0 || -z "$reviewer_pat" ]]; then
+      op_error="$(scrub_op_error "$op_err_file")"
+      rm -f "$op_err_file"
+      echo "Error: failed to read reviewer PAT for $AGENT via OP_SERVICE_ACCOUNT_TOKEN." >&2
+      if [[ -n "$op_error" ]]; then
+        echo "1Password CLI: $op_error" >&2
+      fi
+      exit 1
+    fi
+    rm -f "$op_err_file"
+    EXPORTS+=("export OP_PREFLIGHT_REVIEWER_PAT=$(printf '%q' "$reviewer_pat")")
+    EXPORTS+=("export OP_PREFLIGHT_TOKEN_MODE=1")
+    SESSION_LINES+=("OP_PREFLIGHT_TOKEN_MODE=1")
+    SESSION_LINES+=("OP_PREFLIGHT_REVIEWER_PAT_SOURCE_REF=$(printf '%q' "$reviewer_ref")")
+    SESSION_LINES+=("OP_PREFLIGHT_REVIEWER_PAT=$(printf '%q' "$reviewer_pat")")
+    SUMMARY+=("Reviewer PAT ($AGENT): loaded via service account token")
+    SUMMARY+=("Author PAT: skipped (service account token mode)")
+  else
+    # Build an op inject template for both PATs. op inject resolves all
+    # op:// references in a single process — one biometric prompt covers
+    # both reads.
+    tpl_file="$(mktemp "${TMPDIR:-/tmp}/op-preflight-tpl-XXXXXX")"
+    trap 'rm -f "$tpl_file"' EXIT
 
-  cat > "$tpl_file" <<TPL
+    cat > "$tpl_file" <<TPL
 REVIEWER_PAT={{ op://Private/${reviewer_item}/token }}
 AUTHOR_PAT={{ op://Private/${AUTHOR_PAT_ITEM}/token }}
 TPL
 
-  echo "# Preflight: reading PATs (one biometric prompt)..." >&2
-  log_biometric_trigger "$BIOMETRIC_REASON"
-  resolved="$(op inject -i "$tpl_file")"
-  rm -f "$tpl_file"
+    echo "# Preflight: reading PATs (one biometric prompt)..." >&2
+    log_biometric_trigger "$BIOMETRIC_REASON"
+    resolved="$(op inject -i "$tpl_file")"
+    rm -f "$tpl_file"
 
-  reviewer_pat="$(echo "$resolved" | grep '^REVIEWER_PAT=' | cut -d= -f2-)"
-  author_pat="$(echo "$resolved" | grep '^AUTHOR_PAT=' | cut -d= -f2-)"
+    reviewer_pat="$(echo "$resolved" | grep '^REVIEWER_PAT=' | cut -d= -f2-)"
+    author_pat="$(echo "$resolved" | grep '^AUTHOR_PAT=' | cut -d= -f2-)"
 
-  if [[ -z "$reviewer_pat" ]]; then
-    echo "Error: failed to read reviewer PAT for $AGENT." >&2
-    exit 1
+    if [[ -z "$reviewer_pat" ]]; then
+      echo "Error: failed to read reviewer PAT for $AGENT." >&2
+      exit 1
+    fi
+    if [[ -z "$author_pat" ]]; then
+      echo "Error: failed to read author PAT." >&2
+      exit 1
+    fi
+
+    EXPORTS+=("export OP_PREFLIGHT_REVIEWER_PAT=$(printf '%q' "$reviewer_pat")")
+    EXPORTS+=("export OP_PREFLIGHT_AUTHOR_PAT=$(printf '%q' "$author_pat")")
+    SESSION_LINES+=("OP_PREFLIGHT_REVIEWER_PAT=$(printf '%q' "$reviewer_pat")")
+    SESSION_LINES+=("OP_PREFLIGHT_AUTHOR_PAT=$(printf '%q' "$author_pat")")
+    SUMMARY+=("Reviewer PAT ($AGENT): loaded")
+    SUMMARY+=("Author PAT: loaded")
   fi
-  if [[ -z "$author_pat" ]]; then
-    echo "Error: failed to read author PAT." >&2
-    exit 1
-  fi
-
-  EXPORTS+=("export OP_PREFLIGHT_REVIEWER_PAT=$(printf '%q' "$reviewer_pat")")
-  EXPORTS+=("export OP_PREFLIGHT_AUTHOR_PAT=$(printf '%q' "$author_pat")")
-  SESSION_LINES+=("OP_PREFLIGHT_REVIEWER_PAT=$(printf '%q' "$reviewer_pat")")
-  SESSION_LINES+=("OP_PREFLIGHT_AUTHOR_PAT=$(printf '%q' "$author_pat")")
-  SUMMARY+=("Reviewer PAT ($AGENT): loaded")
-  SUMMARY+=("Author PAT: loaded")
 fi
 
 if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
-  echo "# Preflight: reading GCP ADC (reuses session)..." >&2
+  firebase_project="$(detect_firebase_project 2>/dev/null || true)"
+  firebase_sa_loaded=false
 
-  # Deterministic path so subsequent invocations find the same file.
-  # Overwrite in place — chmod 600 before writing secret content.
-  touch "$ADC_TMPFILE"
-  chmod 600 "$ADC_TMPFILE"
+  if [[ -n "$firebase_project" ]]; then
+    echo "# Preflight: reading Firebase project SA key for $firebase_project..." >&2
 
-  # For --mode deploy (no review credentials loaded), this is the first
-  # op call of the run — log it. For --mode all, the Phase 1 op inject
-  # above already logged a single line covering the whole biometric
-  # burst, so no second log entry is needed here.
-  if [[ "$MODE" == "deploy" ]]; then
-    log_biometric_trigger "$BIOMETRIC_REASON"
-  fi
-  if op read "$DEFAULT_ADC_OP_URI" > "$ADC_TMPFILE" 2>/dev/null && [[ -s "$ADC_TMPFILE" ]]; then
-    if adc_is_usable "$ADC_TMPFILE"; then
-      EXPORTS+=("export GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")
-      EXPORTS+=("export OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$ADC_TMPFILE")")
-      SESSION_LINES+=("GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")
-      SESSION_LINES+=("OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$ADC_TMPFILE")")
-      SUMMARY+=("GCP ADC: loaded -> $ADC_TMPFILE")
+    # Deterministic path so subsequent invocations and op-firebase-deploy
+    # can reuse the same cached project SA key without a second biometric
+    # prompt. Overwrite in place — chmod 600 before writing secret content.
+    touch "$FIREBASE_SA_TMPFILE"
+    chmod 600 "$FIREBASE_SA_TMPFILE"
+    : > "$FIREBASE_SA_TMPFILE"
+
+    # For --mode deploy (no review credentials loaded), this is the first
+    # op call of the run — log it. For --mode all, the Phase 1 op inject
+    # above already logged a single line covering the whole biometric
+    # burst, so no second log entry is needed here.
+    log_deploy_biometric_once
+    if op document get "${firebase_project} — Firebase Deployer SA Key" \
+         --vault "$FIREBASE_SA_VAULT" \
+         --out-file "$FIREBASE_SA_TMPFILE" \
+         --force >/dev/null 2>&1 \
+       && firebase_sa_matches_project "$FIREBASE_SA_TMPFILE" "$firebase_project"; then
+      EXPORTS+=("export GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$FIREBASE_SA_TMPFILE")")
+      EXPORTS+=("export OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$(printf '%q' "$FIREBASE_SA_TMPFILE")")
+      EXPORTS+=("export OP_PREFLIGHT_FIREBASE_PROJECT=$(printf '%q' "$firebase_project")")
+      SESSION_LINES+=("GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$FIREBASE_SA_TMPFILE")")
+      SESSION_LINES+=("OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$(printf '%q' "$FIREBASE_SA_TMPFILE")")
+      SESSION_LINES+=("OP_PREFLIGHT_FIREBASE_PROJECT=$(printf '%q' "$firebase_project")")
+      SUMMARY+=("Firebase SA key ($firebase_project): loaded -> $FIREBASE_SA_TMPFILE")
+      firebase_sa_loaded=true
     else
-      rm -f "$ADC_TMPFILE"
-      log_stale_adc_guidance
-      SUMMARY+=("GCP ADC: STALE (refresh_token rejected — see warning above)")
+      rm -f "$FIREBASE_SA_TMPFILE"
+      SUMMARY+=("Firebase SA key ($firebase_project): SKIPPED (not found or did not match ${SA_NAME}@${firebase_project}.iam.gserviceaccount.com)")
     fi
   else
-    rm -f "$ADC_TMPFILE"
-    echo "# Warning: could not read GCP ADC. Deploy credentials not cached." >&2
-    SUMMARY+=("GCP ADC: SKIPPED (not available)")
+    SUMMARY+=("Firebase SA key: SKIPPED (no .firebaserc default project detected)")
+  fi
+
+  if [[ "$firebase_sa_loaded" != "true" ]]; then
+    echo "# Preflight: reading GCP ADC (reuses session)..." >&2
+
+    # Deterministic path so subsequent invocations find the same file.
+    # Overwrite in place — chmod 600 before writing secret content.
+    touch "$ADC_TMPFILE"
+    chmod 600 "$ADC_TMPFILE"
+
+    log_deploy_biometric_once
+    if op read "$DEFAULT_ADC_OP_URI" > "$ADC_TMPFILE" 2>/dev/null && [[ -s "$ADC_TMPFILE" ]]; then
+      if adc_is_usable "$ADC_TMPFILE"; then
+        EXPORTS+=("export GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")
+        EXPORTS+=("export OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$ADC_TMPFILE")")
+        SESSION_LINES+=("GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")
+        SESSION_LINES+=("OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$ADC_TMPFILE")")
+        SUMMARY+=("GCP ADC: loaded -> $ADC_TMPFILE")
+      else
+        rm -f "$ADC_TMPFILE"
+        log_stale_adc_guidance
+        SUMMARY+=("GCP ADC: STALE (refresh_token rejected — see warning above)")
+      fi
+    else
+      rm -f "$ADC_TMPFILE"
+      echo "# Warning: could not read GCP ADC. Deploy credentials not cached." >&2
+      SUMMARY+=("GCP ADC: SKIPPED (not available)")
+    fi
   fi
 
   # Cloudflare cache-purge token (#167). Optional — if 1Password is
@@ -886,8 +1228,10 @@ if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
 fi
 
 # ── Phase 2: SSH key warming ──────────────────────────────────────────
-if [[ "$MODE" == "review" || "$MODE" == "all" ]] && ! $SKIP_SSH; then
+if [[ "$MODE" == "review" || "$MODE" == "all" ]] && ! $SKIP_SSH && ! $SERVICE_ACCOUNT_TOKEN_MODE; then
   warm_ssh_keys
+elif $SERVICE_ACCOUNT_TOKEN_MODE; then
+  SUMMARY+=("SSH/keyring: skipped (service account token mode)")
 fi
 
 # ── Persist session file ──────────────────────────────────────────────
@@ -926,6 +1270,8 @@ for line in "${SUMMARY[@]}"; do
 done
 echo "# Session file: $SESSION_FILE (TTL ${TTL_SECONDS}s)" >&2
 echo "# OP_PREFLIGHT_DONE=1" >&2
-warn_active_account_mismatch
+if ! $SERVICE_ACCOUNT_TOKEN_MODE; then
+  warn_active_account_mismatch
+fi
 echo "# Human can step away." >&2
 echo "# ──────────────────────────────────────────────────────" >&2

--- a/scripts/request-label-removal.sh
+++ b/scripts/request-label-removal.sh
@@ -2,8 +2,9 @@
 # request-label-removal.sh — post a structured label-removal ask on a PR.
 #
 # Background: REVIEW_POLICY.md prohibits agents from removing the
-# `needs-external-review`, `needs-human-review`, and `policy-violation`
-# labels — even when authorized in chat. Label removal is a human action.
+# `needs-external-review`, `needs-human-review`, `policy-violation`, and
+# `human-hold` labels — even when authorized in chat. Label removal is a
+# human action.
 # This helper turns the prohibition into a one-command ask: the agent
 # posts a templated PR comment and (optionally) pings the human via
 # iMessage so they can clear the label without opening a chat window.
@@ -16,8 +17,8 @@
 # (#197 — catches the 👍-after-last-push case). Use this script for
 # `needs-external-review` only when neither the event-driven path
 # nor the sweep has fired in a reasonable window — typically rare.
-# For `needs-human-review` and `policy-violation`, this script is
-# the only path; both remain manual-only by design.
+# For `needs-human-review`, `policy-violation`, and `human-hold`, this
+# script is the only path; all three remain manual-only by design.
 #
 # Usage:
 #   scripts/request-label-removal.sh <PR#> <label>
@@ -32,6 +33,8 @@
 #   scripts/request-label-removal.sh 182 needs-external-review
 #   scripts/request-label-removal.sh 182 needs-human-review \
 #     --reason "Codex cleared r3; CI green; only blocker is this label"
+#   scripts/request-label-removal.sh 182 human-hold \
+#     --reason "Morning 4b review approved the current HEAD"
 #   MERGEPATH_NOTIFY_IMESSAGE_TO="+15551234567" \
 #     scripts/request-label-removal.sh 182 needs-external-review
 #
@@ -54,7 +57,7 @@ if [ -z "${OP_PREFLIGHT_REVIEWER_PAT:-}" ] && [ -r "$__REQUEST_LABEL_DIR/lib/pre
   auto_source_preflight
 fi
 
-ALLOWED_LABELS=(needs-external-review needs-human-review policy-violation)
+ALLOWED_LABELS=(needs-external-review needs-human-review policy-violation human-hold)
 
 # Escape a string for embedding inside an AppleScript double-quoted
 # literal. See the inline call site below for the full rationale on
@@ -82,7 +85,7 @@ usage() {
   cat <<'EOF' >&2
 Usage: scripts/request-label-removal.sh <PR#> <label> [--reason <text>] [--repo owner/name]
 
-Allowed labels: needs-external-review | needs-human-review | policy-violation
+Allowed labels: needs-external-review | needs-human-review | policy-violation | human-hold
 
 Posts a templated PR comment asking the human to remove the label.
 Sends an iMessage to MERGEPATH_NOTIFY_IMESSAGE_TO if set.
@@ -119,7 +122,7 @@ for ok in "${ALLOWED_LABELS[@]}"; do
   if [ "$LABEL" = "$ok" ]; then allowed=1; break; fi
 done
 if [ "$allowed" -ne 1 ]; then
-  echo "Refusing: '$LABEL' is not a human-action label." >&2
+  echo "Refusing: '$LABEL' is not a protected human-action label." >&2
   echo "Allowed: ${ALLOWED_LABELS[*]}" >&2
   echo "If this label is genuinely a no-op blocker, just remove it directly." >&2
   exit 1
@@ -184,7 +187,7 @@ Per [REVIEW_POLICY.md § Agent prohibitions](https://github.com/nathanjohnpayne/
 - GitHub UI: Labels sidebar → click \`x\` on \`$LABEL\`
 - CLI: \`gh pr edit $PR_NUM --remove-label $LABEL${REPO_HINT_FOR_BODY}\`
 
-Auto-merge will fire as soon as the label is gone.${REASON_BLOCK}${AUTOCLEAR_NOTE}
+The PR can proceed as soon as the label is gone and the normal merge gates are green.${REASON_BLOCK}${AUTOCLEAR_NOTE}
 
 — posted by \`scripts/request-label-removal.sh\`"
 

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -4,8 +4,8 @@
 # Unit tests for scripts/hooks/gh-pr-guard.sh — covers the #241
 # identity-check on `gh pr create`, the #170/#171 mergeStateStatus
 # guard on `gh pr merge`, and a regression net for the existing
-# Authoring-Agent / Self-Review body checks + needs-external-review
-# label check so the newer checks are additive (don't break old
+# Authoring-Agent / Self-Review body checks + needs-external-review /
+# human-hold label checks so the newer checks are additive (don't break old
 # behavior).
 #
 # The hook reads tool_input.command from a JSON envelope on stdin
@@ -122,12 +122,14 @@ run_hook() {
   local skip_id="${3:-0}"
   local merge_state="${4:-CLEAN}"
   local labels="${5:-}"
+  local expected_reviewer="${6:-nathanpayne-claude}"
   local payload
   payload=$(jq -n --arg c "$cmd" '{tool_input: {command: $c}}')
   PATH="$STUB_DIR:$PATH" \
   STUB_ACTIVE_USER="$stub_user" \
   STUB_MERGE_STATE="$merge_state" \
   STUB_LABELS="$labels" \
+  GH_PR_GUARD_EXPECTED_REVIEWER="$expected_reviewer" \
   BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK="$skip_id" \
     bash "$HOOK" <<<"$payload"
 }
@@ -145,6 +147,7 @@ run_hook_review() {
   local deletions="${6:-0}"
   local pr_head="${7:-feature/some-branch}"
   local pr_author="${8:-nathanjohnpayne}"
+  local expected_reviewer="${9:-nathanpayne-claude}"
   local payload
   payload=$(jq -n --arg c "$cmd" '{tool_input: {command: $c}}')
   PATH="$STUB_DIR:$PATH" \
@@ -154,6 +157,27 @@ run_hook_review() {
   STUB_PR_DELETIONS="$deletions" \
   STUB_PR_HEAD="$pr_head" \
   STUB_PR_AUTHOR="$pr_author" \
+  GH_PR_GUARD_EXPECTED_REVIEWER="$expected_reviewer" \
+  BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK="$skip_id" \
+    bash "$HOOK" <<<"$payload"
+}
+
+run_hook_agent_context() {
+  local cmd="$1"
+  local stub_user="${2:-nathanpayne-claude}"
+  local agent="${3:-}"
+  local expected_reviewer="${4:-}"
+  local skip_id="${5:-0}"
+  local merge_state="${6:-CLEAN}"
+  local labels="${7:-}"
+  local payload
+  payload=$(jq -n --arg c "$cmd" '{tool_input: {command: $c}}')
+  PATH="$STUB_DIR:$PATH" \
+  STUB_ACTIVE_USER="$stub_user" \
+  STUB_MERGE_STATE="$merge_state" \
+  STUB_LABELS="$labels" \
+  MERGEPATH_AGENT="$agent" \
+  GH_PR_GUARD_EXPECTED_REVIEWER="$expected_reviewer" \
   BOOTSTRAP_GH_PR_GUARD_SKIP_IDENTITY_CHECK="$skip_id" \
     bash "$HOOK" <<<"$payload"
 }
@@ -256,6 +280,18 @@ if [ "$rc" -eq 0 ]; then
   pass "gh pr merge: identity check does NOT fire (create-only); CLEAN merge allowed"
 else
   fail "gh pr merge: exit $rc, expected 0 (identity check should be create-only); output: $out"
+fi
+
+# Parent-level -R/--repo between `pr` and `merge` is valid gh syntax
+# and must still route into the merge guard.
+set +e
+out=$(run_hook 'gh pr -R nathanjohnpayne/mergepath merge 123 --squash --delete-branch' "nathanjohnpayne" "0" "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "gh pr -R <repo> merge: parent-level repo flag still routes to merge guard"
+else
+  fail "gh pr -R <repo> merge: exit $rc, expected 0; output: $out"
 fi
 
 # ---------------------------------------------------------------------------
@@ -409,6 +445,23 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 15b: human-hold blocks even when all agent-side bypass variables are
+# present. This label is human-remove-only and supersedes CODEX_CLEARED,
+# BREAK_GLASS_ADMIN, and BREAK_GLASS_MERGE_STATE.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'CODEX_CLEARED=1 BREAK_GLASS_ADMIN=1 BREAK_GLASS_MERGE_STATE=1 gh pr merge 123 --admin --squash' "nathanjohnpayne" "0" "DIRTY" "human-hold" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "merge + human-hold + bypass envs: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -qi "human-hold"; then
+  fail "merge + human-hold: diagnostic missing label reference; output: $out"
+else
+  pass "merge + human-hold: hard hold blocks every agent-side bypass"
+fi
+
+# ---------------------------------------------------------------------------
 # Test 16: a label literally NAMED `team,needs-external-review` (commas
 # are legal in GitHub label names) must NOT false-match the real
 # `needs-external-review` gate. Regression net for the CSV-join
@@ -423,6 +476,18 @@ if [ "$rc" -eq 0 ]; then
   pass "label 'team,needs-external-review' does NOT false-match the needs-external-review gate"
 else
   fail "comma-in-label false-match: exit $rc, expected 0 (the label is not literally 'needs-external-review'); output: $out"
+fi
+
+# Same exact-match rule for human-hold: a comma in another label's
+# literal name must not trip the hard-hold gate.
+set +e
+out=$(run_hook 'gh pr merge 123 --squash' "nathanjohnpayne" "0" "CLEAN" "team,human-hold" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "label 'team,human-hold' does NOT false-match the human-hold gate"
+else
+  fail "comma-in-human-hold-label false-match: exit $rc, expected 0; output: $out"
 fi
 
 # ===========================================================================
@@ -462,6 +527,107 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 18b: gh pr comment with the WRONG reviewer identity active →
+# blocked. This closes #363: cross-agent keyring drift (claude session
+# with active=nathanpayne-codex) must not silently post under the wrong
+# reviewer byline.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh pr comment 123 --body "ping"' "nathanpayne-codex" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "pr comment + wrong reviewer identity: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -qi "not the expected reviewer identity"; then
+  fail "pr comment + wrong reviewer identity: diagnostic missing expected-reviewer mismatch; output: $out"
+elif ! echo "$out" | grep -q "gh-as-reviewer.sh"; then
+  fail "pr comment + wrong reviewer identity: diagnostic missing gh-as-reviewer.sh remediation; output: $out"
+else
+  pass "pr comment + wrong reviewer identity: blocked with reviewer mismatch diagnostic"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 18c: GH_PR_GUARD_EXPECTED_REVIEWER override — codex is valid
+# when the operating agent is codex and the hook env says so.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh pr comment 123 --body "ping"' "nathanpayne-codex" "0" "CLEAN" "" "nathanpayne-codex" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "pr comment + expected-reviewer override: codex active allowed when expected=codex"
+else
+  fail "pr comment + expected-reviewer override: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 18c2: MERGEPATH_AGENT fallback — codex is valid when the
+# operating agent is codex even if GH_PR_GUARD_EXPECTED_REVIEWER is
+# unset/empty. This keeps the hook aligned with identity-check.sh
+# --expect-reviewer.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook_agent_context 'gh pr comment 123 --body "ping"' "nathanpayne-codex" "codex" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "pr comment + MERGEPATH_AGENT fallback: codex active allowed when agent=codex"
+else
+  fail "pr comment + MERGEPATH_AGENT fallback: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 18c3: explicit expected-reviewer override wins over
+# MERGEPATH_AGENT. This preserves harness-controlled review sessions
+# where the expected reviewer is intentionally pinned.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook_agent_context 'gh pr comment 123 --body "ping"' "nathanpayne-codex" "codex" "nathanpayne-claude" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "pr comment + explicit override precedence: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -q "GH_PR_GUARD_EXPECTED_REVIEWER"; then
+  fail "pr comment + explicit override precedence: diagnostic missing override source; output: $out"
+else
+  pass "pr comment + explicit override precedence: expected-reviewer override beats MERGEPATH_AGENT"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 18c4: MERGEPATH_AGENT fallback blocks a different active
+# reviewer identity, and the diagnostic names the derived reviewer.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook_agent_context 'gh pr comment 123 --body "ping"' "nathanpayne-claude" "cursor" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "pr comment + MERGEPATH_AGENT mismatch: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -q "nathanpayne-cursor"; then
+  fail "pr comment + MERGEPATH_AGENT mismatch: diagnostic missing derived cursor reviewer; output: $out"
+elif ! echo "$out" | grep -q "MERGEPATH_AGENT"; then
+  fail "pr comment + MERGEPATH_AGENT mismatch: diagnostic missing MERGEPATH_AGENT source; output: $out"
+else
+  pass "pr comment + MERGEPATH_AGENT mismatch: blocks wrong active reviewer"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 18d: wrapped reviewer writes are allowed by the tokenizer. The
+# hook sees scripts/gh-as-reviewer.sh in command position and the gh
+# command only as an argument; the wrapper is responsible for switching
+# and verifying the identity internally.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'scripts/gh-as-reviewer.sh -- gh pr comment 123 --body "ping"' "nathanpayne-codex" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "wrapped pr comment via gh-as-reviewer.sh: allowed"
+else
+  fail "wrapped pr comment via gh-as-reviewer.sh: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
 # Test 19: gh pr review --comment with AUTHOR identity → blocked.
 # ---------------------------------------------------------------------------
 set +e
@@ -490,6 +656,22 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 20b: gh pr review --comment with the wrong reviewer identity
+# active → blocked. Same #363 drift guard as pr comment, but on review.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh pr review 123 --comment --body "review"' "nathanpayne-codex" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "pr review --comment + wrong reviewer identity: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -qi "not the expected reviewer identity"; then
+  fail "pr review --comment + wrong reviewer identity: diagnostic missing expected-reviewer mismatch; output: $out"
+else
+  pass "pr review --comment + wrong reviewer identity: blocked"
+fi
+
+# ---------------------------------------------------------------------------
 # Test 21: gh issue comment with AUTHOR identity → blocked.
 # ---------------------------------------------------------------------------
 set +e
@@ -515,6 +697,22 @@ if [ "$rc" -eq 0 ]; then
   pass "issue comment + reviewer identity: allowed"
 else
   fail "issue comment + reviewer identity: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 22b: gh issue comment with the wrong reviewer identity active →
+# blocked.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh issue comment 7 --body "thanks"' "nathanpayne-codex" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "issue comment + wrong reviewer identity: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -qi "not the expected reviewer identity"; then
+  fail "issue comment + wrong reviewer identity: diagnostic missing expected-reviewer mismatch; output: $out"
+else
+  pass "issue comment + wrong reviewer identity: blocked"
 fi
 
 # ---------------------------------------------------------------------------
@@ -583,6 +781,108 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 23e: compound commands with leading allowed gh issue subcommands
+# followed by a guarded merge are blocked before the leading allow-exit
+# can bypass the merge guard (#348). Covers the known issue allow-exit
+# family: close / view / list / edit.
+# ---------------------------------------------------------------------------
+for leading_issue_subcommand in close view list edit; do
+  case "$leading_issue_subcommand" in
+    list) leading_issue_cmd="gh issue list" ;;
+    *) leading_issue_cmd="gh issue $leading_issue_subcommand 7" ;;
+  esac
+  set +e
+  out=$(run_hook "$leading_issue_cmd && gh pr merge --admin 123" "nathanjohnpayne" "0" "CLEAN" "" 2>&1)
+  rc=$?
+  set -e
+  if [ "$rc" -ne 2 ]; then
+    fail "compound issue-$leading_issue_subcommand then merge: exit $rc, expected 2; output: $out"
+  elif ! echo "$out" | grep -qi "#348"; then
+    fail "compound issue-$leading_issue_subcommand then merge: diagnostic missing #348; output: $out"
+  elif ! echo "$out" | grep -qi "gh pr merge"; then
+    fail "compound issue-$leading_issue_subcommand then merge: diagnostic missing guarded merge label; output: $out"
+  else
+    pass "compound issue-$leading_issue_subcommand then merge: blocked by #348 fail-closed guard"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Test 23f: compound command with a leading allowed gh pr view followed by
+# a guarded merge is also blocked. This covers the PR allow-exit shape,
+# not just the issue allow-exit shape (#348).
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh pr view 7 && gh pr merge 123 --squash' "nathanjohnpayne" "0" "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "compound pr-view then merge: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -qi "#348"; then
+  fail "compound pr-view then merge: diagnostic missing #348; output: $out"
+else
+  pass "compound pr-view then merge: blocked by #348 fail-closed guard"
+fi
+
+set +e
+out=$(run_hook 'gh issue close 7 && gh pr -R nathanjohnpayne/mergepath merge --admin 123' "nathanjohnpayne" "0" "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "compound issue-close then parent-repo merge: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -qi "#348"; then
+  fail "compound issue-close then parent-repo merge: diagnostic missing #348; output: $out"
+else
+  pass "compound issue-close then parent-repo merge: parent-level -R does not bypass #348 guard"
+fi
+
+# `|&` is Bash's stdout+stderr pipe separator. It must split command
+# position the same way `|` does, or a leading allowed gh command can
+# still hide a guarded write in the second segment.
+set +e
+out=$(run_hook 'gh issue close 7 |& gh pr merge --admin 123' "nathanjohnpayne" "0" "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "compound issue-close pipe-err then merge: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -qi "#348"; then
+  fail "compound issue-close pipe-err then merge: diagnostic missing #348; output: $out"
+else
+  pass "compound issue-close pipe-err then merge: |& separator is blocked by #348 guard"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 23g: gh issue create remains allowed as a single command, but a
+# compound issue-create followed by a guarded merge is blocked. This keeps
+# the intended issue-create workflow while closing the chained bypass.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh issue create --title "Bug" --body "filed" && gh pr merge --admin 123' "nathanjohnpayne" "0" "CLEAN" "" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -ne 2 ]; then
+  fail "compound issue-create then merge: exit $rc, expected 2; output: $out"
+elif ! echo "$out" | grep -qi "#348"; then
+  fail "compound issue-create then merge: diagnostic missing #348; output: $out"
+else
+  pass "compound issue-create then merge: issue-create stays allowed only as a single gh command"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 23h: multiple gh invocations are allowed when none is a guarded
+# write. The #348 fail-closed rule is scoped to compounds that contain
+# pr create/merge/comment/review or issue comment.
+# ---------------------------------------------------------------------------
+set +e
+out=$(run_hook 'gh issue close 7 && gh issue view 7' "nathanjohnpayne" "0" 2>&1)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  pass "compound unguarded issue commands: allowed"
+else
+  fail "compound unguarded issue commands: exit $rc, expected 0; output: $out"
+fi
+
+# ---------------------------------------------------------------------------
 # Test 24: gh pr review --approve self-approve on over-threshold PR
 # (Authoring-Agent: claude + active=nathanpayne-claude + size > threshold)
 # → blocked. Uses a synthetic body that names claude as the authoring
@@ -611,7 +911,7 @@ fi
 # ---------------------------------------------------------------------------
 set +e
 out=$(run_hook_review 'gh pr review 123 --approve --body "lgtm"' "nathanpayne-codex" "0" \
-  "Authoring-Agent: claude" "5000" "0" 2>&1)
+  "Authoring-Agent: claude" "5000" "0" "feature/some-branch" "nathanjohnpayne" "nathanpayne-codex" 2>&1)
 rc=$?
 set -e
 if [ "$rc" -eq 0 ]; then

--- a/tests/test_op_preflight_check.sh
+++ b/tests/test_op_preflight_check.sh
@@ -330,6 +330,639 @@ EOF
   pass "test_check_deploy_no_python3_probe: --check --mode deploy emits ADC without python3 probe"
 }
 
+# ---------------------------------------------------------------------------
+# test_check_deploy_firebase_sa_no_python3_probe: --check must stay a
+# no-probe path even when the cached deploy credential is a Firebase SA
+# marker and the checkout has a .firebaserc.
+# ---------------------------------------------------------------------------
+test_check_deploy_firebase_sa_no_python3_probe() {
+  local case_dir="$WORKDIR/deploy-firebase-no-python3"
+  local cache_dir="$case_dir/cache"
+  local py_stub="$case_dir/stub-bin-py"
+  local project="merge-path-test"
+  local sa_file="$case_dir/firebase-sa.json"
+  mkdir -p "$case_dir" "$cache_dir" "$py_stub"
+
+  cat > "$case_dir/.firebaserc" <<JSON
+{
+  "projects": { "default": "$project" },
+  "hosting": { "default": "wrong-project" }
+}
+JSON
+  cat > "$sa_file" <<JSON
+{
+  "type": "service_account",
+  "project_id": "$project",
+  "private_key_id": "fake-key-id",
+  "private_key": "REDACTED_TEST_FIXTURE_NOT_A_REAL_KEY",
+  "client_email": "firebase-deployer@${project}.iam.gserviceaccount.com",
+  "client_id": "0"
+}
+JSON
+
+  local epoch
+  epoch=$(date +%s)
+  cat > "$cache_dir/op-preflight-claude.env" <<EOF
+OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
+OP_PREFLIGHT_TTL_SECONDS=14400
+OP_PREFLIGHT_AGENT=claude
+OP_PREFLIGHT_MODE=deploy
+OP_PREFLIGHT_DONE=1
+GOOGLE_APPLICATION_CREDENTIALS=$sa_file
+OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$sa_file
+OP_PREFLIGHT_FIREBASE_PROJECT=$project
+EOF
+  chmod 600 "$cache_dir/op-preflight-claude.env"
+
+  cat > "$py_stub/python3" <<'EOF'
+#!/usr/bin/env bash
+echo "FATAL: --check --mode deploy invoked python3 with args: $*" >&2
+exit 97
+EOF
+  chmod +x "$py_stub/python3"
+
+  local out rc=0
+  (
+    cd "$case_dir"
+    OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+      PATH="$py_stub:$STUB_DIR:$PATH" \
+      "$SCRIPT" --agent claude --mode deploy --check 2>&1
+  ) >"$case_dir/out" || rc=$?
+  out="$(cat "$case_dir/out")"
+
+  if [ "$rc" -ne 0 ]; then
+    fail "test_check_deploy_firebase_sa_no_python3_probe: --check returned rc=$rc; out=$out"
+    return
+  fi
+  if echo "$out" | grep -q "invoked python3"; then
+    fail "test_check_deploy_firebase_sa_no_python3_probe: --check invoked python3; out=$out"
+    return
+  fi
+  if ! echo "$out" | grep -q "export OP_PREFLIGHT_FIREBASE_SA_TMPFILE="; then
+    fail "test_check_deploy_firebase_sa_no_python3_probe: missing Firebase SA marker export; out=$out"
+    return
+  fi
+  pass "test_check_deploy_firebase_sa_no_python3_probe: --check emits Firebase SA without python3 probe"
+}
+
+# ---------------------------------------------------------------------------
+# test_check_deploy_firebase_sa_project_mismatch_fails_closed:
+# --check is probe-free, but it must still refuse a Firebase SA cache
+# whose project marker/file no longer match the checkout.
+# ---------------------------------------------------------------------------
+test_check_deploy_firebase_sa_project_mismatch_fails_closed() {
+  local case_dir="$WORKDIR/deploy-firebase-check-mismatch"
+  local cache_dir="$case_dir/cache"
+  local py_stub="$case_dir/stub-bin-py"
+  local cached_project="project-a"
+  local current_project="project-b"
+  local sa_file="$case_dir/firebase-sa.json"
+  mkdir -p "$case_dir" "$cache_dir" "$py_stub"
+
+  cat > "$case_dir/.firebaserc" <<JSON
+{ "projects": { "default": "$current_project" } }
+JSON
+  cat > "$sa_file" <<JSON
+{
+  "type": "service_account",
+  "project_id": "$cached_project",
+  "client_email": "firebase-deployer@${cached_project}.iam.gserviceaccount.com"
+}
+JSON
+
+  local epoch
+  epoch=$(date +%s)
+  cat > "$cache_dir/op-preflight-claude.env" <<EOF
+OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
+OP_PREFLIGHT_TTL_SECONDS=14400
+OP_PREFLIGHT_AGENT=claude
+OP_PREFLIGHT_MODE=deploy
+OP_PREFLIGHT_DONE=1
+GOOGLE_APPLICATION_CREDENTIALS=$sa_file
+OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$sa_file
+OP_PREFLIGHT_FIREBASE_PROJECT=$cached_project
+EOF
+  chmod 600 "$cache_dir/op-preflight-claude.env"
+
+  cat > "$py_stub/python3" <<'EOF'
+#!/usr/bin/env bash
+echo "FATAL: --check --mode deploy invoked python3 with args: $*" >&2
+exit 97
+EOF
+  chmod +x "$py_stub/python3"
+
+  local out rc=0
+  (
+    cd "$case_dir"
+    OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+      PATH="$py_stub:$STUB_DIR:$PATH" \
+      "$SCRIPT" --agent claude --mode deploy --check 2>&1
+  ) >"$case_dir/out" || rc=$?
+  out="$(cat "$case_dir/out")"
+
+  if [ "$rc" -eq 0 ]; then
+    fail "test_check_deploy_firebase_sa_project_mismatch_fails_closed: --check should fail closed; out=$out"
+    return
+  fi
+  if echo "$out" | grep -q "invoked python3"; then
+    fail "test_check_deploy_firebase_sa_project_mismatch_fails_closed: --check invoked python3; out=$out"
+    return
+  fi
+  if ! echo "$out" | grep -q "cached Firebase project SA key is for '$cached_project', but current project is '$current_project'"; then
+    fail "test_check_deploy_firebase_sa_project_mismatch_fails_closed: missing mismatch warning; out=$out"
+    return
+  fi
+  pass "test_check_deploy_firebase_sa_project_mismatch_fails_closed: --check fails closed on project drift"
+}
+
+# ---------------------------------------------------------------------------
+# test_deploy_mode_prefers_firebase_sa_over_gcp_adc (#154/#211): in a
+# Firebase repo, --mode deploy should cache the project Firebase-vault
+# SA key first and must not probe the stale shared GCP ADC item when
+# that key is available.
+# ---------------------------------------------------------------------------
+test_deploy_mode_prefers_firebase_sa_over_gcp_adc() {
+  local case_dir="$WORKDIR/firebase-sa-preflight"
+  local cache_dir="$case_dir/cache"
+  local bin_dir="$case_dir/bin"
+  local project="merge-path-test"
+  local shared_adc_uri="op://Private/test-shared-adc/credential"
+  local op_log="$case_dir/op.log"
+  mkdir -p "$case_dir" "$cache_dir" "$bin_dir"
+
+  cat > "$case_dir/.firebaserc" <<JSON
+{ "projects": { "default": "$project" } }
+JSON
+
+  cat > "$bin_dir/op" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$op_log"
+case "\${1:-}" in
+  document)
+    shift
+    if [ "\${1:-}" != "get" ]; then
+      exit 1
+    fi
+    shift
+    out_path=""
+    while [ \$# -gt 0 ]; do
+      if [ "\${1:-}" = "--out-file" ]; then
+        shift
+        out_path="\${1:-}"
+      fi
+      shift || true
+    done
+    if [ -z "\$out_path" ]; then
+      exit 1
+    fi
+    cat > "\$out_path" <<'JSON'
+{
+  "type": "service_account",
+  "project_id": "merge-path-test",
+  "private_key_id": "fake-key-id",
+  "private_key": "REDACTED_TEST_FIXTURE_NOT_A_REAL_KEY",
+  "client_email": "firebase-deployer@merge-path-test.iam.gserviceaccount.com",
+  "client_id": "0",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}
+JSON
+    exit 0
+    ;;
+  read)
+    if [ "\${2:-}" = "$shared_adc_uri" ]; then
+      echo "FATAL: deploy preflight read stale shared GCP ADC despite Firebase SA key" >&2
+      exit 88
+    fi
+    # Cloudflare token is optional; return empty/unavailable.
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$bin_dir/op"
+
+  local out err rc=0
+  (
+    cd "$case_dir"
+    PATH="$bin_dir:$STUB_DIR:$PATH" \
+      OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+      GCP_ADC_OP_URI="$shared_adc_uri" \
+      "$SCRIPT" --mode deploy >"$case_dir/out" 2>"$case_dir/err"
+  ) || rc=$?
+  out="$(cat "$case_dir/out")"
+  err="$(cat "$case_dir/err")"
+
+  if [ "$rc" -ne 0 ]; then
+    fail "test_deploy_mode_prefers_firebase_sa_over_gcp_adc: rc=$rc; stderr=$err"
+    return
+  fi
+  if ! echo "$out" | grep -q "export OP_PREFLIGHT_FIREBASE_SA_TMPFILE="; then
+    fail "test_deploy_mode_prefers_firebase_sa_over_gcp_adc: missing Firebase SA marker export; out=$out"
+    return
+  fi
+  if ! echo "$out" | grep -q "export OP_PREFLIGHT_FIREBASE_PROJECT=$project"; then
+    fail "test_deploy_mode_prefers_firebase_sa_over_gcp_adc: missing Firebase project export; out=$out"
+    return
+  fi
+  if echo "$out" | grep -q "OP_PREFLIGHT_ADC_TMPFILE"; then
+    fail "test_deploy_mode_prefers_firebase_sa_over_gcp_adc: should not export shared ADC marker; out=$out"
+    return
+  fi
+  if grep -qF "$shared_adc_uri" "$op_log"; then
+    fail "test_deploy_mode_prefers_firebase_sa_over_gcp_adc: op read touched shared GCP ADC; log=$(cat "$op_log")"
+    return
+  fi
+  if ! echo "$err" | grep -q "Firebase SA key ($project): loaded"; then
+    fail "test_deploy_mode_prefers_firebase_sa_over_gcp_adc: summary missing Firebase SA loaded line; stderr=$err"
+    return
+  fi
+  pass "test_deploy_mode_prefers_firebase_sa_over_gcp_adc: Firebase SA cached before shared ADC"
+}
+
+# ---------------------------------------------------------------------------
+# test_deploy_mode_refreshes_unusable_cached_firebase_sa (#154/#211):
+# a stale/corrupt preflight-cached Firebase SA file must force the
+# outer fast path into the real refresh flow, not return a cache hit
+# with deploy credentials silently unset.
+# ---------------------------------------------------------------------------
+test_deploy_mode_refreshes_unusable_cached_firebase_sa() {
+  local case_dir="$WORKDIR/firebase-sa-refresh"
+  local cache_dir="$case_dir/cache"
+  local bin_dir="$case_dir/bin"
+  local project="merge-path-test"
+  local shared_adc_uri="op://Private/test-shared-adc-refresh/credential"
+  local op_log="$case_dir/op.log"
+  local bad_sa_file="$case_dir/bad-preflight-sa.json"
+  mkdir -p "$case_dir" "$cache_dir" "$bin_dir"
+
+  cat > "$case_dir/.firebaserc" <<JSON
+{ "projects": { "default": "$project" } }
+JSON
+  printf '{not-json\n' > "$bad_sa_file"
+
+  local epoch
+  epoch=$(date +%s)
+  cat > "$cache_dir/op-preflight-.env" <<EOF
+OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
+OP_PREFLIGHT_TTL_SECONDS=14400
+OP_PREFLIGHT_AGENT=''
+OP_PREFLIGHT_MODE=deploy
+OP_PREFLIGHT_DONE=1
+GOOGLE_APPLICATION_CREDENTIALS=$bad_sa_file
+OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$bad_sa_file
+OP_PREFLIGHT_FIREBASE_PROJECT=$project
+EOF
+  chmod 600 "$cache_dir/op-preflight-.env"
+
+  cat > "$bin_dir/op" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$op_log"
+case "\${1:-}" in
+  document)
+    shift
+    if [ "\${1:-}" != "get" ]; then
+      exit 1
+    fi
+    shift
+    out_path=""
+    while [ \$# -gt 0 ]; do
+      if [ "\${1:-}" = "--out-file" ]; then
+        shift
+        out_path="\${1:-}"
+      fi
+      shift || true
+    done
+    if [ -z "\$out_path" ]; then
+      exit 1
+    fi
+    cat > "\$out_path" <<'JSON'
+{
+  "type": "service_account",
+  "project_id": "merge-path-test",
+  "private_key_id": "fake-key-id",
+  "private_key": "REDACTED_TEST_FIXTURE_NOT_A_REAL_KEY",
+  "client_email": "firebase-deployer@merge-path-test.iam.gserviceaccount.com",
+  "client_id": "0",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}
+JSON
+    exit 0
+    ;;
+  read)
+    if [ "\${2:-}" = "$shared_adc_uri" ]; then
+      echo "FATAL: refresh should re-read Firebase SA before shared GCP ADC" >&2
+      exit 88
+    fi
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$bin_dir/op"
+
+  local out err rc=0
+  (
+    cd "$case_dir"
+    PATH="$bin_dir:$STUB_DIR:$PATH" \
+      OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+      GCP_ADC_OP_URI="$shared_adc_uri" \
+      "$SCRIPT" --mode deploy >"$case_dir/out" 2>"$case_dir/err"
+  ) || rc=$?
+  out="$(cat "$case_dir/out")"
+  err="$(cat "$case_dir/err")"
+
+  if [ "$rc" -ne 0 ]; then
+    fail "test_deploy_mode_refreshes_unusable_cached_firebase_sa: rc=$rc; stderr=$err"
+    return
+  fi
+  if ! echo "$err" | grep -q "refreshing deploy credentials"; then
+    fail "test_deploy_mode_refreshes_unusable_cached_firebase_sa: missing refresh warning; stderr=$err"
+    return
+  fi
+  if ! grep -q "document get" "$op_log"; then
+    fail "test_deploy_mode_refreshes_unusable_cached_firebase_sa: refresh did not re-read Firebase SA; log=$(cat "$op_log")"
+    return
+  fi
+  if grep -qF "$shared_adc_uri" "$op_log"; then
+    fail "test_deploy_mode_refreshes_unusable_cached_firebase_sa: refresh touched shared GCP ADC; log=$(cat "$op_log")"
+    return
+  fi
+  if ! echo "$out" | grep -q "export OP_PREFLIGHT_FIREBASE_SA_TMPFILE="; then
+    fail "test_deploy_mode_refreshes_unusable_cached_firebase_sa: missing refreshed Firebase SA marker export; out=$out"
+    return
+  fi
+  pass "test_deploy_mode_refreshes_unusable_cached_firebase_sa: unusable cached SA forces refresh"
+}
+
+# ---------------------------------------------------------------------------
+# test_deploy_mode_refreshes_mismatched_cached_firebase_sa (#154/#211):
+# a project-A Firebase SA cache must not be re-exported in project B
+# within the preflight TTL.
+# ---------------------------------------------------------------------------
+test_deploy_mode_refreshes_mismatched_cached_firebase_sa() {
+  local case_dir="$WORKDIR/firebase-sa-project-mismatch"
+  local cache_dir="$case_dir/cache"
+  local bin_dir="$case_dir/bin"
+  local cached_project="project-a"
+  local current_project="project-b"
+  local shared_adc_uri="op://Private/test-shared-adc-mismatch/credential"
+  local op_log="$case_dir/op.log"
+  local cached_sa_file="$case_dir/project-a-sa.json"
+  mkdir -p "$case_dir" "$cache_dir" "$bin_dir"
+
+  cat > "$case_dir/.firebaserc" <<JSON
+{ "projects": { "default": "$current_project" } }
+JSON
+  cat > "$cached_sa_file" <<JSON
+{
+  "type": "service_account",
+  "project_id": "$cached_project",
+  "private_key_id": "fake-key-id",
+  "private_key": "REDACTED_TEST_FIXTURE_NOT_A_REAL_KEY",
+  "client_email": "firebase-deployer@${cached_project}.iam.gserviceaccount.com",
+  "client_id": "0",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}
+JSON
+
+  local epoch
+  epoch=$(date +%s)
+  cat > "$cache_dir/op-preflight-.env" <<EOF
+OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
+OP_PREFLIGHT_TTL_SECONDS=14400
+OP_PREFLIGHT_AGENT=''
+OP_PREFLIGHT_MODE=deploy
+OP_PREFLIGHT_DONE=1
+GOOGLE_APPLICATION_CREDENTIALS=$cached_sa_file
+OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$cached_sa_file
+OP_PREFLIGHT_FIREBASE_PROJECT=$cached_project
+EOF
+  chmod 600 "$cache_dir/op-preflight-.env"
+
+  cat > "$bin_dir/op" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$op_log"
+case "\${1:-}" in
+  document)
+    shift
+    if [ "\${1:-}" != "get" ]; then
+      exit 1
+    fi
+    shift
+    out_path=""
+    while [ \$# -gt 0 ]; do
+      if [ "\${1:-}" = "--out-file" ]; then
+        shift
+        out_path="\${1:-}"
+      fi
+      shift || true
+    done
+    if [ -z "\$out_path" ]; then
+      exit 1
+    fi
+    cat > "\$out_path" <<'JSON'
+{
+  "type": "service_account",
+  "project_id": "project-b",
+  "private_key_id": "fake-key-id",
+  "private_key": "REDACTED_TEST_FIXTURE_NOT_A_REAL_KEY",
+  "client_email": "firebase-deployer@project-b.iam.gserviceaccount.com",
+  "client_id": "0",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}
+JSON
+    exit 0
+    ;;
+  read)
+    if [ "\${2:-}" = "$shared_adc_uri" ]; then
+      echo "FATAL: project mismatch should re-read current Firebase SA before shared GCP ADC" >&2
+      exit 88
+    fi
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$bin_dir/op"
+
+  local out err rc=0
+  (
+    cd "$case_dir"
+    PATH="$bin_dir:$STUB_DIR:$PATH" \
+      OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+      GCP_ADC_OP_URI="$shared_adc_uri" \
+      "$SCRIPT" --mode deploy >"$case_dir/out" 2>"$case_dir/err"
+  ) || rc=$?
+  out="$(cat "$case_dir/out")"
+  err="$(cat "$case_dir/err")"
+
+  if [ "$rc" -ne 0 ]; then
+    fail "test_deploy_mode_refreshes_mismatched_cached_firebase_sa: rc=$rc; stderr=$err"
+    return
+  fi
+  if ! echo "$err" | grep -q "cached Firebase project SA key is for '$cached_project', but current project is '$current_project'"; then
+    fail "test_deploy_mode_refreshes_mismatched_cached_firebase_sa: missing project mismatch warning; stderr=$err"
+    return
+  fi
+  if ! grep -q "document get" "$op_log"; then
+    fail "test_deploy_mode_refreshes_mismatched_cached_firebase_sa: refresh did not re-read current Firebase SA; log=$(cat "$op_log")"
+    return
+  fi
+  if grep -qF "$shared_adc_uri" "$op_log"; then
+    fail "test_deploy_mode_refreshes_mismatched_cached_firebase_sa: refresh touched shared GCP ADC; log=$(cat "$op_log")"
+    return
+  fi
+  if ! echo "$out" | grep -q "export OP_PREFLIGHT_FIREBASE_PROJECT=$current_project"; then
+    fail "test_deploy_mode_refreshes_mismatched_cached_firebase_sa: missing refreshed current-project export; out=$out"
+    return
+  fi
+  pass "test_deploy_mode_refreshes_mismatched_cached_firebase_sa: project mismatch forces refresh"
+}
+
+# ---------------------------------------------------------------------------
+# test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch (#154/#211):
+# the session marker may still name the current project even if the
+# deterministic Firebase SA tempfile was overwritten. The fast path must
+# validate the file itself before re-exporting it.
+# ---------------------------------------------------------------------------
+test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch() {
+  local case_dir="$WORKDIR/firebase-sa-file-mismatch"
+  local cache_dir="$case_dir/cache"
+  local bin_dir="$case_dir/bin"
+  local current_project="project-b"
+  local wrong_project="project-a"
+  local shared_adc_uri="op://Private/test-shared-adc-file-mismatch/credential"
+  local op_log="$case_dir/op.log"
+  mkdir -p "$case_dir" "$cache_dir" "$bin_dir"
+  local cached_sa_file="$cache_dir/op-preflight--firebase-sa.json"
+
+  cat > "$case_dir/.firebaserc" <<JSON
+{ "projects": { "default": "$current_project" } }
+JSON
+  cat > "$cached_sa_file" <<JSON
+{
+  "type": "service_account",
+  "project_id": "$wrong_project",
+  "private_key_id": "fake-key-id",
+  "private_key": "REDACTED_TEST_FIXTURE_NOT_A_REAL_KEY",
+  "client_email": "firebase-deployer@${wrong_project}.iam.gserviceaccount.com",
+  "client_id": "0",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}
+JSON
+
+  local epoch
+  epoch=$(date +%s)
+  cat > "$cache_dir/op-preflight-.env" <<EOF
+OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
+OP_PREFLIGHT_TTL_SECONDS=14400
+OP_PREFLIGHT_AGENT=''
+OP_PREFLIGHT_MODE=deploy
+OP_PREFLIGHT_DONE=1
+GOOGLE_APPLICATION_CREDENTIALS=$cached_sa_file
+OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$cached_sa_file
+OP_PREFLIGHT_FIREBASE_PROJECT=$current_project
+EOF
+  chmod 600 "$cache_dir/op-preflight-.env"
+
+  cat > "$bin_dir/op" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$op_log"
+case "\${1:-}" in
+  document)
+    shift
+    if [ "\${1:-}" != "get" ]; then
+      exit 1
+    fi
+    shift
+    out_path=""
+    while [ \$# -gt 0 ]; do
+      if [ "\${1:-}" = "--out-file" ]; then
+        shift
+        out_path="\${1:-}"
+      fi
+      shift || true
+    done
+    if [ -z "\$out_path" ]; then
+      exit 1
+    fi
+    if [ -s "\$out_path" ]; then
+      echo "FATAL: op document get destination was not truncated before fetch" >&2
+      exit 77
+    fi
+    cat > "\$out_path" <<'JSON'
+{
+  "type": "service_account",
+  "project_id": "project-b",
+  "private_key_id": "fake-key-id",
+  "private_key": "REDACTED_TEST_FIXTURE_NOT_A_REAL_KEY",
+  "client_email": "firebase-deployer@project-b.iam.gserviceaccount.com",
+  "client_id": "0",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}
+JSON
+    exit 0
+    ;;
+  read)
+    if [ "\${2:-}" = "$shared_adc_uri" ]; then
+      echo "FATAL: file mismatch should re-read current Firebase SA before shared GCP ADC" >&2
+      exit 88
+    fi
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$bin_dir/op"
+
+  local out err rc=0
+  (
+    cd "$case_dir"
+    PATH="$bin_dir:$STUB_DIR:$PATH" \
+      OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+      GCP_ADC_OP_URI="$shared_adc_uri" \
+      "$SCRIPT" --mode deploy >"$case_dir/out" 2>"$case_dir/err"
+  ) || rc=$?
+  out="$(cat "$case_dir/out")"
+  err="$(cat "$case_dir/err")"
+
+  if [ "$rc" -ne 0 ]; then
+    fail "test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch: rc=$rc; stderr=$err"
+    return
+  fi
+  if ! echo "$err" | grep -q "cached Firebase project SA key file does not match current project '$current_project'"; then
+    fail "test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch: missing file mismatch warning; stderr=$err"
+    return
+  fi
+  if ! grep -q "document get" "$op_log"; then
+    fail "test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch: refresh did not re-read current Firebase SA; log=$(cat "$op_log")"
+    return
+  fi
+  if grep -qF "$shared_adc_uri" "$op_log"; then
+    fail "test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch: refresh touched shared GCP ADC; log=$(cat "$op_log")"
+    return
+  fi
+  if ! echo "$out" | grep -q "export OP_PREFLIGHT_FIREBASE_PROJECT=$current_project"; then
+    fail "test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch: missing refreshed current-project export; out=$out"
+    return
+  fi
+  pass "test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch: file mismatch forces refresh"
+}
+
 test_check_fresh_cache
 test_check_missing_cache
 test_check_stale_cache
@@ -338,6 +971,12 @@ test_status_alias
 test_quiet_mode
 test_default_mode_is_review
 test_check_deploy_no_python3_probe
+test_check_deploy_firebase_sa_no_python3_probe
+test_check_deploy_firebase_sa_project_mismatch_fails_closed
+test_deploy_mode_prefers_firebase_sa_over_gcp_adc
+test_deploy_mode_refreshes_unusable_cached_firebase_sa
+test_deploy_mode_refreshes_mismatched_cached_firebase_sa
+test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch
 
 echo
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
Bulk sync to [mergepath@1cdcc9d](https://github.com/nathanjohnpayne/mergepath/commit/1cdcc9d52a93df764c01f0c563040bbc22a62d5b) — verbatim canonical/kit mirror per `.mergepath-sync.yml`.

Opened by `scripts/sync-to-downstream.sh --sync-all` (v0.4.0-layer3-sync-all, see [#168](https://github.com/nathanjohnpayne/mergepath/issues/168)). Unlike a per-commit propagation PR, this replays the **current HEAD state of every canonical + kit path** so a consumer that has fallen behind reaches a clean steady state in one shot.

## Canonical paths synced
  - scripts/op-preflight.sh
  - scripts/lib/preflight-helpers.sh
  - scripts/lib/gh-retry-helpers.sh
  - scripts/coderabbit-wait.sh
  - scripts/codex-review-request.sh
  - scripts/codex-review-check.sh
  - scripts/phase-4b-classifier.sh
  - scripts/post-phase-4b-handoff.sh
  - scripts/codex-p1-gate.sh
  - scripts/daily-feedback-rollup.sh
  - scripts/lib/daily-feedback-rollup-helpers.sh
  - scripts/disagreement-detector.cjs
  - scripts/resolve-pr-threads.sh
  - scripts/request-label-removal.sh
  - scripts/gh-as-author.sh
  - scripts/gh-as-reviewer.sh
  - scripts/identity-check.sh
  - scripts/hooks/gh-pr-guard.sh
  - scripts/hooks/label-removal-guard.sh
  - tests/test_gh_pr_guard.sh
  - tests/test_gh_as_author.sh
  - tests/test_gh_as_reviewer.sh
  - tests/test_identity_check.sh
  - tests/test_verify_propagation_pr.sh
  - tests/test_codex_p1_gate.sh
  - tests/test_disagreement_detector.sh
  - tests/test_post_phase_4b_handoff.sh
  - tests/test_op_preflight_check.sh
  - tests/test_helper_autosource.sh
  - tests/test_resolve_pr_threads_rationale_tag.sh
  - tests/test_daily_feedback_rollup.sh
  - tests/test_template_substitution.sh
  - tests/test_export_consumer_facts.sh
  - .github/workflows/agent-review.yml
  - .github/workflows/pr-review-policy.yml
  - .github/workflows/dependabot-auto-merge.yml
  - .github/workflows/auto-clear-blocking-labels.yml
  - .github/workflows/pr-audit.yml
  - .github/workflows/codex-p1-gate.yml
  - .github/workflows/daily-feedback-rollup.yml

## Kit paths synced
  - scripts/ci/ (kit, allow-extras)
  - scripts/gh-projects/ (kit, allow-extras)
  - scripts/workflow/ (kit, allow-extras)

## Templated paths rendered (per-consumer facts applied)
  - eslint.config.js (templated, rendered from examples/eslint.config.js)


Authoring-Agent: codex

## Self-Review
- Correctness: mirrors mergepath@1cdcc9d HEAD state verbatim per the manifest. Each path was already reviewed in its upstream PR.
- Regression risk: low. Verbatim mirror; kit paths use allow-extras semantics so consumer-only files are kept.
- Style: N/A (mirror).
- Test coverage: relies on the consumer repo CI. No test changes shipped.
- Security: no new attack surface; `.sync-overrides.yml` was honored per-consumer so documented divergences are untouched.