### PR TITLE
feat(resume): fuller sidebar highlights + header contact icons (#413, #409)

### DIFF
--- a/src/components/resume/ContactIcon.astro
+++ b/src/components/resume/ContactIcon.astro
@@ -1,0 +1,54 @@
+---
+/**
+ * ContactIcon.astro — small inline icon for the /resume header contact links.
+ * Decorative (aria-hidden; the link text is the accessible name). Inherits
+ * `currentColor` so it matches its link/text color. Brand glyphs are reused
+ * from the homepage Connect rows (src/pages/index.astro); mail/globe/map-pin
+ * are Lucide (https://lucide.dev, ISC) inlined here (no icon-library dep).
+ * See #409.
+ */
+interface Props {
+  name: 'mappin' | 'mail' | 'globe' | 'linkedin' | 'github' | 'bluesky' | 'blog';
+}
+const { name } = Astro.props;
+---
+
+{name === 'mappin' && (
+  <svg class="contact-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"></path>
+    <circle cx="12" cy="10" r="3"></circle>
+  </svg>
+)}
+{name === 'mail' && (
+  <svg class="contact-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <rect width="20" height="16" x="2" y="4" rx="2"></rect>
+    <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"></path>
+  </svg>
+)}
+{name === 'globe' && (
+  <svg class="contact-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="10"></circle>
+    <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"></path>
+    <path d="M2 12h20"></path>
+  </svg>
+)}
+{name === 'linkedin' && (
+  <svg class="contact-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M20.45 20.45h-3.56v-5.57c0-1.33-.03-3.03-1.85-3.03-1.86 0-2.14 1.45-2.14 2.94v5.66H9.35V9.01h3.41v1.56h.05c.47-.9 1.64-1.86 3.37-1.86 3.6 0 4.27 2.38 4.27 5.46v6.28zM5.34 7.43a2.06 2.06 0 1 1 0-4.12 2.06 2.06 0 0 1 0 4.12zM7.12 20.45H3.56V9.01h3.56v11.44z"></path>
+  </svg>
+)}
+{name === 'github' && (
+  <svg class="contact-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.341-3.369-1.341-.454-1.154-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.202 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.744 0 .267.18.579.688.481C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"></path>
+  </svg>
+)}
+{name === 'bluesky' && (
+  <svg class="contact-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M5.202 2.857C7.954 4.922 10.913 9.11 12 11.358c1.087-2.247 4.046-6.436 6.798-8.501C20.783 1.366 24 .213 24 3.883c0 .732-.42 6.156-.667 7.037-.856 3.061-3.978 3.842-6.755 3.37 4.854.826 6.089 3.562 3.422 6.299-5.065 5.196-7.28-1.304-7.847-2.97-.104-.305-.152-.448-.153-.327 0-.121-.05.022-.153.327-.568 1.666-2.782 8.166-7.847 2.97-2.667-2.737-1.432-5.473 3.422-6.3-2.777.473-5.899-.308-6.755-3.369C.42 10.04 0 4.615 0 3.883c0-3.67 3.217-2.517 5.202-1.026"></path>
+  </svg>
+)}
+{name === 'blog' && (
+  <svg class="contact-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M6.75 3h10.5A2.25 2.25 0 0 1 19.5 5.25v15.01a.75.75 0 0 1-1.147.637L12 17.092l-6.353 3.806a.75.75 0 0 1-1.147-.637V5.25A2.25 2.25 0 0 1 6.75 3Z"></path>
+  </svg>
+)}

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -17,6 +17,7 @@ import ExperienceSection from '../components/resume/ExperienceSection.astro';
 import EducationSection from '../components/resume/EducationSection.astro';
 import CertificationsSection from '../components/resume/CertificationsSection.astro';
 import ProjectsSection from '../components/resume/ProjectsSection.astro';
+import ContactIcon from '../components/resume/ContactIcon.astro';
 import WritingSection from '../components/resume/WritingSection.astro';
 import AwardsSection from '../components/resume/AwardsSection.astro';
 
@@ -39,11 +40,11 @@ const [skills, experience, education, certifications, resumeProjects, awards] = 
 // the full URL is composed here. Profile links are absolute (it's a CV
 // contact block) so the print stylesheet can append the URL after the text.
 const profileLinks = [
-  { display: m.website, href: `https://${m.website}` },
-  { display: `linkedin.com/in/${m.linkedin}`, href: `https://linkedin.com/in/${m.linkedin}` },
-  { display: `github.com/${m.github}`, href: `https://github.com/${m.github}` },
-  { display: `bsky.app/profile/${m.bluesky}`, href: `https://bsky.app/profile/${m.bluesky}` },
-  { display: m.blog, href: `https://${m.blog}/` },
+  { display: m.website, href: `https://${m.website}`, icon: 'globe' },
+  { display: `linkedin.com/in/${m.linkedin}`, href: `https://linkedin.com/in/${m.linkedin}`, icon: 'linkedin' },
+  { display: `github.com/${m.github}`, href: `https://github.com/${m.github}`, icon: 'github' },
+  { display: `bsky.app/profile/${m.bluesky}`, href: `https://bsky.app/profile/${m.bluesky}`, icon: 'bluesky' },
+  { display: m.blog, href: `https://${m.blog}/`, icon: 'blog' },
 ];
 
 // Sidebar "In this resume" ToC. The page is component-composed (no single
@@ -62,9 +63,26 @@ const toc = [
 
 // Sidebar highlight cards — marquee metrics drawn from the content.
 const highlights = [
-  { text: '$18.1M NCPv3 platform investment', accent: 'red' },
-  { text: '20+ years across streaming & platform', accent: 'yellow' },
-  { text: 'PR cycle time: 7.4 → 4 days', accent: 'blue' },
+  {
+    text: "Conceived and secured an $18.1M investment in NCPv3—extending Disney's JavaScript/React stack across PlayStation, Xbox, Vega OS, MVPD set-top boxes, and smart TVs.",
+    accent: 'red',
+  },
+  {
+    text: "Led Disney's launch on Amazon's Linux-based Vega OS (Kepler): Disney+, Hulu, and ESPN shipped on schedule with no measurable engagement impact.",
+    accent: 'yellow',
+  },
+  {
+    text: 'Introduced an AI-powered PR review pipeline that cut median PR cycle time from 7.4 to 4 days, beating the 30% Q2 OKR target.',
+    accent: 'blue',
+  },
+  {
+    text: 'Replaced 40+ partner questionnaires with a Snowflake and Looker device-intelligence system supporting AV1/HEVC compliance across Germany and Brazil.',
+    accent: 'red',
+  },
+  {
+    text: 'Conceptualized and led the CNN Magic Wall—the multi-touch platform used on-air for historical and real-time news data.',
+    accent: 'yellow',
+  },
 ];
 
 // At-a-glance metadata topics (screen-only panel; contact stays in the
@@ -146,15 +164,15 @@ const jsonLd = {
         <h1 class="resume-name">{m.name}</h1>
         <p class="resume-title">{m.title}</p>
         <p class="resume-contact resume-contact--primary">
-          <span class="resume-contact__location">{m.location}</span>
+          <span class="resume-contact__location"><ContactIcon name="mappin" />{m.location}</span>
           <span class="resume-contact__sep" aria-hidden="true">·</span>
-          <a href={`mailto:${m.email}`}>{m.email}</a>
+          <a href={`mailto:${m.email}`}><ContactIcon name="mail" />{m.email}</a>
         </p>
         <p class="resume-contact resume-contact--profiles">
           {profileLinks.map((link, i) => (
             <>
               {i > 0 && <span class="resume-contact__sep" aria-hidden="true">·</span>}
-              <a href={link.href} target="_blank" rel="noopener">{link.display}</a>
+              <a href={link.href} target="_blank" rel="noopener"><ContactIcon name={link.icon} />{link.display}</a>
             </>
           ))}
         </p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3887,6 +3887,16 @@ body.resume-page {
   border-bottom-color: var(--resume-link);
 }
 
+/* Decorative icon before each contact link/location (inherits currentColor:
+   ochre on links, muted ink on the location). See #409. */
+.contact-icon {
+  width: 0.95em;
+  height: 0.95em;
+  margin-right: 0.32em;
+  vertical-align: -0.13em;
+  flex-shrink: 0;
+}
+
 /* ── Section scaffold ── section titles reuse the project-copy in-content
    header treatment (Cormorant italic over a top rule). The first section
    (Summary) drops the top rule — the header already supplies one. ── */

--- a/tests/resume.test.js
+++ b/tests/resume.test.js
@@ -99,7 +99,12 @@ describe('Resume — page structure', () => {
     expect(meta, 'metadata panel missing').not.toBeNull();
     expect(meta.textContent).toContain('Open to roles');
     expect(document.querySelectorAll('.resume-canvas-topic').length).toBeGreaterThan(0);
-    expect(document.querySelectorAll('.resume-highlight').length).toBe(3);
+    // Fuller set of highlight cards (≥ 5), accents cycle red/yellow/blue.
+    const cards = document.querySelectorAll('.resume-highlight');
+    expect(cards.length).toBeGreaterThanOrEqual(5);
+    for (const c of cards) {
+      expect(c.className).toMatch(/resume-highlight--(red|yellow|blue)/);
+    }
   });
 
   it('renders an in-page ToC linking to every visible section', () => {

--- a/tests/resume.test.js
+++ b/tests/resume.test.js
@@ -102,9 +102,15 @@ describe('Resume — page structure', () => {
     // Fuller set of highlight cards (≥ 5), accents cycle red/yellow/blue.
     const cards = document.querySelectorAll('.resume-highlight');
     expect(cards.length).toBeGreaterThanOrEqual(5);
-    for (const c of cards) {
-      expect(c.className).toMatch(/resume-highlight--(red|yellow|blue)/);
-    }
+    // Accents must cycle red → yellow → blue by index (not all the same).
+    const cycle = ['red', 'yellow', 'blue'];
+    cards.forEach((c, i) => {
+      const expected = cycle[i % cycle.length];
+      expect(
+        c.className,
+        `highlight ${i} should use the ${expected} accent`,
+      ).toContain(`resume-highlight--${expected}`);
+    });
   });
 
   it('renders an in-page ToC linking to every visible section', () => {


### PR DESCRIPTION
## Summary
Two `/resume` enrichments:

- **#413 — fuller Highlights:** the three terse sidebar cards become fuller one-to-two-line statements, plus two more (5 total): NCPv3 $18.1M investment, the Vega OS (Kepler) launch, the AI PR-review pipeline (7.4→4 days), the Snowflake/Looker device-intelligence system, and the CNN Magic Wall. Accents cycle red/yellow/blue; wording stays accurate to the canonical resume.
- **#409 — header contact icons:** each contact link gets an icon via a new `ContactIcon.astro` (inline SVG, **no dependency**, `aria-hidden`, inherits `currentColor`). Brand glyphs (LinkedIn/GitHub/Bluesky/Blog) are reused from the homepage Connect rows; email/website/location use Lucide `mail`/`globe`/`map-pin`.

Closes #413, #409.

Authoring-Agent: claude

## Self-Review
**Correctness.** Built and verified with Playwright: header shows 7 icons (location/email + 5 profile links), color-matched (ochre on links, muted on location) and baseline-aligned; the sidebar shows 5 fuller highlight cards with cycling accents, all wording drawn from the resume. `npm test` green (**188**); the highlight-count assertion was updated (now `≥5`, and asserts each card carries a red/yellow/blue accent class). Commit signed.

**Regression risk.** Scoped to `/resume`. `ContactIcon.astro` is new and only used in the header; icons are inside the existing `<a>`/`<span>` (decorative, don't change link text or `textContent`-based tests). Highlights are a data + accent change in `resume.astro`. ~115 lines; no other page affected; print sidebar still `display:none` (two pages unchanged).

**Style.** Inline SVG per the repo's "no icon library" rule; icons inherit `currentColor` (no hard-coded color); Lucide markup copied (ISC), not added as a dep. Highlights reuse the existing `.resume-highlight--{accent}` styling.

**Accessibility.** Icons are `aria-hidden="true"`; the link text remains the accessible name. No heading/landmark changes.

**Security / dependency hygiene.** No new dependencies or secrets.

## Notes
- Under the `external_review_threshold` → under-threshold path (reviewer approve after CodeRabbit, then merge).
- The Lucide (outlined) + brand (filled) icon mix is intentional per the chosen approach; rendered monochrome at ~1em so they read as a cohesive set.
