### PR TITLE
sync: fix(dependabot): gate major dev-group --auto merges on CI (#406) (#407) (mergepath@9e750a4)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -150,6 +150,29 @@ jobs:
           # continuing to the merge step with no approval on record.
           gh pr review --approve "$PR_URL"
 
+          # Major dev-group bumps must NOT merge before CI (mergepath#406).
+          # A semver-MAJOR update only reaches this step via the
+          # `dependency-group == 'dev-dependencies'` arm of the job `if:`
+          # (single bumps set update-type to patch/minor). The safety case
+          # for auto-merging a dev group is explicitly "CI is green" — but
+          # `gh pr merge --auto` merges as soon as the repo's *required*
+          # status checks pass, NOT after arbitrary in-flight CI. In a
+          # consumer where auto-merge is enabled yet CI is not a required
+          # status check, the approval above already satisfies the merge
+          # requirements, so `--auto` would merge the major dev-group BEFORE
+          # CI finishes. The immediate-squash fallback below already guarded
+          # this case; the `--auto` path did not (Codex P2 on #405 → #406).
+          # Skip BOTH merge paths for a major dev-group and leave it
+          # approved-but-unmerged: the approval is on record (the weekly
+          # audit's "no reviewer approval" gate is satisfied), and a human
+          # merges after CI — or `--auto` becomes safe once required CI
+          # checks are configured. Patch/minor fall through to the path below.
+          if [ "$UPDATE_TYPE" != "version-update:semver-patch" ] && \
+             [ "$UPDATE_TYPE" != "version-update:semver-minor" ]; then
+            echo "::notice::update-type='$UPDATE_TYPE' (dependency-group='$DEPENDENCY_GROUP') is a major dev-group bump; leaving it approved-but-unmerged to preserve the CI-green safety case (mergepath#406). Merge after CI, or enable required CI checks + auto-merge."
+            exit 0
+          fi
+
           # Try GitHub-side auto-merge first (fires when required
           # checks pass). Fall back to an immediate squash ONLY when
           # the failure cause is "auto-merge unavailable" — i.e., the
@@ -184,17 +207,16 @@ jobs:
             fi
             # The immediate (no --auto) squash does NOT wait for CI. That's
             # acceptable for single patch/minor bumps (the long-standing
-            # behavior), but the broadened dev-dependencies-group gate
-            # (#374) can route a semver-MAJOR group here — and the safety
-            # case for auto-merging dev groups is explicitly "CI is green".
-            # Merging a major group before CI in a no-branch-protection
-            # repo would break that (Codex P2 on #405). So only
-            # immediate-squash patch/minor; for anything else (a major dev
-            # group) leave the PR APPROVED but unmerged — --auto will merge
-            # it once branch protection/required checks are configured, or a
-            # human merges after CI. The approval is already recorded, so
-            # the weekly audit's "no reviewer approval" gate is satisfied
-            # either way.
+            # behavior). Major dev-groups are already held approved-but-
+            # unmerged by the early guard above (mergepath#406), so they
+            # should never reach this fallback — the `if` below is a
+            # defensive backstop that re-checks update-type in case that
+            # early guard is ever removed, keeping the CI-green safety case
+            # double-guarded. For a major group, leave the PR APPROVED but
+            # unmerged — --auto will merge it once branch protection/required
+            # checks are configured, or a human merges after CI. The approval
+            # is already recorded, so the weekly audit's "no reviewer
+            # approval" gate is satisfied either way.
             if [ "$UPDATE_TYPE" = "version-update:semver-patch" ] || \
                [ "$UPDATE_TYPE" = "version-update:semver-minor" ]; then
               gh pr merge --squash "$PR_URL"

--- a/scripts/codex-review-request.sh
+++ b/scripts/codex-review-request.sh
@@ -458,8 +458,15 @@ else
   # restores the prior active account on exit. This SUPERSEDES the #284
   # `identity-check --expect-reviewer` guard, which fail-closed on the
   # WRONG identity for this particular write. Opt out via
-  # CODEX_REVIEW_REQUEST_SKIP_IDENTITY_CHECK=1 for test harnesses that
-  # PATH-shim gh (the stub records argv; no real keyring switch).
+  # CODEX_REVIEW_REQUEST_SKIP_IDENTITY_CHECK=1 in two cases: (1) test
+  # harnesses that PATH-shim gh (the stub records argv; no real keyring
+  # switch), and (2) token-only / CI runners that have no gh keyring to
+  # switch but DO set GH_TOKEN to the author PAT ($OP_PREFLIGHT_AUTHOR_PAT
+  # / nathanjohnpayne). gh-as-author.sh unsets GH_TOKEN and runs
+  # `gh auth switch`, which needs the author identity in the keyring; on a
+  # keyless runner that fails. With the opt-out, the direct `gh pr comment`
+  # below posts under the author byline the Codex App requires (because
+  # GH_TOKEN already resolves to nathanjohnpayne) without the switch.
   log "posting '@codex review' trigger comment (as author identity nathanjohnpayne)"
   if [ "${CODEX_REVIEW_REQUEST_SKIP_IDENTITY_CHECK:-0}" = "1" ]; then
     POST_OUTPUT=$(gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@codex review" 2>&1) \
@@ -471,7 +478,8 @@ else
       echo "       Refusing to post '@codex review' without author-identity attribution" >&2
       echo "       (Codex ignores reviewer/bot-authored triggers — see comment above)." >&2
       echo "       Restore the helper, or opt out via" >&2
-      echo "       CODEX_REVIEW_REQUEST_SKIP_IDENTITY_CHECK=1 (dev only)." >&2
+      echo "       CODEX_REVIEW_REQUEST_SKIP_IDENTITY_CHECK=1 (dev, or a" >&2
+      echo "       token-only/CI runner with GH_TOKEN=author PAT)." >&2
       die 3 "gh-as-author.sh helper unavailable"
     fi
     # Capture stdout+stderr so a failure surfaces the real gh error


### PR DESCRIPTION
Auto-propagated from [mergepath@9e750a4](https://github.com/nathanjohnpayne/mergepath/commit/9e750a4e9612038d707c5e8492627dbb0720ef29) by `scripts/sync-to-downstream.sh` (v0.4.0-layer3-sync-all, see [#168](https://github.com/nathanjohnpayne/mergepath/issues/168)).

## Files synced
  - scripts/codex-review-request.sh
  - .github/workflows/dependabot-auto-merge.yml

## Source

fix(dependabot): gate major dev-group --auto merges on CI (#406) (#407)

https://github.com/nathanjohnpayne/mergepath/commit/9e750a4e9612038d707c5e8492627dbb0720ef29

Authoring-Agent: claude

## Self-Review
- Correctness: mirrors mergepath@9e750a4 verbatim per the upstream manifest. The change has already been reviewed in the upstream Mergepath PR.
- Regression risk: low. Verbatim mirror of an already-reviewed upstream change.
- Style: N/A (mirror).
- Test coverage: relies on the consumer repo CI. No test changes shipped.
- Security: no new attack surface; the sync script never ran with elevated privileges in this consumer.