### PR TITLE
fix(resume): full-width Experience description below a centered logo head row

### DIFF
--- a/specs/resume.md
+++ b/specs/resume.md
@@ -115,8 +115,10 @@ The `resumeProjects` collection must remain separate from the existing
   company logos ~72px, Education/Certification logos ~56px.
   Square brand marks fill the tile edge-to-edge (corners clipped); a wide
   wordmark (Current TV) is contained and centered with the card showing
-  above/below. The card sits to the left of the entry with the heading +
-  description indented beside it; the initials fallback reuses the same card.
+  above/below. In each entry the card sits in a head row, vertically centered
+  beside the heading + meta line; the Experience description then wraps at full
+  width *below* that head row (not indented beside the card). The initials
+  fallback reuses the same card.
 
 ## Styling
 

--- a/src/components/resume/ExperienceSection.astro
+++ b/src/components/resume/ExperienceSection.astro
@@ -1,9 +1,10 @@
 ---
 /**
  * ExperienceSection — work history, most-recent-first (by `order`). Each
- * entry: a CompanyLogo (decorative) beside an <h3> "Role — Company", a
- * meta line (team · location · year range), and the markdown body
- * (intro paragraph + bullets) rendered with render().
+ * entry: a head row with a CompanyLogo (decorative) centered beside an <h3>
+ * "Role — Company" + a meta line (team · location · year range), then the
+ * markdown body (intro paragraph + bullets) below at full width so it wraps
+ * under the logo. Rendered with render().
  */
 import { render } from 'astro:content';
 import CompanyLogo from './CompanyLogo.astro';
@@ -23,13 +24,15 @@ const rendered = await Promise.all(
     const meta = [d.team, d.location, range].filter(Boolean).join(' · ');
     return (
       <article class="resume-entry resume-entry--logo">
-        <CompanyLogo name={d.company} website={d.website} logo={d.logo} size={72} />
-        <div class="resume-entry__body">
-          <h3 class="resume-entry__title">{d.title} — {d.company}</h3>
-          <p class="resume-entry__meta">{meta}</p>
-          <div class="resume-prose">
-            <Content />
+        <div class="resume-entry__head">
+          <CompanyLogo name={d.company} website={d.website} logo={d.logo} size={72} />
+          <div class="resume-entry__headings">
+            <h3 class="resume-entry__title">{d.title} — {d.company}</h3>
+            <p class="resume-entry__meta">{meta}</p>
           </div>
+        </div>
+        <div class="resume-prose">
+          <Content />
         </div>
       </article>
     );

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3992,7 +3992,7 @@ body.resume-page {
 
 .resume-entry__head {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 0.85rem;
 }
 
@@ -4000,21 +4000,12 @@ body.resume-page {
   min-width: 0;
 }
 
-/* Experience entries (LinkedIn-style): the logo sits in a left rail and the
-   heading + meta + description share a body column that indents past it. */
-.resume-entry--logo {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.85rem;
-}
-
-.resume-entry__body {
-  min-width: 0;
-  flex: 1;
-}
-
-.resume-entry__body .resume-prose {
-  margin-top: 0.5rem;
+/* Experience entries: a [logo | title + meta] head row (logo vertically
+   centered with the headings via .resume-entry__head), with the description
+   below at full width so it wraps under the logo rather than indenting past
+   it. */
+.resume-entry--logo .resume-prose {
+  margin-top: 0.55rem;
 }
 
 .resume-entry__title {
@@ -4025,7 +4016,7 @@ body.resume-page {
 }
 
 .resume-entry__meta {
-  margin-top: 0.18rem;
+  margin-top: 0.32rem;
   font-size: clamp(0.8rem, 0.78rem + 0.1vw, 0.9rem);
   letter-spacing: 0.01em;
   color: rgba(17, 16, 13, 0.6);
@@ -4434,7 +4425,7 @@ body.resume-page {
   .resume-entry { margin-top: 0.28rem; }
   .resume-entry__meta { margin-top: 0.05rem; }
   .resume-entry__head { gap: 0.5rem; }
-  .resume-entry__body .resume-prose { margin-top: 0.14rem; }
+  .resume-entry--logo .resume-prose { margin-top: 0.14rem; }
   .resume-prose p + p { margin-top: 0.15rem; }
   .resume-prose ul { gap: 0.06rem; margin-top: 0.12rem; }
   .resume-prose li { padding-left: 0.8rem; }


### PR DESCRIPTION
## Summary
Restructures each **Experience** entry's layout:

- The `CompanyLogo` + `<h3>` title + meta line now form a **head row**, with the logo **vertically centered** beside the headings (`.resume-entry__head` → `align-items: center`).
- The markdown **description wraps at full width *below*** that head row, instead of indenting in a right-hand column beside the logo.
- **Relaxed** the title → dept/location spacing (`.resume-entry__meta` margin-top 0.18rem → 0.32rem).

Implementation: Experience now uses the same `.resume-entry__head` + `.resume-entry__headings` head pattern as Education (so the centering tidies Education too), with `.resume-prose` as a full-width sibling below. Removed the now-unused `.resume-entry__body`; retargeted the screen and print prose-spacing rules to `.resume-entry--logo .resume-prose`.

Authoring-Agent: claude

## Self-Review
**Correctness.** Verified via Playwright on `/resume/`: the Disney head row shows the logo centered against the 2-line title + meta, and the description + bullets span the full column width below. `npm test` green (**188**); print still **two pages** (logos hidden in print; the retargeted `.resume-entry--logo .resume-prose` print rule keeps the 0.14rem density); build clean; commit signed.

**Regression risk.** Scoped to `/resume`. `.resume-entry__body` was used only by Experience (grep-confirmed) — safe to remove. `.resume-entry__head` is shared with Education; the `align-items: center` change is intentional and improves both. Projects/Summary prose are unaffected (they don't carry `--logo`).

**Test coverage.** Existing resume smoke tests pass (h3 roles, bullets `<ul>/<li>`, logo cards, print hides logos) — structure assertions hold under the markup change.

**Style.** Reuses existing entry classes; no hardcoded motion. Spec updated to describe the head-row + full-width-description layout.

**Security / deps.** None.

## Notes
- Under `external_review_threshold`, no protected paths → under-threshold path.
