### PR TITLE
fix(home): use full title for the HTML Mock-up writing link

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -99,7 +99,7 @@ const homepageJsonLd = {
                 <ul class="writing-list">
                   <li><a href="/blog/six-prs-one-bug-agent-failure-modes/" class="p-name-link">Six PRs, One Bug: What AI Agents Actually Get <span class="no-break">Wrong<span class="link-arrow" aria-hidden="true">→</span></span></a></li>
                   <li><a href="/blog/agent-approval-workflow-genesis-of-mergepath/" class="p-name-link">Agent Approval Workflow and the Genesis of <span class="no-break">Mergepath<span class="link-arrow" aria-hidden="true">→</span></span></a></li>
-                  <li><a href="/blog/html-mockups-as-spec/" class="p-name-link">The HTML Mock-up Is the <span class="no-break">Spec<span class="link-arrow" aria-hidden="true">→</span></span></a></li>
+                  <li><a href="/blog/html-mockups-as-spec/" class="p-name-link">The HTML Mock-up Is the Spec: How I Got Visual Work Out of Claude <span class="no-break">Code<span class="link-arrow" aria-hidden="true">→</span></span></a></li>
                 </ul>
               </div>
               <div class="now-ribbon">


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

The About > Writing list on the homepage showed a shortened title for the third entry ("The HTML Mock-up Is the Spec") while the other two links carry their full post titles. This updates it to the complete title from the post frontmatter:

> The HTML Mock-up Is the Spec: How I Got Visual Work Out of Claude Code

The trailing word ("Code") and arrow stay bound in the existing `no-break` span so the arrow can't orphan onto its own line—matching the pattern used by the sibling links.

## Self-Review

- **Correctness**—Title matches the post frontmatter `title` in `src/content/blog/html-mockups-as-spec.md` exactly. Verified the rendered link in the dev preview (full text, arrow bound to "Code", wraps cleanly to two lines on mobile) and in the built HTML.
- **Regression risk**—Low. Single-line, copy-only change to one list item; no logic, schema, or styling changes. Reuses the established `no-break` / `link-arrow` markup.
- **Style**—Consistent with the two sibling Writing links (full title + bound final word/arrow).
- **Test coverage**—Full suite green (164/164); `npm run build` clean. No test asserts this link's text.
- **Security / dependency hygiene**—No dependency, config, or credential changes.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` passes (164/164)
- [x] Link renders the full title with the arrow bound to "Code" (preview + dist)
