### PR TITLE
Make white-footer hover red; align 404 frame and box gutters

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -20,8 +20,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <p class="deck">The page you're looking for doesn't exist or has been moved.</p>
         <div class="project-actions">
           <a class="project-action" href="/">Homepage</a>
-          <a class="project-action" href="/blog/">Blog</a>
+          <a class="project-action" href="/resume/">Résumé</a>
           <a class="project-action" href="/projects/">Builds</a>
+          <a class="project-action" href="/blog/">Blog</a>
         </div>
       </div>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1264,7 +1264,9 @@ body.blog-page {
 
 .project-shell {
   min-height: 100vh;
-  padding: clamp(0.9rem, 2.5vw, 1.8rem);
+  /* 2rem side gutter keeps the centered box's 14px drop shadow off the
+     viewport edge on narrow screens, matching .error-shell. */
+  padding: clamp(0.9rem, 2.5vw, 1.8rem) 2rem;
 }
 
 .project-detail {
@@ -1911,7 +1913,10 @@ body.blog-page {
 
 .shell {
   min-height: 100vh;
-  padding: clamp(0.9rem, 2.5vw, 1.8rem);
+  /* 2rem side gutter keeps the centered .frame's 14px drop shadow off the
+     viewport edge on narrow screens, matching .error-shell. The box stays
+     centered (margin: 0 auto); only the symmetric breathing room grows. */
+  padding: clamp(0.9rem, 2.5vw, 1.8rem) 2rem;
 }
 
 .frame {
@@ -2236,8 +2241,11 @@ a.tag:hover {
     transform var(--motion-hover) var(--ease-standard);
 }
 
+/* Red on hover to match the other white footers (blog post, resume). The
+   white-footer pages share a single red hover affordance; only the
+   color-themed project detail footer keeps its per-project accent. */
 .footer-action:hover {
-  background: var(--blue);
+  background: var(--red);
   color: var(--cream);
   transform: translateY(-2px);
 }
@@ -2327,14 +2335,17 @@ a.tag:hover {
 
 /* 768px matches --bp-tablet on :root. (#332) */
 @media (max-width: 768px) {
+  /* Keep the var(--line) frame and full drop shadow so the collapsed card
+     matches the resume/blog/project canvases on narrow screens, rather than
+     thinning to the 1px border + small shadow. */
   .error-mondrian {
-    grid-template-columns: 1fr;
-    grid-template-rows: auto;
-    box-shadow: 4px 4px 0 rgba(17, 16, 13, 0.06);
+    grid-template-columns: var(--line) 1fr var(--line);
+    grid-template-rows: var(--line) auto var(--line);
+    box-shadow: 14px 14px 0 rgba(17, 16, 13, 0.12);
   }
   .e-content {
-    grid-column: 1;
-    grid-row: 1;
+    grid-column: 2;
+    grid-row: 2;
   }
   .e-block { display: none; }
 }
@@ -3586,14 +3597,17 @@ body.resume-page {
     linear-gradient(135deg, rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0)),
     var(--project-bg, #d8d1c5);
   --resume-link: var(--blue);
-  /* Drives the screen-only footer nav buttons (.project-action). */
-  --project-accent: var(--ink);
+  /* Drives the screen-only footer nav buttons (.project-action). Red to
+     match the other white footers (blog post + index pages). */
+  --project-accent: var(--red);
   --project-accent-foreground: #f5f0e4;
 }
 
 .resume-shell {
   min-height: 100vh;
-  padding: clamp(0.9rem, 2.5vw, 1.8rem);
+  /* 2rem side gutter keeps the centered .resume-canvas's 14px drop shadow off
+     the viewport edge on narrow screens, matching .error-shell. */
+  padding: clamp(0.9rem, 2.5vw, 1.8rem) 2rem;
 }
 
 /* ── Mondrian "composition with margins" canvas (mirrors .blog-canvas) ──

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2265,7 +2265,10 @@ a.tag:hover {
 }
 
 .error-mondrian {
-  width: min(95vw, 64rem);
+  /* Size from the padded content width (like .frame/.blog-canvas/.resume-canvas
+     use min(100%, 72rem)) rather than 95vw, so the card never depends on
+     flex-shrink to fit inside .error-shell's 2rem gutter on narrow screens. */
+  width: min(100%, 64rem);
   display: grid;
   grid-template-columns:
     var(--line) 2.4fr var(--line) 1fr var(--line) 1.2fr var(--line) 0.5fr var(--line);


### PR DESCRIPTION
## Summary

Four small CSS/markup consistency fixes for footers, the 404 page, and the shared black-box layout shells.

1. White-footer hover turns red. Footer nav buttons now hover red on every page with a white footer (blog index, projects index, resume), matching the blog post footer. Previously the index pages hovered blue (.footer-action) and the resume hovered black (--project-accent set to var(--ink)). Project detail footers are intentionally untouched (per-project color theme).
2. 404 Resume button. Added a Resume link to /resume/ on the 404 and reordered the nav to Homepage / Resume / Builds / Blog.
3. 404 responsive frame and shadow. On narrow screens the 404 previously thinned to a 1px border plus a small shadow; it now keeps the var(--line) frame and the full 14px drop shadow, matching the resume/blog/project canvases.
4. Consistent box gutters. .shell, .project-shell, and .resume-shell now use a 2rem side gutter (matching .error-shell) so each centered box drop shadow clears the viewport edge on narrow screens. The box stays centered.

Authoring-Agent: claude

## Self-Review

Correctness. Verified on a local dev server across blog index, projects index, blog post, project detail, resume, and 404 at 375px and 800px: all white-footer hovers resolve to var(--red) (hex c11d19); the blog post footer was already red; project detail footers stay themed. Every black box centers with an equal left/right gap (32px) and the drop shadow stays inside the viewport (at least 18px clearance); no horizontal overflow on any page. The 404 renders the new Resume button (to /resume/) and keeps the frame and shadow on mobile.

Regression risk. Low. CSS-only plus one added anchor on the 404. .footer-action is used only on the two index pages; on the resume page --project-accent drives only the footer buttons (breadcrumbs use inherit/rgba, confirmed). The shell gutter change only widens symmetric padding on narrow screens (boxes were already centered via margin auto / flex centering); desktop is unaffected since each box is capped at 64/72rem with large auto margins.

Style. Uses existing tokens (var(--red), var(--line)); no new hard-coded motion values. Added an explanatory comment at each change site.

Test coverage. No behavioral or JS logic changed; existing Vitest smoke tests cover route and render. No specs/ files added or changed, so check_spec_test_alignment is unaffected.

Security and dependency hygiene. No dependencies added, no new external resources, no secrets. The added link is an internal route.