### PR TITLE
feat(resume): restyle /resume to the blog-post Mondrian-canvas layout

### DIFF
--- a/specs/resume.md
+++ b/specs/resume.md
@@ -7,8 +7,12 @@ title: Resume Page
 
 Specification for the `/resume` route — Nathan Payne's resume rendered as
 native content from this repo's content collections and small section
-components, styled to match the editorial reading layout (blog/project
-pages), not the homepage Mondrian grid. See issue #394.
+components, laid out in the **blog post reading format**: the Mondrian
+"composition with margins" canvas from `src/layouts/BlogPost.astro` (accent
+margin ▏ content column ▏ sticky sidebar with a metadata panel + in-page
+ToC), implemented via parallel `.resume-canvas-*` classes. Not the homepage
+interactive grid. See issues #394 (initial build) and #402 (blog-layout
+restyle).
 
 The paired smoke test is `tests/resume.test.js`. This spec is the contract;
 the test verifies the structural invariants below against the built
@@ -40,8 +44,20 @@ The `resumeProjects` collection must remain separate from the existing
 
 - Mounted at `src/pages/resume.astro`; served at `/resume/`
   (`format: 'directory'`).
-- A header renders the name (`<h1>`), title, and a contact line composed
-  from the `myself` handles (full URLs built in the page).
+- The page is a `.resume-canvas` Mondrian grid with these cells:
+  - **Left accent margin** (`.resume-canvas-margin--header|body|footer`,
+    `aria-hidden`) — the red / yellow→ink→paper→blue Mondrian stripe.
+  - **Header** (`.resume-canvas-header`) — breadcrumbs (`Nathan Payne /
+    Resume`), the name (`<h1>`), the title, and the **contact line**
+    (location · email · profile links, composed from the `myself` handles).
+    The contact stays in the header so it prints.
+  - **Metadata panel** (`.resume-canvas-meta`, top-right, screen-only) — a
+    `<dl>`: Location, Availability, Focus, and a few Topic pills.
+  - **Content column** (`.resume-canvas-content`) — the section components.
+  - **Sidebar** (`.resume-canvas-sidebar`, sticky, screen-only) — an
+    "In this resume" in-page ToC (`.resume-canvas-toc-list`) + 2–3
+    `.resume-highlight` metric cards.
+  - **Footer** (`.resume-canvas-footer`) — attribution + nav.
 - Sections compose in this order: **Summary, Core Skills, Experience,
   Education, Certifications, Selected Projects, Writing, Awards.**
   - `AwardsSection` renders **nothing** (no header) while the `awards`
@@ -54,11 +70,16 @@ The `resumeProjects` collection must remain separate from the existing
 
 ## Semantics & structure
 
-- Single-column document — one `.resume-document` container; sections are
-  linear (no Mondrian grid, no sidebar).
-- Each section has a semantic `<h2>` title.
-- Each Experience role, Education degree, and Project has a semantic `<h3>`.
+- One `.resume-canvas` container. On desktop it is a 3-column Mondrian grid;
+  it collapses to a single column at ≤ 1023px (`--bp-stack`) — margin and
+  sidebar hidden, metadata panel moved to the top — and prints single-column.
+- Each `<section>` carries a stable `id` (`summary`, `skills`, `experience`,
+  `education`, `certifications`, `projects`, `writing`, `awards`) so the
+  sidebar ToC anchors resolve; `scroll-margin-top` offsets the anchor.
+- Exactly one `<h1>` (the name); each section has a semantic `<h2>` title;
+  each Experience role, Education degree, and Project has a semantic `<h3>`.
 - Experience entries with bullets render them as a `<ul>` of `<li>`.
+- The sidebar ToC links to every visible section id.
 - Title is `Nathan Payne | Resume`; the page has a resolvable `og:image`
   and a dedicated one-line meta/OG description.
 - A `Person` + `ProfilePage` JSON-LD graph is emitted.
@@ -84,9 +105,15 @@ The `resumeProjects` collection must remain separate from the existing
 
 ## Styling
 
-- Anchored to the project/blog reading surface: consumes the site tokens
-  (`--ink`, `--cream`/`--surface`, `--paper`, `--rule`) and the Cormorant
+- Laid out in the blog-post Mondrian "composition with margins" format via
+  **parallel `.resume-canvas-*` classes** (mirroring `.blog-*`, kept separate
+  so the resume isn't coupled to blog-layout changes). The accent margin
+  reuses the full red/yellow/blue Mondrian stripe.
+- Consumes the site tokens (`--ink`, `--cream`/`--surface`, `--paper`,
+  `--rule`, `--accent-gray`, `--red`/`--yellow`/`--blue`) and the Cormorant
   Garamond + Inter pairing — it does not redefine them or import new fonts.
+- The content-column section styling stays under the existing `.resume-*`
+  classes (sections, entries, skills, certs, writing, `CompanyLogo`).
 - In-content links use the darker ochre treatment (not bright blue), with
   the `→` arrow convention on the project and writing links.
 - Skills render as inline `·`-joined lists.
@@ -96,14 +123,20 @@ The `resumeProjects` collection must remain separate from the existing
 
 - US Letter, 0.5in margins; the 8.5in width constraint lives **inside
   `@media print` only**.
-- Forces black-on-white regardless of screen colors.
+- The canvas collapses to a single content block in print: the accent
+  margin, the metadata panel, the sidebar (ToC + highlights), the
+  breadcrumbs, and the footer are **hidden**; the header (with the contact
+  line) and the content column print.
+- Forces black-on-white regardless of screen colors (text, bullet `::before`
+  squares, and link underlines/borders all forced to `#000`).
 - `page-break-inside: avoid` on each work entry, project, and certification.
 - Brand logos are **hidden in print** (`@media print { .company-logo {
   display: none } }`); the company/school/issuer name remains as text.
 - Descriptive-text external links get their URL appended for hard copy
   (`a[href^="http"]::after`); links whose visible text is already the URL
   suppress this.
-- Targets exactly two pages.
+- Targets exactly two pages (the content column collapses to full 8.5in
+  width in print, so the narrower on-screen column doesn't affect paging).
 
 ## Content fidelity
 

--- a/src/components/resume/AwardsSection.astro
+++ b/src/components/resume/AwardsSection.astro
@@ -8,7 +8,7 @@ const sorted = [...entries].sort((a, b) => (a.data.order ?? 99) - (b.data.order 
 ---
 
 {sorted.length > 0 && (
-  <section class="resume-section resume-awards" aria-labelledby="resume-awards-heading">
+  <section id="awards" class="resume-section resume-awards" aria-labelledby="resume-awards-heading">
     <h2 id="resume-awards-heading" class="resume-section__title">Hackathons &amp; Awards</h2>
     <ul class="resume-awards__list">
       {sorted.map((entry) => {

--- a/src/components/resume/CertificationsSection.astro
+++ b/src/components/resume/CertificationsSection.astro
@@ -9,7 +9,7 @@ const { entries } = Astro.props;
 const sorted = [...entries].sort((a, b) => (a.data.order ?? 99) - (b.data.order ?? 99));
 ---
 
-<section class="resume-section resume-certifications" aria-labelledby="resume-certifications-heading">
+<section id="certifications" class="resume-section resume-certifications" aria-labelledby="resume-certifications-heading">
   <h2 id="resume-certifications-heading" class="resume-section__title">Certifications</h2>
   <ul class="resume-certs">
     {sorted.map((entry) => {

--- a/src/components/resume/EducationSection.astro
+++ b/src/components/resume/EducationSection.astro
@@ -9,7 +9,7 @@ const { entries } = Astro.props;
 const sorted = [...entries].sort((a, b) => b.data.year - a.data.year);
 ---
 
-<section class="resume-section resume-education" aria-labelledby="resume-education-heading">
+<section id="education" class="resume-section resume-education" aria-labelledby="resume-education-heading">
   <h2 id="resume-education-heading" class="resume-section__title">Education</h2>
   {sorted.map((entry) => {
     const d = entry.data;

--- a/src/components/resume/ExperienceSection.astro
+++ b/src/components/resume/ExperienceSection.astro
@@ -15,7 +15,7 @@ const rendered = await Promise.all(
 );
 ---
 
-<section class="resume-section resume-experience" aria-labelledby="resume-experience-heading">
+<section id="experience" class="resume-section resume-experience" aria-labelledby="resume-experience-heading">
   <h2 id="resume-experience-heading" class="resume-section__title">Experience</h2>
   {rendered.map(({ entry, Content }) => {
     const d = entry.data;

--- a/src/components/resume/ProjectsSection.astro
+++ b/src/components/resume/ProjectsSection.astro
@@ -19,7 +19,7 @@ function displayUrl(url: string): string {
 }
 ---
 
-<section class="resume-section resume-projects" aria-labelledby="resume-projects-heading">
+<section id="projects" class="resume-section resume-projects" aria-labelledby="resume-projects-heading">
   <h2 id="resume-projects-heading" class="resume-section__title">Selected Projects</h2>
   {rendered.map(({ entry, Content }) => {
     const d = entry.data;

--- a/src/components/resume/SkillsSection.astro
+++ b/src/components/resume/SkillsSection.astro
@@ -8,7 +8,7 @@ const { categories } = Astro.props;
 const sorted = [...categories].sort((a, b) => a.data.priority - b.data.priority);
 ---
 
-<section class="resume-section resume-skills" aria-labelledby="resume-skills-heading">
+<section id="skills" class="resume-section resume-skills" aria-labelledby="resume-skills-heading">
   <h2 id="resume-skills-heading" class="resume-section__title">Core Skills</h2>
   <dl class="resume-skills__list">
     {sorted.map((category) => (

--- a/src/components/resume/SummarySection.astro
+++ b/src/components/resume/SummarySection.astro
@@ -9,7 +9,7 @@ const { entry } = Astro.props;
 const { Content } = await render(entry);
 ---
 
-<section class="resume-section resume-summary" aria-labelledby="resume-summary-heading">
+<section id="summary" class="resume-section resume-summary" aria-labelledby="resume-summary-heading">
   <h2 id="resume-summary-heading" class="resume-section__title">Summary</h2>
   <div class="resume-prose">
     <Content />

--- a/src/components/resume/WritingSection.astro
+++ b/src/components/resume/WritingSection.astro
@@ -16,7 +16,7 @@ const essays = [
 ];
 ---
 
-<section class="resume-section resume-writing" aria-labelledby="resume-writing-heading">
+<section id="writing" class="resume-section resume-writing" aria-labelledby="resume-writing-heading">
   <h2 id="resume-writing-heading" class="resume-section__title">Writing</h2>
   <p class="resume-writing__lead">
     <strong>The AI-Augmented PM</strong> —

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -2,10 +2,12 @@
 /**
  * /resume — Nathan Payne's resume, rendered as native content from the
  * resume content collections (see src/content.config.ts) and small section
- * components (src/components/resume/). Styled to match the site's editorial
- * reading layout (blog/project), not the homepage Mondrian grid. Prints to a
- * clean two-page PDF via the @media print rules in global.css. See #394 and
- * specs/resume.md.
+ * components (src/components/resume/). Laid out in the blog-post reading
+ * format — a Mondrian "composition with margins" canvas (accent margin ▏
+ * content ▏ sticky sidebar with a metadata panel + in-page ToC) — mirroring
+ * src/layouts/BlogPost.astro via parallel .resume-canvas-* classes. Prints to
+ * a clean two-page PDF (margin/sidebar hidden) via the @media print rules in
+ * global.css. See #394 / #402 and specs/resume.md.
  */
 import { getCollection, getEntry } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
@@ -43,6 +45,31 @@ const profileLinks = [
   { display: `bsky.app/profile/${m.bluesky}`, href: `https://bsky.app/profile/${m.bluesky}` },
   { display: m.blog, href: `https://${m.blog}/` },
 ];
+
+// Sidebar "In this resume" ToC. The page is component-composed (no single
+// markdown body), so there are no render() headings to derive from — the ToC
+// is built from the static section list. Awards is listed only when present.
+const toc = [
+  { label: 'Summary', id: 'summary' },
+  { label: 'Core Skills', id: 'skills' },
+  { label: 'Experience', id: 'experience' },
+  { label: 'Education', id: 'education' },
+  { label: 'Certifications', id: 'certifications' },
+  { label: 'Selected Projects', id: 'projects' },
+  { label: 'Writing', id: 'writing' },
+  ...(awards.length ? [{ label: 'Hackathons & Awards', id: 'awards' }] : []),
+];
+
+// Sidebar highlight cards — marquee metrics drawn from the content.
+const highlights = [
+  { text: '$18.1M NCPv3 platform investment', accent: 'red' },
+  { text: '20+ years across streaming & platform', accent: 'yellow' },
+  { text: 'PR cycle time: 7.4 → 4 days', accent: 'blue' },
+];
+
+// At-a-glance metadata topics (screen-only panel; contact stays in the
+// header so it prints).
+const topics = ['Connected-TV', 'Partner ecosystems', 'AI-augmented dev'];
 
 const title = 'Nathan Payne | Resume';
 // Dedicated one-line OG/meta description (≤ ~160 chars) — the on-page
@@ -98,8 +125,24 @@ const jsonLd = {
   jsonLd={jsonLd}
 >
   <main class="resume-shell">
-    <article class="resume-document">
-      <header class="resume-header">
+    {/* ── Mondrian "composition with margins" canvas ──────────────
+         3-column grid: accent margin | content | sidebar. The --ink
+         background shows through the var(--line) gaps as grid lines.
+         Mirrors src/layouts/BlogPost.astro. ─────────────────────── */}
+    <article class="resume-canvas">
+
+      {/* Left margin: per-row Mondrian accent blocks (decorative) */}
+      <div class="resume-canvas-margin resume-canvas-margin--header" aria-hidden="true"></div>
+      <div class="resume-canvas-margin resume-canvas-margin--body" aria-hidden="true"></div>
+      <div class="resume-canvas-margin resume-canvas-margin--footer" aria-hidden="true"></div>
+
+      {/* Header — breadcrumbs, name, title, and contact (kept here so it prints) */}
+      <header class="resume-canvas-header">
+        <nav class="project-breadcrumbs" aria-label="Breadcrumb">
+          <a href="/">Nathan Payne</a>
+          <span class="breadcrumb-sep">/</span>
+          <span class="breadcrumb-current">Resume</span>
+        </nav>
         <h1 class="resume-name">{m.name}</h1>
         <p class="resume-title">{m.title}</p>
         <p class="resume-contact resume-contact--primary">
@@ -117,21 +160,66 @@ const jsonLd = {
         </p>
       </header>
 
-      <SummarySection entry={myself} />
-      <SkillsSection categories={skills} />
-      <ExperienceSection entries={experience} />
-      <EducationSection entries={education} />
-      <CertificationsSection entries={certifications} />
-      <ProjectsSection entries={resumeProjects} />
-      <WritingSection />
-      <AwardsSection entries={awards} />
+      {/* Metadata panel (top-right; screen-only — contact lives in the header) */}
+      <div class="resume-canvas-meta">
+        <dl>
+          <div><dt>Location</dt><dd>{m.location}</dd></div>
+          <div><dt>Availability</dt><dd>Open to roles</dd></div>
+          <div><dt>Focus</dt><dd>Platform · Streaming · AI-augmented</dd></div>
+          <div>
+            <dt>Topics</dt>
+            <dd class="resume-canvas-topics">
+              {topics.map((topic) => (
+                <span class="resume-canvas-topic">{topic}</span>
+              ))}
+            </dd>
+          </div>
+        </dl>
+      </div>
 
-      <footer class="resume-footer">
+      {/* Main content column */}
+      <div class="resume-canvas-content">
+        <SummarySection entry={myself} />
+        <SkillsSection categories={skills} />
+        <ExperienceSection entries={experience} />
+        <EducationSection entries={education} />
+        <CertificationsSection entries={certifications} />
+        <ProjectsSection entries={resumeProjects} />
+        <WritingSection />
+        <AwardsSection entries={awards} />
+      </div>
+
+      {/* Right sidebar — in-page ToC + highlight cards (screen-only) */}
+      <aside class="resume-canvas-sidebar" aria-label="Resume sidebar">
+        <div class="resume-canvas-sidebar-inner">
+          <nav class="resume-canvas-section resume-canvas-toc" aria-label="Table of contents">
+            <h2 class="resume-canvas-heading">In this resume</h2>
+            <ol class="resume-canvas-toc-list">
+              {toc.map((item) => (
+                <li><a href={`#${item.id}`}>{item.label}</a></li>
+              ))}
+            </ol>
+          </nav>
+          <div class="resume-canvas-section resume-canvas-highlights">
+            <h2 class="resume-canvas-heading">Highlights</h2>
+            {highlights.map((highlight) => (
+              <blockquote class={`resume-highlight resume-highlight--${highlight.accent}`}>
+                <p>{highlight.text}</p>
+              </blockquote>
+            ))}
+          </div>
+        </div>
+      </aside>
+
+      {/* Footer */}
+      <footer class="resume-canvas-footer">
+        <p class="resume-canvas-footer__attribution">{m.name} &middot; San Francisco</p>
         <nav class="resume-footer-nav" aria-label="Resume footer navigation">
           <a class="project-action" href="/">&larr; Back to Homepage</a>
           <a class="project-action" href="/blog/">Read the Blog &rarr;</a>
         </nav>
       </footer>
+
     </article>
   </main>
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3592,20 +3592,232 @@ body.resume-page {
   padding: clamp(0.9rem, 2.5vw, 1.8rem);
 }
 
-.resume-document {
-  width: min(100%, 52rem);
+/* ── Mondrian "composition with margins" canvas (mirrors .blog-canvas) ──
+   3-column grid: accent margin | content | sidebar. The --ink background
+   shows through the var(--line) gaps as grid lines. ── */
+.resume-canvas {
+  display: grid;
+  grid-template-columns:
+    var(--line)
+    minmax(2.5rem, 0.4fr)    /* left margin — accent blocks */
+    var(--line)
+    minmax(18rem, 3fr)        /* main content */
+    var(--line)
+    minmax(10rem, 1.3fr)      /* right sidebar */
+    var(--line);
+  grid-template-rows:
+    var(--line) auto           /* header row */
+    var(--line) 1fr            /* body row (content + sidebar) */
+    var(--line) auto           /* footer row */
+    var(--line);
+  background: var(--ink);
+  width: min(100%, 72rem);
   margin: 0 auto;
-  background: var(--surface);
-  border: var(--line) solid var(--grid-border);
   box-shadow: 14px 14px 0 rgba(17, 16, 13, 0.12);
-  padding: clamp(1.5rem, 4vw, 3.2rem) clamp(1.2rem, 3.5vw, 3rem);
+  /* clip (not hidden) so position:sticky on the sidebar still works. */
+  overflow: clip;
+}
+
+/* Left margin: per-row Mondrian accent blocks (decorative) */
+.resume-canvas-margin {
+  grid-column: 2;
+}
+.resume-canvas-margin--header {
+  grid-row: 2;
+  background: var(--red);
+}
+.resume-canvas-margin--body {
+  grid-row: 4;
+  /* Gradient stripe: yellow | ink line | paper | ink line | blue */
+  background: linear-gradient(
+    to bottom,
+    var(--yellow) 0%,
+    var(--yellow) 25%,
+    var(--ink) 25%,
+    var(--ink) calc(25% + var(--line)),
+    var(--paper) calc(25% + var(--line)),
+    var(--paper) 60%,
+    var(--ink) 60%,
+    var(--ink) calc(60% + var(--line)),
+    var(--blue) calc(60% + var(--line)),
+    var(--blue) 100%
+  );
+}
+.resume-canvas-margin--footer {
+  grid-row: 6;
+  background: var(--paper);
+}
+
+/* Header cell — breadcrumbs, name, title, contact */
+.resume-canvas-header {
+  grid-column: 4;
+  grid-row: 2;
+  min-width: 0;
+  background: var(--paper);
+  padding: clamp(1.15rem, 3vw, 2.5rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+.resume-canvas-header .project-breadcrumbs {
+  margin-bottom: 1.4rem;
+  padding-left: 0;
+}
+
+/* Metadata panel (top-right; screen-only) */
+.resume-canvas-meta {
+  grid-column: 6;
+  grid-row: 2;
+  min-width: 0;
+  background: var(--accent-gray);
+  padding: clamp(0.85rem, 2vw, 1.5rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+.resume-canvas-meta dl {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  margin: 0;
+}
+.resume-canvas-meta dt {
+  margin-bottom: 0.12rem;
+  font-size: clamp(0.58rem, 0.72vw, 0.68rem);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(17, 16, 13, 0.48);
+}
+.resume-canvas-meta dd {
+  font-family: "Cormorant Garamond", Garamond, serif;
+  font-weight: 500;
+  font-size: clamp(0.88rem, 0.92vw, 0.98rem);
+  line-height: 1.25;
+}
+.resume-canvas-topics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+.resume-canvas-topic {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.18rem 0.45rem;
+  background: rgba(17, 16, 13, 0.08);
+  border-radius: 2px;
+  font-family: "Inter", system-ui, sans-serif;
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(17, 16, 13, 0.62);
+}
+
+/* Main content column */
+.resume-canvas-content {
+  grid-column: 4;
+  grid-row: 4;
+  min-width: 0;
+  background: var(--surface);
+  padding: clamp(1.15rem, 3vw, 2.5rem);
+  align-self: stretch;
   overflow-wrap: break-word;
 }
 
-/* ── Header ── */
-.resume-header {
-  padding-bottom: 1.4rem;
+/* Right sidebar — sticky ToC + highlights (screen-only) */
+.resume-canvas-sidebar {
+  grid-column: 6;
+  grid-row: 4;
+  min-width: 0;
+  background: var(--surface);
+}
+.resume-canvas-sidebar-inner {
+  padding: clamp(0.85rem, 2vw, 1.5rem);
+  position: sticky;
+  top: var(--line);
+}
+.resume-canvas-section {
+  padding-bottom: 1rem;
+  margin-bottom: 1rem;
   border-bottom: 1px solid var(--rule);
+}
+.resume-canvas-section:last-child {
+  padding-bottom: 0;
+  margin-bottom: 0;
+  border-bottom: none;
+}
+.resume-canvas-heading {
+  margin-bottom: 0.55rem;
+  font-family: "Inter", system-ui, sans-serif;
+  font-weight: 600;
+  font-size: clamp(0.58rem, 0.72vw, 0.68rem);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(17, 16, 13, 0.48);
+}
+.resume-canvas-toc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+.resume-canvas-toc-list li {
+  font-size: clamp(0.78rem, 0.86vw, 0.88rem);
+  line-height: 1.35;
+  padding: 0.25em 0;
+  border-bottom: 1px solid var(--rule);
+}
+.resume-canvas-toc-list li:last-child {
+  border-bottom: none;
+}
+.resume-canvas-toc-list a {
+  color: rgba(17, 16, 13, 0.62);
+  text-decoration: none;
+  transition: color var(--motion-fast) var(--ease-standard);
+}
+.resume-canvas-toc-list a:hover,
+.resume-canvas-toc-list a:focus-visible {
+  color: var(--resume-link);
+}
+
+/* Highlight cards (replace the blog's pullquotes) */
+.resume-highlight {
+  margin: 0.7rem 0;
+  padding: 0.7rem 0.9rem;
+  border-left: 3px solid var(--ink);
+  background: rgba(255, 255, 255, 0.52);
+}
+.resume-highlight:first-of-type {
+  margin-top: 0;
+}
+.resume-highlight--red    { border-left-color: var(--red); }
+.resume-highlight--yellow { border-left-color: var(--yellow); }
+.resume-highlight--blue   { border-left-color: var(--blue); }
+.resume-highlight p {
+  margin: 0;
+  font-family: "Cormorant Garamond", Garamond, serif;
+  font-size: clamp(0.95rem, 1vw, 1.08rem);
+  font-style: italic;
+  line-height: 1.32;
+}
+
+/* Footer cell */
+.resume-canvas-footer {
+  grid-column: 2 / -2;
+  grid-row: 6;
+  min-width: 0;
+  background: var(--paper);
+  padding: clamp(1.15rem, 3vw, 2rem) clamp(1.15rem, 3vw, 2.5rem);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.resume-canvas-footer__attribution {
+  font-size: clamp(0.8rem, 0.9vw, 0.92rem);
+  color: rgba(17, 16, 13, 0.55);
 }
 
 .resume-name {
@@ -3665,6 +3877,7 @@ body.resume-page {
   margin-top: 2.1rem;
   padding-top: 1.6rem;
   border-top: 1px solid var(--rule);
+  scroll-margin-top: 1rem; /* so ToC anchors don't sit flush at the top */
 }
 
 .resume-summary {
@@ -4001,21 +4214,46 @@ body.resume-page {
 }
 
 /* ── Footer (screen-only navigation) ── */
-.resume-footer {
-  margin-top: 2.4rem;
-  padding-top: 1.4rem;
-  border-top: 1px solid var(--ink);
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
 .resume-footer-nav {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
+}
+
+/* ── /resume canvas — collapse to a single column (≤ 1023px, --bp-stack) ──
+   Mirrors the blog collapse: margin + sidebar hidden, the metadata panel
+   moves to the top as a horizontal bar, content fills width. ── */
+@media (max-width: 1023px) {
+  .resume-canvas {
+    grid-template-columns: var(--line) 1fr var(--line);
+    grid-template-rows:
+      var(--line) auto    /* metadata panel (moves to top) */
+      var(--line) auto    /* header */
+      var(--line) auto    /* content */
+      var(--line) auto    /* footer */
+      var(--line);
+  }
+
+  .resume-canvas-margin { display: none; }
+
+  .resume-canvas-meta {
+    grid-column: 2;
+    grid-row: 2;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: 0.7rem 1.5rem;
+  }
+  .resume-canvas-meta dl {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.5rem 1.5rem;
+  }
+
+  .resume-canvas-header { grid-column: 2; grid-row: 4; }
+  .resume-canvas-content { grid-column: 2; grid-row: 6; }
+  .resume-canvas-sidebar { display: none; }
+  .resume-canvas-footer { grid-column: 2; grid-row: 8; }
 }
 
 /* ════════════════════════════════════════════════════════════════════
@@ -4035,15 +4273,43 @@ body.resume-page {
     padding: 0;
   }
 
-  /* The 8.5in canvas constraint lives here — inside @media print only. */
-  .resume-document {
+  /* Collapse the canvas to a single content block: drop the grid, and hide
+     the accent margin, the metadata panel, the sidebar (ToC + highlights),
+     the screen-only footer, the breadcrumbs, and the logos (the company /
+     school / issuer name stays as text — ATS-safe). The 8.5in width
+     constraint lives here, inside @media print only. */
+  .resume-canvas {
+    display: block;
     width: 100%;
     max-width: 8.5in;
     margin: 0;
-    padding: 0;
-    border: none;
-    box-shadow: none;
     background: #fff !important;
+    box-shadow: none;
+    overflow: visible;
+  }
+
+  .resume-canvas-margin,
+  .resume-canvas-meta,
+  .resume-canvas-sidebar,
+  .resume-canvas-footer,
+  .resume-canvas-header .project-breadcrumbs,
+  .company-logo {
+    display: none !important;
+  }
+
+  /* Header (contact letterhead) + content stack as plain blocks. The
+     header retains the contact line so it prints (the metadata panel,
+     hidden above, is screen-only). */
+  .resume-canvas-header,
+  .resume-canvas-content {
+    display: block;
+    grid-column: auto;
+    grid-row: auto;
+    background: #fff !important;
+    padding: 0;
+  }
+  .resume-canvas-header {
+    padding-bottom: 0.4rem;
   }
 
   /* Force black-on-white regardless of screen colors. `color` only covers
@@ -4051,8 +4317,8 @@ body.resume-page {
      ::before squares (a background) and link underlines/borders — to black
      so the printed copy is truly monochrome. */
   .resume-page,
-  .resume-document,
-  .resume-document * {
+  .resume-canvas,
+  .resume-canvas * {
     color: #000 !important;
   }
 
@@ -4061,20 +4327,9 @@ body.resume-page {
     background: #000 !important;
   }
 
-  .resume-document a {
+  .resume-canvas a {
     text-decoration-color: #000 !important;
     border-bottom-color: #000 !important;
-  }
-
-  /* Logos are hidden in print — keeps the PDF clean and ATS-safe (the
-     company/school/issuer name remains as text). */
-  .company-logo {
-    display: none !important;
-  }
-
-  /* Screen-only footer nav. */
-  .resume-footer {
-    display: none !important;
   }
 
   /* Keep each work entry, project, and certification on one page. The
@@ -4096,7 +4351,7 @@ body.resume-page {
      project links, and the Writing lead (nathanpayne.com/blog) — suppress
      this to avoid duplication. The essay links show titles, so they keep
      the suffix if ever made absolute. */
-  .resume-document a[href^="http"]::after {
+  .resume-canvas a[href^="http"]::after {
     content: " (" attr(href) ")";
     font-size: 0.85em;
     word-break: break-all;
@@ -4112,7 +4367,6 @@ body.resume-page {
      lands on two US-Letter pages. The screen margins (2.1rem sections,
      1.5rem entries) are far too airy for print; the content is dense
      (six roles, five projects) so the vertical rhythm is tuned tight. */
-  .resume-header { padding-bottom: 0.35rem; }
   .resume-contact { margin-top: 0.28rem; gap: 0.1rem 0.4rem; line-height: 1.25; }
   .resume-contact--profiles { margin-top: 0.08rem; }
   .resume-section { margin-top: 0.3rem; padding-top: 0.22rem; }

--- a/tests/resume.test.js
+++ b/tests/resume.test.js
@@ -110,6 +110,10 @@ describe('Resume — page structure', () => {
       expect(links, `ToC missing link #${id}`).toContain(`#${id}`);
       expect(document.getElementById(id), `no <section id="${id}"> for the ToC link`).not.toBeNull();
     }
+    // Awards is empty → AwardsSection renders nothing, so the ToC must NOT
+    // list a (broken) #awards anchor and there is no <section id="awards">.
+    expect(links, 'ToC should omit #awards while the collection is empty').not.toContain('#awards');
+    expect(document.getElementById('awards'), 'awards section should not render while empty').toBeNull();
   });
 
   it('renders the section <h2> titles in order; no References; Awards absent while empty', () => {

--- a/tests/resume.test.js
+++ b/tests/resume.test.js
@@ -70,9 +70,46 @@ describe('Resume — page structure', () => {
     expect(og.getAttribute('content')).toMatch(/^https:\/\/nathanpayne\.com\//);
   });
 
-  it('renders a single-column document (one .resume-document, no Mondrian grid)', () => {
-    expect(document.querySelectorAll('.resume-document').length).toBe(1);
-    expect(document.querySelector('.blog-canvas'), 'should not reuse the blog Mondrian grid').toBeNull();
+  it('renders the blog-canvas layout (canvas, accent margin, header, content, sidebar)', () => {
+    expect(document.querySelectorAll('.resume-canvas').length).toBe(1);
+    // The old project-style centered card is gone.
+    expect(document.querySelector('.resume-document')).toBeNull();
+    expect(document.querySelector('.resume-canvas-margin--header'), 'accent margin missing').not.toBeNull();
+    expect(document.querySelector('.resume-canvas-content'), 'content column missing').not.toBeNull();
+    expect(document.querySelector('.resume-canvas-sidebar'), 'sidebar missing').not.toBeNull();
+    expect(document.querySelector('.resume-canvas-footer'), 'footer missing').not.toBeNull();
+  });
+
+  it('renders breadcrumbs (Nathan Payne / Resume) in the header', () => {
+    const crumbs = document.querySelector('.resume-canvas-header .project-breadcrumbs');
+    expect(crumbs, 'breadcrumbs missing').not.toBeNull();
+    const text = crumbs.textContent.replace(/\s+/g, ' ').trim();
+    expect(text).toContain('Nathan Payne');
+    expect(text).toContain('Resume');
+  });
+
+  it('keeps the contact line in the header so it prints (not only the sidebar)', () => {
+    const header = document.querySelector('.resume-canvas-header');
+    expect(header.querySelector('.resume-contact'), 'header contact line missing').not.toBeNull();
+    expect(header.textContent).toContain('hire@nathanpayne.com');
+  });
+
+  it('renders the metadata panel and highlight cards (screen sidebar)', () => {
+    const meta = document.querySelector('.resume-canvas-meta');
+    expect(meta, 'metadata panel missing').not.toBeNull();
+    expect(meta.textContent).toContain('Open to roles');
+    expect(document.querySelectorAll('.resume-canvas-topic').length).toBeGreaterThan(0);
+    expect(document.querySelectorAll('.resume-highlight').length).toBe(3);
+  });
+
+  it('renders an in-page ToC linking to every visible section', () => {
+    const toc = document.querySelector('.resume-canvas-toc-list');
+    expect(toc, 'sidebar ToC missing').not.toBeNull();
+    const links = Array.from(toc.querySelectorAll('a')).map((a) => a.getAttribute('href'));
+    for (const id of ['summary', 'skills', 'experience', 'education', 'certifications', 'projects', 'writing']) {
+      expect(links, `ToC missing link #${id}`).toContain(`#${id}`);
+      expect(document.getElementById(id), `no <section id="${id}"> for the ToC link`).not.toBeNull();
+    }
   });
 
   it('renders the section <h2> titles in order; no References; Awards absent while empty', () => {
@@ -228,27 +265,29 @@ describe('Resume — print stylesheet', () => {
     return null;
   }
 
-  it('hides .company-logo inside an @media print block', () => {
+  it('hides the canvas chrome (logo, accent margin, sidebar) inside @media print', () => {
     expect(cssFiles.length, 'no emitted CSS found in dist/_astro').toBeGreaterThan(0);
     const block = cssFiles.map(printBlock).find((b) => b && b.includes('company-logo'));
     expect(block, 'no @media print block referencing .company-logo').toBeTruthy();
     expect(block).toContain('display:none');
+    // The screen-only Mondrian margin + sidebar (ToC/highlights) are hidden too.
+    expect(block).toContain('resume-canvas-margin');
+    expect(block).toContain('resume-canvas-sidebar');
   });
 
   it('forces black-on-white and avoids breaking entries inside @media print', () => {
-    const block = cssFiles.map(printBlock).find((b) => b && b.includes('resume-document'));
+    const block = cssFiles.map(printBlock).find((b) => b && b.includes('resume-canvas'));
     expect(block, 'no @media print block found').toBeTruthy();
     expect(block).toContain('#000'); // forced black text
     expect(block).toContain('break-inside:avoid'); // keep entries/projects/certs whole
   });
 
-  it('constrains the document to an 8.5in page width only inside @media print', () => {
-    const screenWidthRule = /\.resume-document\{[^}]*max-width:8\.5in/;
-    // The 8.5in constraint must not appear in the base (screen) cascade.
+  it('applies the 8.5in page width only inside @media print', () => {
+    // The 8.5in constraint must not appear anywhere in the base (screen) cascade.
     for (const css of cssFiles) {
       const printIdx = css.indexOf('@media print');
       const head = printIdx === -1 ? css : css.slice(0, printIdx);
-      expect(screenWidthRule.test(head), '8.5in width leaked into the screen cascade').toBe(false);
+      expect(/8\.5in/.test(head), '8.5in width leaked into the screen cascade').toBe(false);
     }
     const block = cssFiles.map(printBlock).find((b) => b && b.includes('8.5in'));
     expect(block, '8.5in print width constraint missing').toBeTruthy();


### PR DESCRIPTION
## Summary

Restyles `/resume` from the project-style centered card to the **blog post reading format** — the Mondrian "composition with margins" canvas from `BlogPost.astro` — per #402. Implemented with **parallel `.resume-canvas-*` classes** (kept separate from `.blog-*` so the resume isn't coupled to blog-layout changes).

Closes #402.

Authoring-Agent: claude

### What's here (per the decisions on #402)
- **Canvas layout** (`.resume-canvas`, 3-col Mondrian grid): left accent margin ▏ content column ▏ sticky right sidebar.
- **Accent:** the full red/yellow→ink→paper→blue Mondrian margin stripe (decision: full Mondrian).
- **Header:** breadcrumbs (`Nathan Payne / Resume`), name (`<h1>`), title, and the **contact line** (location · email · profile links) — kept here so it prints.
- **Metadata panel** (top-right, screen-only): Location · Availability · Focus + Topic pills (decision: that field set).
- **Sticky sidebar:** an "In this resume" in-page **ToC** linking to every section + **3 highlight cards** ($18.1M NCPv3, 20+ years, PR cycle 7.4 → 4 days) with red/yellow/blue accents (decision: include highlights).
- **Section anchors:** each `<section>` gets a stable `id` + `scroll-margin-top` for the ToC.
- **Responsive:** collapses to a single column at ≤1023px (margin/sidebar hidden, metadata bar to top).
- **Print:** canvas collapses to one block; margin/sidebar/breadcrumbs/footer hidden; contact prints; black-on-white — **still exactly two pages**.

Content collections, the `CompanyLogo` cascade, OG image, and JSON-LD are unchanged.

## Self-Review

**Correctness.** `npm test` passes — build clean + **188 tests** (4 new canvas assertions: structure, breadcrumbs, header-contact, metadata+highlights, ToC-resolves-to-section-ids; print tests updated for `.resume-canvas`). Verified via clean Playwright renders: desktop canvas (margin + header + meta panel + content + sidebar ToC/highlights), mobile collapse (meta bar → header → content, sidebar/margin hidden), and print → Letter PDF → `qpdf --show-npages` = **2** (content collapses to full 8.5in width in print, so the narrower screen column doesn't change paging).

**Regression risk.** Scoped to `/resume`. New `.resume-canvas-*` classes are additive; the content-column `.resume-*` section styles are unchanged; the old `.resume-document`/`.resume-header`/`.resume-footer` card rules were removed (those classes no longer exist in the markup). No other pages/layouts touched. *(Branch hygiene: this PR contains only the 12 resume files — the concurrent `.coderabbit.yml` follow-up was separated out to its own branch.)*

**Style.** Mirrors `BlogPost.astro` via parallel classes; consumes existing tokens (`--ink`/`--surface`/`--rule`/`--accent-gray`/`--red`/`--yellow`/`--blue`, Cormorant + Inter) without redefining them; ToC/highlight transitions use `--motion-*`/`--ease-*` (no hard-coded motion); ochre in-content links retained. `eslint` clean on changed files.

**Test coverage.** Updated `specs/resume.md` (canvas cells, sidebar ToC + metadata + highlights, single-column collapse, print hides chrome + keeps header contact) and `tests/resume.test.js` to match — spec↔test gate (`check_spec_test_alignment`) stays green.

**Security / dependency hygiene.** No new dependencies or secrets. Markup + CSS only.

## Notes
- Over the `external_review_threshold` (~580 lines) → expects Phase 4 (Codex) external review.
- The `awards`-collection-empty build line is the expected informational warning.
