### PR TITLE
chore(git): normalize SVG line endings to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Line-ending normalization
+#
+# SVG assets sourced from external origins (e.g. Wikimedia Commons) can arrive
+# with CRLF line endings. Git stores them verbatim, and `git diff --check` then
+# flags every CRLF as a whitespace error—this surfaced as 126 whitespace
+# errors during the #400 external review and required a one-off normalization
+# commit. SVG is XML text, so treat it as text and store it with LF in the repo;
+# this keeps diffs readable and prevents the CRLF reintroduction from recurring.
+*.svg text eol=lf


### PR DESCRIPTION
## Summary

Adds a repo-root `.gitattributes` normalizing SVG line endings to LF on commit (`*.svg text eol=lf`).

### Background

The two resume logo SVGs (`public/images/logos/current-tv.svg`, `turner.svg`) came from Wikimedia Commons with CRLF line endings. `git diff --check` flagged those CRLFs as 126 whitespace errors during the #400 external review, forcing a one-off normalization commit. With no `.gitattributes` rule, nothing prevents the same regression on the next externally sourced SVG.

### Change

- New repo-root `.gitattributes` with one rule: `*.svg text eol=lf`. SVG is XML text, so this keeps diffs readable (unlike `-text`/binary) while guaranteeing LF storage.
- `git check-attr text eol -- public/images/logos/*.svg` resolves to `text: set` / `eol: lf` for both logos.
- All four tracked SVGs (`favicon.svg`, `current-tv.svg`, `turner.svg`, `matchline-wordmark.svg`) are already LF in the index from the #400 fix-up, so `git add --renormalize` is a content no-op. This PR only adds the enforcing rule.
- `git diff --check origin/main...HEAD` is clean.

Authoring-Agent: claude

## Self-Review

- **Correctness:** Root-level `.gitattributes` applies the glob repo-wide. `git check-attr` confirms `text: set` / `eol: lf` on both logo SVGs. `git add --renormalize .` produced no SVG content changes (already LF), confirming no unintended rewrites. `git diff --check origin/main...HEAD` reports no whitespace errors.
- **Regression risk:** Minimal. The rule only governs how `*.svg` is stored and checked out. Tracked SVGs are byte-for-byte unchanged (already LF), so the Astro build and `/resume` logo rendering are unaffected. No source, build, or runtime code is touched.
- **Style:** One focused rule with an explanatory comment citing #400. Scoped to `*.svg`; deliberately avoids a repo-wide `* text=auto` that would trigger a mass renormalization beyond this task.
- **Test coverage:** No spec or test changes needed. `.gitattributes` is git plumbing, not application behavior, and `check_spec_test_alignment` applies to `specs/` files only. Behavior is verified via `git check-attr` and `git diff --check` (above).
- **Security / dependency hygiene:** No dependencies, secrets, or credentials. No file matches `external_review_paths`; the diff is +9 lines (well under the 300-line threshold), so this is an under-threshold change merged after internal reviewer approval.