### PR TITLE
fix: disable CodeRabbit's broken ESLint tool for .astro frontmatter (#426)

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -17,6 +17,16 @@ reviews:
   profile: assertive
   request_changes_workflow: false
 
+  # CodeRabbit's hosted ESLint sandbox runs only curated plugins and does
+  # not install local deps, so it can't resolve the TypeScript frontmatter
+  # parser for .astro files and emits "Parsing error: Unexpected token :"
+  # on every PR touching an .astro component. Our eslint.config.js is
+  # correct (passes `npm run lint` locally); disable the redundant, broken
+  # CodeRabbit ESLint tool. See #426.
+  tools:
+    eslint:
+      enabled: false
+
   high_level_summary: true
   high_level_summary_placeholder: "@coderabbitai summary"
   high_level_summary_in_walkthrough: true


### PR DESCRIPTION
## Summary

CodeRabbit's hosted ESLint tool fails on every PR touching an `.astro` file with `Parsing error: Unexpected token :`. The CodeRabbit sandbox runs only curated plugins and does **not** install local deps, so it can't resolve the TypeScript frontmatter sub-parser (`@typescript-eslint/parser`) that our Astro flat-config wires up. The `.astro` frontmatter (which uses TS, e.g. `function displayUrl(url: string): string`) therefore falls back to espree and trips on the type-annotation colon.

Our own `eslint.config.js` is correct — `npm run lint` / `npx eslint` passes locally (exit 0). The CodeRabbit ESLint run is redundant and pure noise on `.astro`, so this PR disables it via a repo-local `reviews.tools.eslint` override in `.coderabbit.yml`. No CI workflow runs the JS ESLint, so nothing else regresses.

Authoring-Agent: claude

## Self-Review

- **Correctness:** Adds `reviews.tools.eslint.enabled: false` as a sibling of `auto_review:`/`profile:` under the existing top-level `reviews:` block — the schema location CodeRabbit documents for tool toggles. Validated with `yq '.' .coderabbit.yml` (parses) and `yq '.reviews.tools.eslint.enabled'` → `false`.
- **Regression risk:** Minimal. The only behavior change is CodeRabbit no longer running its (broken) ESLint pass. No CI workflow invokes the JS ESLint today (`repo_lint.yml` only runs Mergepath structural checks), so CodeRabbit's run was the sole automated ESLint signal on PRs and it was noise on `.astro`. The canonical `eslint.config.js` is untouched and still runnable locally via `npm run lint`. Trade-off: CodeRabbit ESLint is also disabled for `.js`/`.ts` (no per-extension scoping exists in `.coderabbit.yml`); acceptable since the local config covers those.
- **Style:** Single 10-line addition. Explanatory comment matches the file's existing comment style and indentation (2-space, block-folded prose). No other lines changed.
- **Test coverage:** Configuration-only change to a third-party tool's settings; no unit tests apply. Verified by YAML parse + key-value assertion above. Acceptance is observational: CodeRabbit should stop emitting the "issues while running some tools → ESLint" warning on `.astro` PRs.
- **Security / dependency hygiene:** No dependencies added, removed, or changed. No secrets or credentials touched. The change only narrows an external review tool's scope; it does not weaken any repo CI gate or branch protection.

Closes #426.
