### PR TITLE
style(resume,blog): tighten the ToC closing divider under the last item

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3781,6 +3781,17 @@ body.resume-page {
   color: var(--resume-link);
 }
 
+/* ToC closing divider — sit it tight under the last item (matching the
+   per-item dividers) instead of floating ~1rem below it. The last list item
+   has no border of its own, so the section's own border-bottom is the closing
+   divider; zeroing the section padding-bottom pulls it up to the last item.
+   The section's margin-bottom still separates the ToC from the next sidebar
+   section. Applies to the blog ToC and the resume ToC. See #411. */
+.blog-sidebar-section.blog-sidebar-toc,
+.resume-canvas-section.resume-canvas-toc {
+  padding-bottom: 0;
+}
+
 /* Highlight cards (replace the blog's pullquotes) */
 .resume-highlight {
   margin: 0.7rem 0;


### PR DESCRIPTION
## Summary

Tightens the sidebar ToC's closing divider so it sits directly under the last item, on **both `/resume` and every `/blog` post** (one shared CSS rule). Pivot of #411: **keep** the per-item dividers (matching the blog) and fix the real bug — the trailing gap after the last item.

Closes #411.

Authoring-Agent: claude

### What & why
Each ToC item has a tight per-item `border-bottom`, but the last item's border is suppressed (`:last-child { border-bottom: none }`) and the ToC section adds `padding-bottom: 1rem` before its own closing border — so the closing divider floated ~1rem below the last item ("Writing" on /resume, "The PM lesson" et al. on the blog). Fix: zero the ToC **section** padding-bottom (scoped to `.blog-sidebar-section.blog-sidebar-toc` + `.resume-canvas-section.resume-canvas-toc`) so the closing border pulls up tight; the section's `margin-bottom: 1rem` still separates the ToC from the next sidebar section.

```css
.blog-sidebar-section.blog-sidebar-toc,
.resume-canvas-section.resume-canvas-toc {
  padding-bottom: 0;
}
```

## Self-Review

**Correctness.** Measured the last-item→closing-border gap before/after with Playwright: drops from ~17px to **1px** (just the border) on `/resume` and on **all four** blog posts (12/7/8/10-item ToCs). `npm test` green (**188 tests**).

**Regression risk.** Minimal — one CSS rule, +11 lines, no markup change. Scoped to the ToC sections via the compound `.…-section.…-toc` selector (specificity 0,2,0), so it overrides only the ToC's `padding-bottom`; pullquote/highlight/other sidebar sections and the per-item dividers, gap, hover, and section margin are all untouched.

**Style.** Uses the existing section/token system; no hard-coded motion; consistent with the blog (dividers kept).

**Test coverage.** Purely visual spacing — no behavioral assertion to add; the existing ToC tests (links resolve to section ids) still pass.

**Security / dependency hygiene.** None — CSS only.

## Notes
- Under the `external_review_threshold` (11 lines) → under-threshold path (reviewer approve after CodeRabbit, then merge).
- Touches the blog intentionally (the same trailing-gap bug was on every blog ToC).
