### PR TITLE
fix(coderabbit): scope frontmatter title/date/description to blog only

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -34,11 +34,23 @@ reviews:
         Astro pages. Check for proper use of Astro component syntax,
         SEO meta tags (title, description, og:image), and that pages
         render correctly in both static and server modes.
+    - path: "src/content/blog/**"
+      instructions: >-
+        Blog post markdown. Verify frontmatter schema is complete
+        (title, date, description) and that any linked assets exist.
     - path: "src/content/**"
       instructions: >-
-        Blog and content collection files. Verify frontmatter schema
-        is complete (title, date, description) and that any linked
-        assets exist.
+        Astro content collections. Each collection is validated against
+        its Zod schema in src/content.config.ts. Outside of
+        src/content/blog/**, the resume and structured-data
+        collections—experience, education, certifications, skills,
+        myself, resume/projects, bio, projects, awards—intentionally
+        use domain-specific frontmatter (company, issuer, degree, year,
+        tech, order, etc.) and have NO title/date/description. Do not
+        flag those fields as missing on non-blog collections; the
+        title/date/description requirement applies only to
+        src/content/blog/**. Verify frontmatter matches the relevant
+        collection schema and that any linked assets exist.
     - path: "src/styles/**"
       instructions: >-
         Global styles. Flag accessibility issues — contrast ratios,

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -40,17 +40,19 @@ reviews:
         (title, date, description) and that any linked assets exist.
     - path: "src/content/**"
       instructions: >-
-        Astro content collections. Each collection is validated against
-        its Zod schema in src/content.config.ts. Outside of
-        src/content/blog/**, the resume and structured-data
+        Astro content collections. Validate each file against its own
+        collection's Zod schema in src/content.config.ts — the schemas
+        differ per collection (e.g. projects requires title +
+        description; certifications requires name/issuer/year; skills
+        requires label/priority/skills). The resume and structured-data
         collections—experience, education, certifications, skills,
-        myself, resume/projects, bio, projects, awards—intentionally
-        use domain-specific frontmatter (company, issuer, degree, year,
-        tech, order, etc.) and have NO title/date/description. Do not
-        flag those fields as missing on non-blog collections; the
-        title/date/description requirement applies only to
-        src/content/blog/**. Verify frontmatter matches the relevant
-        collection schema and that any linked assets exist.
+        myself, resume/projects, bio, awards—intentionally do NOT use
+        the blog title/date/description triad, instead carrying
+        domain-specific frontmatter (company, issuer, degree, year,
+        tech, order, etc.); do not flag those three fields as missing on
+        them. The title/date/description requirement applies only to
+        src/content/blog/**. Always verify frontmatter matches the
+        relevant collection schema and that any linked assets exist.
     - path: "src/styles/**"
       instructions: >-
         Global styles. Flag accessibility issues — contrast ratios,


### PR DESCRIPTION
## Summary

`.coderabbit.yml` had a single `src/content/**` path_instruction telling CodeRabbit to "verify frontmatter schema is complete (title, date, description)". That's calibrated for blog prose, but it fires on the structured resume collections added in #394 — `src/content/{experience,education,certifications,skills,myself}/` and `src/content/resume/projects/` — which intentionally use domain-specific Zod schemas (`company`, `issuer`, `degree`, `year`, `tech`, `order`, …) with **no** `title`/`date`/`description`, exactly like the pre-existing `bio` collection. On #400 this produced **13 false-positive "missing frontmatter" comments**.

## Change

Split the one instruction into two:

- **`src/content/blog/**`** — keeps the `title`/`date`/`description` requirement (blog prose).
- **`src/content/**`** — a schema-aware instruction that points the reviewer at the per-collection Zod schemas in `src/content.config.ts` and explicitly says **not** to flag missing `title`/`date`/`description` on non-blog collections.

CodeRabbit applies all matching `path_instructions` cumulatively, so blog files match both entries. The general instruction carves out blog explicitly ("the title/date/description requirement applies only to `src/content/blog/**`") so the two never contradict.

Authoring-Agent: claude

## Self-Review

- **Correctness:** New `src/content/blog/**` entry inserted before the broad `src/content/**` entry; `yq` parses the file (now 5 `path_instructions`) and `scripts/ci/check_coderabbit_config` reports PASS (YAML valid; profile gate is template-repo-scoped and correctly skipped here). All eight non-blog collection dirs named in the instruction (`experience`, `education`, `certifications`, `skills`, `myself`, `resume/projects`, `bio`, `projects`, `awards`) exist on disk and match their `src/content.config.ts` schemas.
- **Regression risk:** Minimal. Config-only change to reviewer guidance; no application code, build, or runtime behavior is touched. The blog frontmatter check is preserved verbatim under the narrower glob. Worst case is a CodeRabbit prompt-tuning nuance, which is advisory and non-blocking.
- **Style:** Matches the existing `>-` folded-scalar format of the surrounding `path_instructions`. Em dashes are closed-up per CMOS.
- **Test coverage:** `scripts/ci/check_coderabbit_config` (YAML-validity + profile gate) passes. Note: that check and `check_coderabbit_config_tests` are synced-template artifacts and are **not** wired into this repo's `repo_lint.yml`; the `_tests` wrapper references a `tests/test_check_coderabbit_config.sh` that does not exist in this repo (pre-existing, unrelated to this change). No new test is warranted for a CodeRabbit prose-instruction tweak.
- **Security / dependency hygiene:** No dependencies, secrets, or permissions touched. Single config file.
