### PR TITLE
feat(resume): homepage Resume link + dedicated /resume OG image

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -275,6 +275,16 @@ const homepageJsonLd = {
                 <span class="s-label">Blog</span>
                 <span class="s-arrow">→</span>
               </a>
+              <a href="/resume/" class="social-row social-row--resume">
+                <span class="s-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M6.75 2.5h6.69c.6 0 1.17.24 1.59.66l3.31 3.31c.42.42.66.99.66 1.59V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V4.75A2.25 2.25 0 0 1 6.75 2.5Z"></path>
+                    <path d="M8.25 8h4v1.4h-4zM8.25 11.4h7.5v1.4h-7.5zM8.25 14.8h7.5v1.4h-7.5z" fill="#dde1e5"></path>
+                  </svg>
+                </span>
+                <span class="s-label">Resume</span>
+                <span class="s-arrow">→</span>
+              </a>
               <a href="https://bsky.app/profile/nathanpayne.bsky.social" target="_blank" rel="noopener" class="social-row social-row--bluesky">
                 <span class="s-icon" aria-hidden="true">
                   <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">

--- a/src/pages/og-templates/resume.astro
+++ b/src/pages/og-templates/resume.astro
@@ -1,0 +1,9 @@
+---
+import OgCard from '../../layouts/OgCard.astro';
+---
+
+<OgCard
+  label="nathanpayne.com/resume"
+  heading="Nathan Payne"
+  description="Senior Platform Product Manager — 20+ years across streaming, partner ecosystems, and platform infrastructure (Disney+, Hulu, ESPN), now building AI-augmented software."
+/>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -92,6 +92,8 @@ const jsonLd = {
   title={title}
   description={description}
   canonical={canonical}
+  ogImage="https://nathanpayne.com/og/resume.png"
+  ogImageAlt="Nathan Payne — Resume"
   bodyClass="resume-page"
   jsonLd={jsonLd}
 >

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -637,6 +637,16 @@ html[data-fonts-pending] .panel-label {
     var(--blue) 100%
   );
 }
+.social-row--resume::after {
+  /* Reversed Mondrian (blue→yellow→red) — an internal site destination
+     like Blog, distinguished from Blog's red→yellow→blue bar. */
+  background: linear-gradient(
+    90deg,
+    var(--blue) 0%,
+    var(--yellow) 54%,
+    var(--red) 100%
+  );
+}
 .social-row--bluesky::after {
   background: linear-gradient(
     90deg,


### PR DESCRIPTION
## Summary

Phase 5 finish for #394 (the base `/resume` route landed in #400): adds the homepage navigation link and a dedicated social-card image.

- **Homepage Resume link** — a `Resume` row in the Connect panel's `.social-stack` (right after Blog; both are internal destinations), with an inline document icon and the `→` arrow, matching the existing `social-row` pattern. Hover under-bar uses a reversed-Mondrian gradient to distinguish it from Blog.
- **Dedicated OG image** — `src/pages/og-templates/resume.astro` (OgCard) so the build-time Playwright pipeline emits `/og/resume.png`; the `/resume` page's `og:image` now points at it (was reusing `og/home.png` in v1).

Authoring-Agent: claude

## Self-Review

**Correctness.** `npm test` passes — build clean + **184 tests**. The OG integration generated **14** images (was 13; `+resume.png` confirmed in `dist/og/`), and the generic `og-image-targets` test verifies `/resume`'s `og:image` (`/og/resume.png`) resolves to a real file. The homepage link resolves to `/resume/` with an icon, label, and arrow, ordered right after Blog. OG card and Connect-panel rendering verified visually.

**Regression risk.** Minimal / additive (~31 lines). The Resume row is one new `.social-row`; the new `::after` rule sits alongside the existing platform rules; the `og-templates/resume.astro` follows the home/blog/projects template pattern exactly. No existing markup, routes, or styles changed.

**Style.** External-link/icon conventions followed (inline SVG icon, `→` arrow, `target`/`rel` not needed — `/resume/` is internal like Blog). Hover bar uses the site's Mondrian color tokens and the `--motion-hover`/`--ease-standard` transition (inherited from `.social-row::after`); no hard-coded motion.

**Test coverage.** Covered by the existing `og-image-targets` suite (every page's `og:image` must resolve) and `blog-pages`/`seo-metadata` OG assertions. No new spec needed — this is nav + an asset, within the existing `/resume` spec contract from #400.

**Security / dependency hygiene.** No new dependencies, no secrets. Static markup, asset, and CSS only.

## Notes
- Under the `external_review_threshold` (~31 lines), so this is the under-threshold path: nathanpayne-claude approves once CodeRabbit clears, then merge.
