### PR TITLE
fix(builds): correct stack ribbon and project-page stacks

### DIFF
--- a/src/content/projects/device-source-of-truth.md
+++ b/src/content/projects/device-source-of-truth.md
@@ -17,7 +17,7 @@ status: "PAUSED"
 metadata:
   format: "Internal platform tool"
   focus: "Partner platforms and device support"
-stack: "React · TypeScript · Vite · Firebase · Vitest"
+stack: "React · TypeScript · Vite · Tailwind · Zod · Firebase · Express · Vitest"
 related:
   - label: "Blog: Six PRs, One Bug—What AI Agents Actually Get Wrong"
     href: "/blog/six-prs-one-bug-agent-failure-modes/"

--- a/src/content/projects/friends-and-family-billing.md
+++ b/src/content/projects/friends-and-family-billing.md
@@ -17,7 +17,7 @@ status: "SHIPPED"
 metadata:
   format: "Household coordination tool"
   focus: "Shared subscriptions and recurring group expenses"
-stack: "React · TypeScript · Vite · Firebase · Vitest"
+stack: "React · JavaScript · Vite · Firebase · Vitest · Playwright"
 related:
   - label: "Blog: Six PRs, One Bug—What AI Agents Actually Get Wrong"
     href: "/blog/six-prs-one-bug-agent-failure-modes/"

--- a/src/content/projects/mergepath.md
+++ b/src/content/projects/mergepath.md
@@ -12,12 +12,12 @@ gradientFrom: "#dce3f0"
 gradientTo: "#f5f0e4"
 liveUrl: "https://htmlpreview.github.io/?https://raw.githubusercontent.com/nathanjohnpayne/mergepath/main/mergepath/playground/index.html"
 githubUrl: "https://github.com/nathanjohnpayne/mergepath"
-tags: ["Infrastructure", "AI Tooling", "GitHub Actions", "Bash/Python"]
+tags: ["Infrastructure", "AI Tooling", "GitHub Actions", "Bash"]
 status: "SHIPPED"
 metadata:
   format: "Repository standard"
   focus: "Agent governance, code review, and CI enforcement"
-stack: "Bash · Python · GitHub Actions · 1Password · Claude Code · Codex · Cursor · CodeRabbit"
+stack: "Bash · GitHub Actions · 1Password · Claude Code · Codex · Cursor · CodeRabbit"
 related:
   - label: "Blog: Agent Approval Workflow and the Genesis of Mergepath"
     href: "/blog/agent-approval-workflow-genesis-of-mergepath/"

--- a/src/content/projects/override.md
+++ b/src/content/projects/override.md
@@ -17,7 +17,7 @@ status: "SHIPPED"
 metadata:
   format: "Financial operating system"
   focus: "Capitalization, ownership, and investor workflows"
-stack: "Next.js · TypeScript · Firebase · Vitest"
+stack: "Next.js · TypeScript · Tailwind · Zod · Firebase · Vitest"
 related:
   - label: "Blog: Agent Approval Workflow and the Genesis of Mergepath"
     href: "/blog/agent-approval-workflow-genesis-of-mergepath/"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -159,7 +159,7 @@ const homepageJsonLd = {
             </div>
             <div class="stack-ribbon">
               <span class="stack-label">Stack</span>
-              <span class="stack-items">Bash · Python · TypeScript · Vanilla JS · React · Next.js · Vite · Tailwind CSS · Vitest · Firebase · GitHub Actions · Claude Code · Codex · Cursor</span>
+              <span class="stack-items">Bash · TypeScript · Vanilla JS · React · Next.js · Vite · Tailwind CSS · Zod · Vitest · Playwright · Firebase · Express · GitHub Actions · Anthropic · OpenAI · Claude Code · Codex · Cursor · CodeRabbit</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Scanned all six Builds repos (mergepath, matchline, overridebroadway, swipewatch, friends-and-family-billing, device-source-of-truth) and corrected stack metadata that had drifted from what the projects actually use.

**Homepage ribbon** (`src/pages/index.astro`)
- Removed **Python**—zero `.py` files exist across any of the six repos.
- Added **Zod** (matchline, override, dst), **Playwright** (ffb E2E), **Express** (dst Cloud Functions API), **Anthropic** + **OpenAI** (matchline's runtime LLM layer), and **CodeRabbit** (part of the multi-agent review system the section describes).

**Project pages** (`src/content/projects/*.md`)
- **mergepath**—dropped Python from `stack`; `Bash/Python` tag becomes `Bash`.
- **friends-and-family-billing**—`TypeScript` becomes `JavaScript` (no tsconfig, no `.ts/.tsx`, no typescript dep); added `Playwright`.
- **override**—added `Tailwind` and `Zod`.
- **device-source-of-truth**—added `Tailwind`, `Zod`, and `Express`.

Matchline and Swipe Watch were already accurate and are unchanged.

## Self-Review

- **Correctness**—Each change verified against the source repos: zero `.py` files across all six (find), dependency presence in `package.json` (zod, playwright, express, @anthropic-ai/sdk, openai), and absence of tsconfig/`.ts` in ffb. Rendered output confirmed in the dev preview and built HTML for the ribbon and all four project pages.
- **Regression risk**—Low. Content/copy-only changes: one Astro text node and four markdown frontmatter strings. No logic, schema, or component changes.
- **Style**—Kept the existing middle-dot separator and the language → framework → styling → data → infra → test → tooling ordering.
- **Test coverage**—Full suite green (164/164); `npm run build` clean. No test asserts ribbon/stack strings, so none needed updating.
- **Security / dependency hygiene**—No dependency, config, or credential changes.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` passes (164/164)
- [x] Homepage ribbon renders the full updated stack (preview + dist)
- [x] All four edited project pages render the corrected stack; mergepath card shows the `Bash` tag
