### PR TITLE
feat(home): résumé CTA in About + Connect; refresh Now timestamp to June 2026

### DIFF
--- a/src/content/bio/now.md
+++ b/src/content/bio/now.md
@@ -1,5 +1,5 @@
 ---
-lastUpdated: May 2026
+lastUpdated: June 2026
 ---
 
 The current seam is where AI coding agents meet shipped software. Building products end-to-end with Claude Code, Codex, and Cursor, under an enforcement system I designed to catch the failure modes agents miss. Open to product roles where streaming infrastructure, developer tools, or AI-augmented workflows are the center of gravity.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -93,6 +93,10 @@ const homepageJsonLd = {
                 <span class="about-label">Now</span>
                 <NowContent />
               </div>
+              <div class="about-block about-block--resume">
+                <span class="about-label">Résumé</span>
+                <p>Open to new platform &amp; product roles. <a href="/resume/" class="p-name-link">Read my <span class="no-break">résumé<span class="link-arrow" aria-hidden="true">→</span></span></a></p>
+              </div>
               <div class="about-block about-block--writing">
                 <span class="about-label">Writing</span>
                 <p>Three pieces on building with AI coding agents: where they fail, what makes them reliable, and how to get real work out of them.</p>
@@ -229,6 +233,8 @@ const homepageJsonLd = {
                 data-d="bmF0aGFucGF5bmUuY29t"
                 data-s="RnJvbSUyMG5hdGhhbnBheW5lLmNvbQ=="
               >Get in touch<span class="link-arrow" aria-hidden="true">→</span></a>
+              {' · '}
+              <a class="availability-resume p-link" href="/resume/">Résumé<span class="link-arrow" aria-hidden="true">→</span></a>
             </p>
             <noscript>
               <p class="availability-noscript">Email: hire [at] nathanpayne [dot] com</p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -521,7 +521,8 @@ html[data-fonts-pending] .panel-label {
 }
 
 /* Blue arrow matches the Builds .p-name-link convention. */
-.writing-list .p-name-link .link-arrow {
+.writing-list .p-name-link .link-arrow,
+.about-block--resume .p-name-link .link-arrow {
   color: var(--blue);
   font-weight: 700;
 }
@@ -531,7 +532,8 @@ html[data-fonts-pending] .panel-label {
    on a title that wraps, that lets the arrow orphan onto its own line.
    nowrap on the trailing word+arrow keeps them one unit while the rest of
    the title still wraps normally. */
-.writing-list .no-break {
+.writing-list .no-break,
+.about-block--resume .no-break {
   white-space: nowrap;
 }
 
@@ -3394,7 +3396,8 @@ a:focus-visible {
 
   /* Dark-blue arrow is near-invisible on the red mobile base; keep it
      cream (matching the link text) so the affordance stays legible. */
-  .panel--red .writing-list .p-name-link .link-arrow {
+  .panel--red .writing-list .p-name-link .link-arrow,
+  .panel--red .about-block--resume .p-name-link .link-arrow {
     color: var(--cream);
   }
 


### PR DESCRIPTION
## Summary
Adds a résumé call-to-action to the homepage and refreshes the "Now" timestamp.

- **About panel** — new **Résumé** block (right after *Now*): *"Open to new platform & product roles."* + **Read my résumé →** linking to `/resume/`. Reuses the existing `.about-block` / `.p-name-link` pattern; its link-arrow uses the same `--blue` (and cream-on-mobile) treatment as the Writing/Builds arrows so it matches the panel.
- **Connect panel** — adds a **Résumé →** link to the existing availability line, beside "Get in touch", reinforcing the open-to-roles CTA.
- **Now block** — "Last updated" refreshed to **June 2026** (current month).

**Intentional:** the standalone **"Resume"** row already in Connect's "Elsewhere" list is **kept** by design — per the owner it's a job-search CTA to be removed once re-employed — so Connect links the résumé from both the availability line and the Elsewhere list on purpose.

Authoring-Agent: claude

## Self-Review
**Correctness.** Verified via Playwright: the About Résumé block renders after *Now*; its arrow computes to `rgb(34,63,137)` = `--blue`, matching the Writing arrows; the Connect availability line shows "Get in touch → · Résumé →"; the ribbon reads "June 2026". `npm test` green (**188**); build clean; commit signed.

**Regression risk.** Low — homepage-only, additive markup. New About block reuses existing classes (no new layout CSS); the arrow-color rule extends the existing `.writing-list … .link-arrow` selectors to also cover `.about-block--resume`. `now.md` is a one-field content edit consumed only by the homepage Now ribbon.

**Test coverage.** Existing homepage/bio tests pass; change is additive markup + a content date + a CSS selector extension.

**Style.** Reuses existing `.p-name-link` / `.p-link` / link-arrow conventions; no hardcoded motion.

**Security / deps.** None.

## Notes
- Under `external_review_threshold`, no protected paths → under-threshold path.
