### PR TITLE
sync: fix(rollup): bound daily-feedback-rollup body under 65536 cap (#400) (#401) (mergepath@1b4ba0d)

### DIFF
--- a/scripts/daily-feedback-rollup.sh
+++ b/scripts/daily-feedback-rollup.sh
@@ -127,6 +127,20 @@ DEDUPE_WINDOW_DAYS="${ROLLUP_DEDUPE_WINDOW_DAYS:-14}"
 # label scopes). The 14-day window already bounds expected volume;
 # this is belt-and-suspenders.
 MAX_PRIOR_ROLLUPS_PER_LABEL="${ROLLUP_MAX_PRIOR_ROLLUPS_PER_LABEL:-50}"
+# Body-size policy (#400, revised per #401 Phase-4b review). GitHub caps
+# issue/comment bodies at 65536 bytes (the #397 failure mode). The daily
+# job scans ONLY the current per-day window, so a finding not recorded in
+# the issue BODY (the one surface the dedupe pass reads) is lost for good
+# once the window advances — capping-and-dropping would silently lose it.
+# We therefore render EVERY finding into the body: the top-N highest-
+# severity inline with full detail, the rest in a collapsed <details>
+# block (trimmed, then mp-id stubs) so all mp-ids stay dedupe-readable. If
+# even stubs won't fit under ROLLUP_BODY_BUDGET we FAIL LOUD rather than
+# drop. Paired with the --body-file switch (avoids the lower ARG_MAX
+# ceiling that --body hits first).
+ROLLUP_MAX_VISIBLE="${ROLLUP_MAX_VISIBLE:-60}"
+# Whole-body byte budget; headroom under GitHub's hard 65536 cap.
+ROLLUP_BODY_BUDGET="${ROLLUP_BODY_BUDGET:-64000}"
 
 # Compute the window. Default: yesterday 00:00:00Z → today 00:00:00Z UTC.
 # BSD date (macOS) and GNU date have divergent flag syntax — try GNU first.
@@ -529,8 +543,12 @@ PRE_DEDUP_POLISH=$(wc -l < "$POLISH_NDJSON" | tr -d ' ')
 # out explicitly but is the natural read.)
 
 TRIAGED_IDS_FILE=$(mktemp "${TMPDIR:-/tmp}/rollup-triaged-XXXXXX.ids")
-# Extend the EXIT trap to clean this up too.
-trap 'rm -f "$SUBSTANTIVE_NDJSON" "$POLISH_NDJSON" "$TRIAGED_IDS_FILE"' EXIT
+# Rendered-body scratch file (#400): post_or_append writes the body here
+# and passes --body-file, instead of --body "$body" (which hits ARG_MAX
+# before the GitHub 65536 cap on a large body).
+BODY_FILE=$(mktemp "${TMPDIR:-/tmp}/rollup-body-XXXXXX.md")
+# Extend the EXIT trap to clean these up too.
+trap 'rm -f "$SUBSTANTIVE_NDJSON" "$POLISH_NDJSON" "$TRIAGED_IDS_FILE" "$BODY_FILE"' EXIT
 
 # Compute the dedupe-window cutoff. We pass it to `gh issue list` as
 # `closed:>=YYYY-MM-DD` so the search server-side filters out stale
@@ -562,7 +580,7 @@ collect_triaged_ids_for_label() {
        --state all \
        --search "is:issue label:$label closed:>=$DEDUP_CUTOFF" \
        --limit "$MAX_PRIOR_ROLLUPS_PER_LABEL" \
-       --json number,state,body 2>/dev/null); then
+       --json number,state,body,comments 2>/dev/null); then
     echo "daily-feedback-rollup: WARN dedupe: could not list prior '$label' rollups (best-effort, continuing)" >&2
     DEDUP_FETCH_FAILURES=$((DEDUP_FETCH_FAILURES + 1))
     return 0
@@ -577,7 +595,7 @@ collect_triaged_ids_for_label() {
        --label "$label" \
        --state open \
        --limit "$MAX_PRIOR_ROLLUPS_PER_LABEL" \
-       --json number,state,body 2>/dev/null); then
+       --json number,state,body,comments 2>/dev/null); then
     echo "daily-feedback-rollup: WARN dedupe: could not list open '$label' rollups (best-effort, continuing)" >&2
     DEDUP_FETCH_FAILURES=$((DEDUP_FETCH_FAILURES + 1))
     open_json='[]'
@@ -596,15 +614,24 @@ collect_triaged_ids_for_label() {
   n=$(printf '%s' "$merged" | jq 'length')
   local x=0
   while [ "$x" -lt "$n" ]; do
-    local issue_state issue_body
+    local issue_state issue_text
     issue_state=$(printf '%s' "$merged" | jq -r ".[$x].state")
-    issue_body=$(printf '%s' "$merged" | jq -r ".[$x].body // \"\"")
+    # Parse the BODY *and* all comment bodies (#402). The throttle path
+    # appends today's findings as a COMMENT (append-only, atomic — we keep
+    # that rather than a read-modify-write body edit that could clobber a
+    # concurrent run). So mp-ids and triage signals can live in comments;
+    # folding them in here makes the comment-append path dedupe-visible.
+    issue_text=$(printf '%s' "$merged" | jq -r "
+      .[$x] | ((.body // \"\") + \"\n\" + ((.comments // []) | map(.body // \"\") | join(\"\n\")))
+    ")
     if [ "$issue_state" = "CLOSED" ] || [ "$issue_state" = "closed" ]; then
-      # Closed host → ALL mp-ids on this rollup are implicitly triaged.
-      parse_all_ids_from_body "$issue_body" >> "$TRIAGED_IDS_FILE"
+      # Closed host → ALL mp-ids on this rollup (body + comments) are
+      # implicitly triaged.
+      parse_all_ids_from_body "$issue_text" >> "$TRIAGED_IDS_FILE"
     else
-      # Open host → only lines with an explicit triage signal count.
-      parse_triaged_ids_from_body "$issue_body" >> "$TRIAGED_IDS_FILE"
+      # Open host → only lines with an explicit triage signal count,
+      # whether they sit in the body or an appended comment.
+      parse_triaged_ids_from_body "$issue_text" >> "$TRIAGED_IDS_FILE"
     fi
     x=$((x + 1))
   done
@@ -729,7 +756,20 @@ fi
 render_rollup_body() {
   local ndjson_file="$1" track="$2"
   local f="$ndjson_file"
-  cat <<INTRO
+  # Render EVERY finding into the body (#401): top-N highest-severity
+  # inline with full detail, the rest in a collapsed <details> overflow
+  # block. Overflow detail degrades rich -> mp-id stub to fit
+  # ROLLUP_BODY_BUDGET; if even stubs won't fit we return 2 (fail loud,
+  # no partial post) so the caller aborts rather than silently dropping
+  # findings the per-day window will never re-enumerate. All logic stays
+  # INSIDE this function so the test's sed-extraction stays whole.
+  local total
+  total=$(wc -l < "$f" | tr -d ' ')
+
+  local rb
+  rb=$(mktemp -d "${TMPDIR:-/tmp}/rollup-render-XXXXXX")
+
+  cat > "$rb/intro.md" <<INTRO
 Auto-generated rollup of bot review threads that were resolved on
 ${DATE_STAMP} without an associated fix commit or substantive reply.
 Severity scope: ${track} (see § Two-track rollup in #299 for the
@@ -742,22 +782,7 @@ Triage markers (set on the checkbox below):
 
 INTRO
 
-  # Group by PR. NDJSON is naturally per-thread; awk gives us a
-  # quick group-by without re-parsing.
-  jq -s -r '
-    group_by(.pr_number)[] |
-    "## " + .[0].repo + "#" + .[0].pr_number +
-      " (merged " + (.[0].pr_merged_at // "n/a") + ", " +
-      (.[0].pr_title | tostring) + ")\n" +
-    (map(
-      "- [ ] [" + .thread_path + ":" + .thread_line + "](" + .thread_url + ")" +
-      " — `" + .author + "` " + .severity +
-      " [" + .tag_note + "]: \"" + .body_excerpt + "\"" +
-      " <!-- mp-id:" + .item_id + " -->"
-    ) | join("\n"))
-  ' "$f"
-
-  cat <<FOOTER
+  cat > "$rb/footer.md" <<FOOTER
 
 ---
 
@@ -775,9 +800,84 @@ INTRO
   - deferred-untagged (heuristic): ${COUNT_DEFERRED_UNTAGGED}
 - Dedupe pass (#304): ${COUNT_DEDUP_SKIPPED} item(s) previously triaged on prior rollups in the ${DEDUPE_WINDOW_DAYS}-day window (since ${DEDUP_CUTOFF})
 
-Generator: \`scripts/daily-feedback-rollup.sh\` (mergepath#299 v1 + #304 dedupe)
+Generator: \`scripts/daily-feedback-rollup.sh\` (mergepath#299 v1 + #304 dedupe + #401 overflow)
 </details>
 FOOTER
+
+  # Severity-major sort (P0 first), one JSON per line. Top-N render inline
+  # with full detail; the rest are the overflow tail.
+  jq -s -c '
+    def sevrank:
+      (.severity // "Unknown") as $s |
+      if   $s == "P0"      then 0 elif $s == "P1"      then 1
+      elif $s == "P2"      then 2 elif $s == "Major"   then 3
+      elif $s == "Minor"   then 4 elif $s == "P3"      then 5
+      elif $s == "Nitpick" then 6 elif $s == "Trivial" then 7
+      else 8 end;
+    sort_by(sevrank * 1000000 + ((.pr_number | tonumber?) // 0)) | .[]
+  ' "$f" > "$rb/sorted.ndjson"
+  head -n "$ROLLUP_MAX_VISIBLE" "$rb/sorted.ndjson" > "$rb/top.ndjson"
+  tail -n "+$((ROLLUP_MAX_VISIBLE + 1))" "$rb/sorted.ndjson" > "$rb/over.ndjson" 2>/dev/null || : > "$rb/over.ndjson"
+  local overflow_count
+  overflow_count=$(wc -l < "$rb/over.ndjson" | tr -d ' ')
+
+  # Inline top-N (full detail). Byte-identical to the pre-#400 line format
+  # so unchecked_count_on() and the mp-id parsers still match.
+  jq -s -r '
+    group_by(.pr_number)[] |
+    "## " + .[0].repo + "#" + .[0].pr_number +
+      " (merged " + (.[0].pr_merged_at // "n/a") + ", " +
+      (.[0].pr_title | tostring) + ")\n" +
+    (map(
+      "- [ ] [" + .thread_path + ":" + .thread_line + "](" + .thread_url + ")" +
+      " — `" + .author + "` " + .severity +
+      " [" + .tag_note + "]: \"" + .body_excerpt + "\"" +
+      " <!-- mp-id:" + .item_id + " -->"
+    ) | join("\n"))
+  ' "$rb/top.ndjson" > "$rb/inline.md"
+
+  # Overflow renderings (tried rich -> stub until the body fits). Both
+  # keep an OPEN `- [ ]` + the exact `<!-- mp-id:ID -->` marker and carry
+  # NO triage signal: the mp-id sits alone on its bullet line; any `#NUM`
+  # appears only on a `###` header line (rich), never adjacent to a
+  # boundary char, so parse_triaged_ids_from_body never mis-reads it.
+  jq -s -r '
+    group_by(.pr_number)[] |
+    "### " + .[0].repo + "#" + .[0].pr_number + " (merged " + (.[0].pr_merged_at // "n/a") + ")\n" +
+    (map(
+      "- [ ] [" + .thread_path + ":" + .thread_line + "](" + .thread_url + ")" +
+      " — `" + .author + "` " + .severity +
+      " <!-- mp-id:" + .item_id + " -->"
+    ) | join("\n"))
+  ' "$rb/over.ndjson" > "$rb/over-rich.md"
+  jq -r '"- [ ] <!-- mp-id:" + .item_id + " -->"' "$rb/over.ndjson" > "$rb/over-stub.md"
+
+  local mode chosen=""
+  for mode in rich stub; do
+    {
+      cat "$rb/intro.md"
+      cat "$rb/inline.md"
+      if [ "$overflow_count" -gt 0 ]; then
+        printf '\n<details>\n<summary>+%s more finding(s) — full set retained below. NOTE: closing this issue marks ALL of these (including the collapsed overflow) as triaged.</summary>\n\n' "$overflow_count"
+        cat "$rb/over-$mode.md"
+        printf '\n</details>\n'
+      fi
+      cat "$rb/footer.md"
+    } > "$rb/body-$mode.md"
+    if [ "$(wc -c < "$rb/body-$mode.md" | tr -d ' ')" -le "$ROLLUP_BODY_BUDGET" ]; then
+      chosen="$rb/body-$mode.md"
+      break
+    fi
+  done
+
+  if [ -n "$chosen" ]; then
+    cat "$chosen"
+    rm -rf "$rb"
+    return 0
+  fi
+  rm -rf "$rb"
+  echo "daily-feedback-rollup: $track — FATAL: $total findings exceed single-issue capacity (${ROLLUP_BODY_BUDGET}B) even as mp-id stubs; refusing to post a partial rollup that would silently drop findings the per-day window will not re-enumerate. Narrow the window (--since/--until) or split the backlog." >&2
+  return 2
 }
 
 # Self-throttling: count unchecked items on the most recently-opened
@@ -878,8 +978,15 @@ post_or_append() {
   # `--dry-run` stays a pure read.
   ensure_label "$label" "$track"
 
-  local body
-  body=$(render_rollup_body "$ndjson_file" "$track")
+  # Render to a file and post via --body-file (#400): --body "$body"
+  # caps out at ARG_MAX on a large rollup, below GitHub's 65536 limit.
+  # render_rollup_body returns 2 (fail loud, no partial body) if even
+  # mp-id stubs exceed the body budget — abort rather than post a rollup
+  # that silently drops findings the per-day window won't re-enumerate.
+  if ! render_rollup_body "$ndjson_file" "$track" > "$BODY_FILE"; then
+    echo "daily-feedback-rollup: $track — ABORTING: rollup body exceeds the size budget even as stubs (see FATAL above); not posting a partial rollup." >&2
+    exit 2
+  fi
 
   local existing=""
   # No `|| true` here: most_recent_open_rollup now fails-closed (exit 2)
@@ -892,14 +999,13 @@ post_or_append() {
     unchecked=$(unchecked_count_on "$existing")
     if [ "$unchecked" -ge "$throttle" ]; then
       echo "daily-feedback-rollup: $track — appending to existing #$existing ($unchecked unchecked ≥ throttle $throttle)" >&2
-      # shellcheck disable=SC2016
-      gh issue comment "$existing" --repo "$REPO" --body "$body" >&2
+      gh issue comment "$existing" --repo "$REPO" --body-file "$BODY_FILE" >&2
       return 0
     fi
   fi
 
   echo "daily-feedback-rollup: $track — creating new issue '$title'" >&2
-  gh issue create --repo "$REPO" --title "$title" --label "$label" --body "$body"
+  gh issue create --repo "$REPO" --title "$title" --label "$label" --body-file "$BODY_FILE"
 }
 
 post_or_append "$SUBSTANTIVE_NDJSON" "substantive" "$SUBSTANTIVE_LABEL" \

--- a/tests/test_daily_feedback_rollup.sh
+++ b/tests/test_daily_feedback_rollup.sh
@@ -351,6 +351,144 @@ assert_all_ids "$body_all2" "ddd444aaaaaa" "closed-host: duplicate mp-ids de-dup
 assert_all_ids "no markers here at all" "" "closed-host: no markers → empty"
 
 # ---------------------------------------------------------------------
+# render_rollup_body NO-SILENT-LOSS (#400 / #401). The daily window is
+# per-day, so a finding not in the issue BODY is lost once the window
+# advances. Extract the real function (reads actual source — no drift)
+# and assert: EVERY finding's mp-id lands in the body (no cap-drop), the
+# dedupe parsers read them all (and read none as triaged), overflow
+# degrades rich->stub to stay under budget, and an unfittable backlog
+# FAILS LOUD (return 2) instead of dropping.
+# ---------------------------------------------------------------------
+SCRIPT="$ROOT/scripts/daily-feedback-rollup.sh"
+eval "$(sed -n '/^render_rollup_body()/,/^}/p' "$SCRIPT")"
+if type render_rollup_body >/dev/null 2>&1; then
+  pass "render_rollup_body: extracted from source (no factored helper broke the slice)"
+else
+  fail "render_rollup_body: sed extraction failed — function undefined"
+fi
+
+DATE_STAMP="2026-06-01"; ROLLUP_MAX_VISIBLE=60; ROLLUP_BODY_BUDGET=64000
+SINCE="2026-05-31T00:00:00Z"; UNTIL="2026-06-01T00:00:00Z"; pr_count=4
+COUNT_FIX=0; COUNT_REPLY=0; COUNT_STALE=0; COUNT_TAGGED_SKIP=0
+COUNT_TAGGED_SURFACE=0; COUNT_DEFERRED_UNTAGGED=200; COUNT_DEDUP_SKIPPED=0
+DEDUPE_WINDOW_DAYS=14; DEDUP_CUTOFF="2026-05-18"
+
+gen_findings() {  # $1 = count → NDJSON on stdout
+  local n="$1" i=0 sev
+  while [ "$i" -lt "$n" ]; do
+    sev=$(printf 'P0 P1 P2 Major Minor' | tr ' ' '\n' | sed -n "$(((i % 5) + 1))p")
+    jq -nc --arg repo "owner/repo$((i % 4))" --arg pr "$(( (i % 4) + 100 ))" \
+      --arg tp "scripts/file$i.sh" --arg tl "$i" --arg sev "$sev" \
+      --arg id "$(printf 'abc%09x' "$i")" \
+      '{repo:$repo, pr_number:$pr, pr_title:("PR "+$pr), pr_merged_at:"2026-05-31T12:00:00Z",
+        thread_path:$tp, thread_line:$tl,
+        thread_url:("https://github.com/"+$repo+"/pull/"+$pr+"#discussion_r"+$tl),
+        author:"chatgpt-codex-connector[bot]", severity:$sev, tag_note:"deferred-untagged",
+        body_excerpt:"A representative ~150-char excerpt mirroring real bot feedback so the rendered checklist line reflects realistic per-finding size in the body ok done now yes",
+        item_id:$id}'
+    i=$((i + 1))
+  done
+}
+
+BIG_RB="$(mktemp "${TMPDIR:-/tmp}/rb-big-XXXXXX.ndjson")"
+RB_OUT="$(mktemp "${TMPDIR:-/tmp}/rb-out-XXXXXX.md")"
+gen_findings 200 > "$BIG_RB"
+
+# --- 1) Rich mode (default budget): no loss + within cap ---
+render_rollup_body "$BIG_RB" "substantive" > "$RB_OUT"
+RB_BYTES=$(wc -c < "$RB_OUT" | tr -d ' ')
+RB_MPIDS=$(grep -oE '<!-- *mp-id:[a-f0-9]+ *-->' "$RB_OUT" | sort -u | wc -l | tr -d ' ')
+
+if [ "$RB_BYTES" -le 65536 ] && [ "$RB_BYTES" -gt 0 ]; then
+  pass "render_rollup_body: 200-finding body within 65536-byte cap ($RB_BYTES B)"
+else
+  fail "render_rollup_body: body $RB_BYTES B not in 1..65536"
+fi
+if [ "$RB_MPIDS" -eq 200 ]; then
+  pass "render_rollup_body: ALL 200 mp-ids present in body (no silent drop)"
+else
+  fail "render_rollup_body: only $RB_MPIDS/200 mp-ids in body — SILENT LOSS"
+fi
+
+# --- 2) Dedupe round-trip: parsers see all ids; none read as triaged ---
+RB_BODY="$(cat "$RB_OUT")"
+ALL_IDS=$(parse_all_ids_from_body "$RB_BODY" | grep -c . || true)
+TRI_IDS=$(parse_triaged_ids_from_body "$RB_BODY" | grep -c . || true)
+if [ "$ALL_IDS" -eq 200 ]; then
+  pass "render_rollup_body: parse_all_ids_from_body reads all 200 (closed-host dedupe complete)"
+else
+  fail "render_rollup_body: parse_all_ids_from_body read $ALL_IDS/200"
+fi
+if [ "$TRI_IDS" -eq 0 ]; then
+  pass "render_rollup_body: parse_triaged_ids_from_body reads 0 (overflow not mis-flagged triaged)"
+else
+  fail "render_rollup_body: $TRI_IDS overflow items mis-read as triaged"
+fi
+
+# --- 3) Format/severity/footer invariants ---
+if grep -q ' P0 \[' "$RB_OUT"; then
+  pass "render_rollup_body: P0 findings inline (severity-major)"
+else
+  fail "render_rollup_body: no P0 inline — severity ordering broken"
+fi
+if grep -q 'full set retained below' "$RB_OUT" && ! grep -q 're-surface on the next rollup' "$RB_OUT"; then
+  pass "render_rollup_body: overflow <details> present; false 're-surface' claim gone"
+else
+  fail "render_rollup_body: overflow summary missing or stale re-surface claim present"
+fi
+
+# --- 4) Stub mode: tighter budget forces mp-id stubs, still no loss ---
+STUB_OUT="$(mktemp "${TMPDIR:-/tmp}/rb-stub-XXXXXX.md")"
+ROLLUP_BODY_BUDGET=30000 render_rollup_body "$BIG_RB" "substantive" > "$STUB_OUT"
+STUB_BYTES=$(wc -c < "$STUB_OUT" | tr -d ' ')
+STUB_MPIDS=$(grep -oE '<!-- *mp-id:[a-f0-9]+ *-->' "$STUB_OUT" | sort -u | wc -l | tr -d ' ')
+if [ "$STUB_BYTES" -le 30000 ] && [ "$STUB_MPIDS" -eq 200 ] && grep -qE '^- \[ \] <!-- mp-id:' "$STUB_OUT"; then
+  pass "render_rollup_body: stub-mode keeps all 200 mp-ids under a 30000B budget ($STUB_BYTES B)"
+else
+  fail "render_rollup_body: stub-mode bytes=$STUB_BYTES mpids=$STUB_MPIDS (want <=30000 and 200)"
+fi
+rm -f "$STUB_OUT"
+
+# --- 5) Fail loud: budget too small even for stubs → return 2, no body ---
+set +e
+( ROLLUP_BODY_BUDGET=1500 render_rollup_body "$BIG_RB" "substantive" >/dev/null 2>&1 )
+rb_rc=$?
+set -e
+if [ "$rb_rc" -eq 2 ]; then
+  pass "render_rollup_body: unfittable backlog fails loud (return 2, no partial post)"
+else
+  fail "render_rollup_body: expected return 2 on unfittable backlog, got $rb_rc"
+fi
+
+rm -f "$BIG_RB" "$RB_OUT"
+
+# ---------------------------------------------------------------------
+# #402: the dedupe folds COMMENT bodies in, so the throttle/append path
+# (which posts findings as an append-only comment) is dedupe-visible.
+# Mirror the body+comments concatenation collect_triaged_ids_for_label
+# builds and assert comment-resident mp-ids + triage signals surface.
+# ---------------------------------------------------------------------
+merged402='[{"state":"open",
+  "body":"- [x] body item <!-- mp-id:aaaaaaaaaaaa -->",
+  "comments":[
+    {"body":"## Appended 2026-06-01\n- [x] comment triaged <!-- mp-id:bbbbbbbbbbbb -->"},
+    {"body":"- [ ] comment still open <!-- mp-id:cccccccccccc -->"}
+  ]}]'
+combined402=$(printf '%s' "$merged402" | jq -r '.[0] | ((.body // "") + "\n" + ((.comments // []) | map(.body // "") | join("\n")))')
+tri402=$(parse_triaged_ids_from_body "$combined402" | sort | tr '\n' ' ')
+all402=$(parse_all_ids_from_body "$combined402" | sort | tr '\n' ' ')
+if [ "$tri402" = "aaaaaaaaaaaa bbbbbbbbbbbb " ]; then
+  pass "#402 dedupe: open-host triaged mp-ids surface from BOTH body and comment (not the open one)"
+else
+  fail "#402 dedupe: triaged set = [$tri402] (want 'aaaaaaaaaaaa bbbbbbbbbbbb ')"
+fi
+if [ "$all402" = "aaaaaaaaaaaa bbbbbbbbbbbb cccccccccccc " ]; then
+  pass "#402 dedupe: closed-host parse_all reads all body+comment mp-ids"
+else
+  fail "#402 dedupe: all set = [$all402] (want all three)"
+fi
+
+# ---------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------
 


### PR DESCRIPTION
Auto-propagated from [mergepath@1b4ba0d](https://github.com/nathanjohnpayne/mergepath/commit/1b4ba0d63cc47fe04403ac8527b94d3e20c4c939) by `scripts/sync-to-downstream.sh` (v0.4.0-layer3-sync-all, see [#168](https://github.com/nathanjohnpayne/mergepath/issues/168)).

## Files synced
  - scripts/daily-feedback-rollup.sh
  - tests/test_daily_feedback_rollup.sh

## Source

fix(rollup): bound daily-feedback-rollup body under 65536 cap (#400) (#401)

https://github.com/nathanjohnpayne/mergepath/commit/1b4ba0d63cc47fe04403ac8527b94d3e20c4c939

Authoring-Agent: claude

## Self-Review
- Correctness: mirrors mergepath@1b4ba0d verbatim per the upstream manifest. The change has already been reviewed in the upstream Mergepath PR.
- Regression risk: low. Verbatim mirror of an already-reviewed upstream change.
- Style: N/A (mirror).
- Test coverage: relies on the consumer repo CI. No test changes shipped.
- Security: no new attack surface; the sync script never ran with elevated privileges in this consumer.