### PR TITLE
Widen blog/projects card body measure; bound the title

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2042,6 +2042,14 @@ body.blog-page {
 
 /* ── Post Cards ── */
 .post-card {
+  /* Text-column measures (used by .post-title + .post-desc). Body is capped
+     to a comfortable reading measure; the title is allowed a slightly wider
+     measure since display type carries a longer line, so each card reads as
+     one column without the headline overshooting a narrow body. Both only
+     bite on cards wider than the cap — narrow grid cards and phones (card
+     narrower than the measure) fill normally and are unaffected. */
+  --post-measure: 62ch;
+  --post-title-measure: 40rem;
   background: var(--surface);
   padding: clamp(1.2rem, 2.5vw, 2rem);
   display: flex;
@@ -2079,6 +2087,7 @@ body.blog-page {
   line-height: 1.05;
   font-weight: 600;
   margin-bottom: 0.6rem;
+  max-width: var(--post-title-measure);
 }
 
 .post-title a {
@@ -2093,7 +2102,7 @@ body.blog-page {
 }
 
 .post-desc {
-  max-width: 48ch;
+  max-width: var(--post-measure);
   font-size: clamp(0.88rem, 0.95vw, 0.98rem);
   line-height: 1.55;
   color: rgba(17, 16, 13, 0.78);


### PR DESCRIPTION
## Summary

The blog and projects index cards capped body text (.post-desc) at 48ch. That measure is too tight on any card wider than ~48ch, namely the stacked single-column layout (tablet/narrow window) and the wide desktop Mondrian cards, where the body became a narrow column sitting under a full-width headline.

Changes (scoped tokens on .post-card, so blog and projects index stay in sync):
1. .post-desc max-width: 48ch to var(--post-measure) = 62ch. Still a comfortable reading measure (the optimal range is ~50 to 75 characters), but it fills the wide cards far better.
2. .post-title: add max-width var(--post-title-measure) = 40rem. The headline no longer overshoots a narrow body; it reads as a slightly wider line in the same text column (display type carries a longer measure).

Both caps only bite on cards wider than the measure. Phones and narrow desktop-grid cards (card narrower than the cap) fill normally and are unchanged.

Authoring-Agent: claude

## Self-Review

Correctness. Verified on a local dev server at 375 / 820 / 1280px on the blog index:
- Phone (375px): card 261px; title and body both fill the card (261/261), no horizontal overflow. Unchanged from before.
- Stacked (820px): body went from 426px (48ch) to 551px (62ch); empty space on the right dropped from 277px to 152px; title capped at 640px (2 lines); title is now ~16 percent wider than the body instead of ~65 percent.
- Desktop grid (1280px): narrow cards (499px) fill and align title=body; the wide card (748px) shows a tidy column (body 551, title 640).
- Same .post-card component drives the projects index, so the change applies there too.

Regression risk. Low. CSS-only, two max-width declarations plus two scoped custom properties. max-width only caps; it never widens a card or forces overflow. No layout/grid changes. No JS.

Style. Uses scoped CSS custom properties on .post-card with an explanatory comment; no new hard-coded motion values.

Test coverage. No behavioral or JS logic changed; existing Vitest smoke tests cover route and render. No specs files added or changed.

Security and dependency hygiene. No dependencies, no new external resources, no secrets.