### PR TITLE
style(resume): match the blog backdrop, footer, and shadow (#406, #407, #410)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4270,7 +4270,14 @@ body.resume-page {
   .resume-canvas-header { grid-column: 2; grid-row: 4; }
   .resume-canvas-content { grid-column: 2; grid-row: 6; }
   .resume-canvas-sidebar { display: none; }
-  .resume-canvas-footer { grid-column: 2; grid-row: 8; }
+  /* Match the blog footer's narrow-screen flow: stack + center. */
+  .resume-canvas-footer {
+    grid-column: 2;
+    grid-row: 8;
+    flex-direction: column;
+    text-align: center;
+  }
+  .resume-footer-nav { justify-content: center; }
 }
 
 /* ════════════════════════════════════════════════════════════════════

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3578,6 +3578,8 @@ a:focus-visible {
    ════════════════════════════════════════════════════════════════════ */
 body.resume-page {
   min-height: 100%;
+  /* Match the blog backdrop (body.blog-page sets the same --project-bg). */
+  --project-bg: #c4c3bc;
   background:
     linear-gradient(135deg, rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0)),
     var(--project-bg, #d8d1c5);
@@ -3819,7 +3821,9 @@ body.resume-page {
   grid-row: 6;
   min-width: 0;
   background: var(--paper);
-  padding: clamp(1.15rem, 3vw, 2rem) clamp(1.15rem, 3vw, 2.5rem);
+  /* Match .blog-footer: padding, top rule, and uppercase attribution. */
+  padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.15rem, 3vw, 2.5rem);
+  border-top: 1px solid var(--rule);
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -3827,8 +3831,10 @@ body.resume-page {
   gap: 1rem;
 }
 .resume-canvas-footer__attribution {
-  font-size: clamp(0.8rem, 0.9vw, 0.92rem);
-  color: rgba(17, 16, 13, 0.55);
+  font-size: clamp(0.7rem, 0.88vw, 0.82rem);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(17, 16, 13, 0.58);
 }
 
 .resume-name {


### PR DESCRIPTION
## Summary
Brings `/resume` to visual parity with the blog reading layout. Batches three small CSS tickets:

- **#406 — backdrop:** `body.resume-page` now sets `--project-bg: #c4c3bc` (it was falling back to the lighter `#d8d1c5`); matches `body.blog-page`.
- **#407 — footer:** the footer attribution is now uppercase + `0.18em` tracking + the blog's size/color, with a `border-top: 1px solid var(--rule)` and matching padding — same treatment as `.blog-footer`.
- **#410 — shadow:** the canvas `box-shadow` was already byte-identical to `.blog-canvas`; it only *read* differently against the lighter backdrop. With #406 fixed, it now matches — **no shadow-value change needed**.

Closes #406, #407, #410.

Authoring-Agent: claude

## Self-Review
**Correctness.** Verified against the blog with Playwright: `--project-bg` is now `#c4c3bc` on both `/resume` and `/blog/<post>`; footer screenshots match (uppercase letter-spaced "NATHAN PAYNE · SAN FRANCISCO", top rule, same nav buttons). `npm test` green (188).

**Regression risk.** Minimal — 12 lines, CSS only, scoped to `body.resume-page` and `.resume-canvas-footer*`. No markup change; the blog and other pages are untouched.

**Style.** Consumes existing tokens (`--project-bg`, `--rule`); no hard-coded motion; matches the blog precedent intentionally.

**Test coverage.** Purely visual parity — no behavioral assertion to add; existing resume/blog tests still pass.

**Security / dependency hygiene.** None — CSS only.

## Notes
- Under the `external_review_threshold` → under-threshold path (reviewer approve after CodeRabbit, then merge).
- #410 is closed by the #406 fix (the shadow declaration was already correct).
