### PR TITLE
refactor(css): extract shared Footer component (#434)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,52 @@
+---
+/**
+ * Shared site footer (#434).
+ *
+ * One implementation of the attribution + nav-action footer used across the
+ * blog index, projects index, blog post, project detail, and resume. The
+ * cosmetic content (layout, attribution, nav, hover affordance) lives in
+ * `.site-footer` in global.css so a change lands on every page at once.
+ * Per-page placement/chrome is a thin `variant` modifier:
+ *   - grid   → white band row in the Mondrian index grids
+ *   - canvas → white footer cell inside the framed blog/resume canvas
+ *   - detail → plain block in the single-column project-detail article
+ *
+ * Buttons reuse the shared `.project-action`; white footers share one red
+ * hover affordance, while the color-themed project-detail footer keeps its
+ * per-project accent (see `.site-footer` rules in global.css).
+ */
+interface FooterLink {
+  href: string;
+  label: string;
+}
+
+interface Props {
+  /** Name before the "· San Francisco" byline. */
+  attribution: string;
+  /** Nav actions, left-to-right. Labels may include arrows (←/→). */
+  links: FooterLink[];
+  /** Placement/chrome modifier. */
+  variant?: "grid" | "canvas" | "detail";
+  /** Extra class(es), e.g. the resume canvas-collapse/print hook. */
+  class?: string;
+}
+
+const { attribution, links, variant, class: extra } = Astro.props;
+
+const classList = [
+  "site-footer",
+  variant ? `site-footer--${variant}` : null,
+  extra ?? null,
+]
+  .filter(Boolean)
+  .join(" ");
+---
+
+<footer class={classList}>
+  <p class="site-footer__attribution">{attribution} &middot; San Francisco</p>
+  <nav class="site-footer__nav" aria-label="Footer navigation">
+    {links.map((link) => (
+      <a class="project-action" href={link.href}>{link.label}</a>
+    ))}
+  </nav>
+</footer>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -20,6 +20,7 @@
  * @see Issue #74 — Blog post template: Mondrian composition with margins layout
  */
 import BaseLayout from './BaseLayout.astro';
+import Footer from '../components/Footer.astro';
 
 interface Props {
   title: string;
@@ -244,15 +245,14 @@ const jsonLd = {
       )}
 
       {/* ── Footer ── */}
-      <footer class="blog-canvas-footer">
-        <div class="blog-footer">
-          <p class="blog-footer-attribution">{author} · San Francisco</p>
-          <nav class="blog-footer-nav" aria-label="Blog footer navigation">
-            <a class="project-action" href="/blog/">&larr; Back to Blog</a>
-            <a class="project-action" href="/">Back to Homepage &rarr;</a>
-          </nav>
-        </div>
-      </footer>
+      <Footer
+        attribution={author}
+        variant="canvas"
+        links={[
+          { href: "/blog/", label: "← Back to Blog" },
+          { href: "/", label: "Back to Homepage →" },
+        ]}
+      />
     </article>
   </main>
 

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -4,6 +4,7 @@ import HeroWide from '../components/HeroWide.astro';
 import HeroNarrow from '../components/HeroNarrow.astro';
 import MetadataStrip from '../components/MetadataStrip.astro';
 import ProjectMuxPlayer from '../components/ProjectMuxPlayer.astro';
+import Footer from '../components/Footer.astro';
 
 interface RelatedLink {
   label: string;
@@ -156,13 +157,14 @@ const topics = kicker.split(/\s*×\s*/).join(' · ');
         </section>
       )}
 
-      <footer class="project-detail-footer">
-        <p class="project-footer-attribution">Nathan Payne &middot; San Francisco</p>
-        <nav class="project-footer-nav" aria-label="Project footer navigation">
-          <a class="project-action" href="/projects/">&larr; Back to Projects</a>
-          <a class="project-action" href="/">Back to Homepage &rarr;</a>
-        </nav>
-      </footer>
+      <Footer
+        attribution="Nathan Payne"
+        variant="detail"
+        links={[
+          { href: "/projects/", label: "← Back to Projects" },
+          { href: "/", label: "Back to Homepage →" },
+        ]}
+      />
 
     </article>
   </main>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
 import { estimateReadingMinutes } from '../../lib/reading-time';
+import Footer from '../../components/Footer.astro';
 
 const posts = (await getCollection('blog', ({ data }) => !data.draft))
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
@@ -138,10 +139,11 @@ function readingTime(body: string | undefined): string {
       </div>
 
       {/* ── Footer ── */}
-      <footer class="grid-footer">
-        <span class="footer-attribution">Nathan Payne &middot; San Francisco</span>
-        <a href="/" class="footer-action">&larr; Back to Homepage</a>
-      </footer>
+      <Footer
+        attribution="Nathan Payne"
+        variant="grid"
+        links={[{ href: "/", label: "← Back to Homepage" }]}
+      />
     </div>
   </main>
 </BaseLayout>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
+import Footer from '../../components/Footer.astro';
 
 const allProjects = await getCollection('projects', ({ data }) => !data.draft);
 const projects = allProjects.sort((a, b) => a.data.order - b.data.order);
@@ -128,10 +129,11 @@ const jsonLd = {
       </div>
 
       {/* ── Footer ── */}
-      <footer class="grid-footer">
-        <span class="footer-attribution">Nathan Payne &middot; San Francisco</span>
-        <a href="/" class="footer-action">&larr; Back to Homepage</a>
-      </footer>
+      <Footer
+        attribution="Nathan Payne"
+        variant="grid"
+        links={[{ href: "/", label: "← Back to Homepage" }]}
+      />
     </div>
   </main>
 </BaseLayout>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -11,6 +11,7 @@
  */
 import { getCollection, getEntry } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
+import Footer from '../components/Footer.astro';
 import SummarySection from '../components/resume/SummarySection.astro';
 import SkillsSection from '../components/resume/SkillsSection.astro';
 import ExperienceSection from '../components/resume/ExperienceSection.astro';
@@ -227,13 +228,15 @@ const jsonLd = {
       </aside>
 
       {/* Footer */}
-      <footer class="resume-canvas-footer">
-        <p class="resume-canvas-footer__attribution">{m.name} &middot; San Francisco</p>
-        <nav class="resume-footer-nav" aria-label="Resume footer navigation">
-          <a class="project-action" href="/">&larr; Back to Homepage</a>
-          <a class="project-action" href="/blog/">Read the Blog &rarr;</a>
-        </nav>
-      </footer>
+      <Footer
+        attribution={m.name}
+        variant="canvas"
+        class="site-footer--resume"
+        links={[
+          { href: "/", label: "← Back to Homepage" },
+          { href: "/blog/", label: "Read the Blog →" },
+        ]}
+      />
 
     </article>
   </main>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1852,29 +1852,7 @@ body.resume-page {
   text-decoration: underline;
 }
 
-/* Project footer — matches blog footer pattern */
-.project-detail-footer {
-  padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.15rem, 3vw, 2.5rem);
-  border-top: 1px solid var(--ink, #11100d);
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.project-footer-nav {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-}
-
-.project-footer-attribution {
-  font-size: clamp(0.7rem, 0.88vw, 0.82rem);
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(17, 16, 13, 0.58);
-}
+/* Project-detail footer now uses the shared .site-footer system (#434). */
 
 /* ── Responsive: metadata + layout ── */
 /* 768px matches --bp-tablet on :root. CSS does not allow var() in @media
@@ -1911,14 +1889,7 @@ body.resume-page {
     border-top: none;
   }
 
-  .project-detail-footer {
-    flex-direction: column;
-    text-align: center;
-  }
-
-  .project-footer-nav {
-    justify-content: center;
-  }
+  /* footer column-stack + nav-center handled by the shared .site-footer @1023 rule (#434) */
 }
 
 /* ── Blog Index: Mondrian Row Grid ──────────────────────────
@@ -2228,51 +2199,75 @@ a.tag:hover {
   color: var(--ink);
 }
 
-/* ── Footer Row ── */
-.grid-footer {
-  background: var(--paper);
+/* ── Shared site footer (#434) ──────────────────────────────────────────
+   One footer: attribution + nav actions across the blog index, projects
+   index, blog post, project detail, and resume. The cosmetic content lives
+   here so a change lands on every page; per-page placement/chrome is a thin
+   modifier. Buttons reuse .project-action. See src/components/Footer.astro. */
+.site-footer {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding: clamp(1.15rem, 2.5vw, 2rem) clamp(1.15rem, 3vw, 2.5rem);
-  border-top: var(--line) solid var(--ink);
+  padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.15rem, 3vw, 2.5rem);
+  border-top: 1px solid var(--rule);
 }
 
-.footer-attribution {
+.site-footer__attribution {
   font-size: clamp(0.7rem, 0.88vw, 0.82rem);
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: rgba(17, 16, 13, 0.58);
 }
 
-.footer-action {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.55rem 0.85rem;
-  border: 1px solid var(--ink);
-  background: transparent;
-  font-size: clamp(0.8rem, 0.92vw, 0.92rem);
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: inherit;
-  text-decoration: none;
-  transition:
-    background-color var(--motion-hover) var(--ease-standard),
-    color var(--motion-hover) var(--ease-standard),
-    transform var(--motion-hover) var(--ease-standard);
+.site-footer__nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
-/* Red on hover to match the other white footers (blog post, resume). The
-   white-footer pages share a single red hover affordance; only the
-   color-themed project detail footer keeps its per-project accent. */
-.footer-action:hover {
+/* White footers (index, blog post, resume) share one red hover affordance;
+   only the color-themed project-detail footer keeps its per-project accent. */
+.site-footer:not(.site-footer--detail) .project-action:hover,
+.site-footer:not(.site-footer--detail) .project-action:focus-visible {
   background: var(--red);
   color: var(--cream);
-  transform: translateY(-2px);
+}
+
+/* Mondrian grid footer row (blog + projects index): white band, thick rule. */
+.site-footer--grid {
+  background: var(--paper);
+  border-top: var(--line) solid var(--ink);
+  padding-block: clamp(1.15rem, 2.5vw, 2rem);
+}
+
+/* Footer cell inside the framed blog/resume canvas (col 2/-2, row 6). */
+.site-footer--canvas {
+  grid-column: 2 / -2;
+  grid-row: 6;
+  min-width: 0;
+  background: var(--paper);
+}
+
+/* Project-detail footer: plain block in the single-column article, dark rule. */
+.site-footer--detail {
+  border-top: 1px solid var(--ink);
+}
+
+@media (max-width: 1023px) {
+  .site-footer {
+    flex-direction: column;
+    text-align: center;
+  }
+  .site-footer__nav {
+    justify-content: center;
+  }
+  /* Blog + resume canvases collapse to one column; the footer cell moves down. */
+  .site-footer--canvas {
+    grid-column: 2;
+    grid-row: 8;
+  }
 }
 
 /* ── 404 Page: Mondrian Grid ────
@@ -2485,7 +2480,7 @@ a.tag:hover {
      ├── blog-sidebar-meta   (col 6, row 2)    — date, author, tags
      ├── blog-content        (col 4, row 4)    — meta-bar + prose
      ├── blog-sidebar        (col 6, row 4)    — sticky: ToC, pullquotes
-     └── blog-canvas-footer  (col 2/-2, row 6) — attribution, nav
+     └── site-footer--canvas (col 2/-2, row 6) — attribution, nav
 
    @see Issue #74
    ────────────────────────────────────────────────────────────── */
@@ -2806,13 +2801,7 @@ a.tag:hover {
   color: rgba(17, 16, 13, 0.72);
 }
 
-/* ── Footer ── */
-.blog-canvas-footer {
-  grid-column: 2 / -2;
-  grid-row: 6;
-  min-width: 0;
-  background: var(--paper);
-}
+/* Blog footer now uses the shared .site-footer system (#434). */
 
 /* Legacy single-column fallback (kept for backward compatibility) */
 .blog-layout {
@@ -3113,28 +3102,7 @@ a.tag:hover {
 }
 
 
-.blog-footer {
-  padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.15rem, 3vw, 2.5rem);
-  border-top: 1px solid var(--rule);
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.blog-footer-attribution {
-  font-size: clamp(0.7rem, 0.88vw, 0.82rem);
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(17, 16, 13, 0.58);
-}
-
-.blog-footer-nav {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-}
+/* (blog footer content styles moved to the shared .site-footer system, #434) */
 
 .blog-diagram {
   margin: 1rem 0 1.2rem;
@@ -3496,24 +3464,10 @@ a:focus-visible {
     box-shadow: 8px 8px 0 rgba(17, 16, 13, 0.1);
   }
 
-  .project-detail-footer {
-    flex-direction: column;
-    text-align: center;
-  }
-
   .blog-meta-bar dl {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 1rem;
-  }
-
-  .blog-footer {
-    flex-direction: column;
-    text-align: center;
-  }
-
-  .blog-footer-nav {
-    justify-content: center;
   }
 
   .blog-diagram-fanout-row {
@@ -3599,11 +3553,7 @@ a:focus-visible {
 
   .blog-sidebar { display: none; }
 
-  .blog-canvas-footer {
-    grid-column: 2;
-    grid-row: 8;
-    min-width: 0;
-  }
+  /* blog footer reposition handled by the shared .site-footer--canvas @1023 rule (#434) */
 }
 
 /* ════════════════════════════════════════════════════════════════════
@@ -3859,27 +3809,7 @@ body.resume-page {
   line-height: 1.32;
 }
 
-/* Footer cell */
-.resume-canvas-footer {
-  grid-column: 2 / -2;
-  grid-row: 6;
-  min-width: 0;
-  background: var(--paper);
-  /* Match .blog-footer: padding, top rule, and uppercase attribution. */
-  padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.15rem, 3vw, 2.5rem);
-  border-top: 1px solid var(--rule);
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-.resume-canvas-footer__attribution {
-  font-size: clamp(0.7rem, 0.88vw, 0.82rem);
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(17, 16, 13, 0.58);
-}
+/* Resume footer now uses the shared .site-footer system (#434). */
 
 .resume-name {
   font-family: "Cormorant Garamond", Garamond, serif;
@@ -4299,12 +4229,7 @@ body.resume-page {
   color: rgba(17, 16, 13, 0.6);
 }
 
-/* ── Footer (screen-only navigation) ── */
-.resume-footer-nav {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-}
+/* (resume footer nav styles moved to the shared .site-footer system, #434) */
 
 /* ── /resume canvas — collapse to a single column (≤ 1023px, --bp-stack) ──
    Mirrors the blog collapse: margin + sidebar hidden, the metadata panel
@@ -4340,13 +4265,9 @@ body.resume-page {
   .resume-canvas-content { grid-column: 2; grid-row: 6; }
   .resume-canvas-sidebar { display: none; }
   /* Match the blog footer's narrow-screen flow: stack + center. */
-  .resume-canvas-footer {
-    grid-column: 2;
-    grid-row: 8;
-    flex-direction: column;
-    text-align: center;
-  }
-  .resume-footer-nav { justify-content: center; }
+  /* Resume footer reposition + column-stack now come from the shared
+     .site-footer / .site-footer--canvas @1023 rules (#434); --resume is the
+     print-hide hook only. */
 }
 
 /* ════════════════════════════════════════════════════════════════════
@@ -4398,7 +4319,7 @@ body.resume-page {
   .resume-canvas-margin,
   .resume-canvas-meta,
   .resume-canvas-sidebar,
-  .resume-canvas-footer,
+  .site-footer--resume,
   .resume-canvas-header .project-breadcrumbs,
   .company-logo {
     display: none !important;

--- a/tests/resume.test.js
+++ b/tests/resume.test.js
@@ -77,7 +77,7 @@ describe('Resume — page structure', () => {
     expect(document.querySelector('.resume-canvas-margin--header'), 'accent margin missing').not.toBeNull();
     expect(document.querySelector('.resume-canvas-content'), 'content column missing').not.toBeNull();
     expect(document.querySelector('.resume-canvas-sidebar'), 'sidebar missing').not.toBeNull();
-    expect(document.querySelector('.resume-canvas-footer'), 'footer missing').not.toBeNull();
+    expect(document.querySelector('.site-footer--resume'), 'footer missing').not.toBeNull();
   });
 
   it('renders breadcrumbs (Nathan Payne / Resume) in the header', () => {


### PR DESCRIPTION
## Summary

Replaces the four footer implementations with **one** `Footer.astro` + **one**
`.site-footer` class set across the blog index, projects index, blog post,
project detail, and resume.

Before: `.grid-footer` + `.footer-action` (indexes), `.blog-canvas-footer` >
`.blog-footer` + `.project-action` (blog post), `.project-detail-footer`
(project detail), `.resume-canvas-footer` (resume) — four containers, two button
classes, and the #428 hover-color drift.

After:
- **`src/components/Footer.astro`** renders the shared markup (attribution + nav
  actions) from `{ attribution, links, variant, class? }`.
- **One `.site-footer` class set** owns the cosmetic content (flex layout,
  attribution, nav, the ≤1023 column-stack). Per-page placement/chrome is a thin
  modifier: `--grid` (white Mondrian band), `--canvas` (framed blog/resume cell,
  col 2/-2 → row 8 on collapse), `--detail` (plain article block).
- **One hover rule.** White footers (index/blog/resume) share a single red
  affordance *regardless of page accent*; the color-themed project-detail footer
  keeps its per-project accent via `:not(.site-footer--detail)`.
- Buttons reuse the shared `.project-action` (semantic rename deferred to #436).
- Resume `@media print` hide and the canvas ≤1023 row-8 reposition are preserved
  (retargeted to the new classes).

Closes #434. Part of #429.

Authoring-Agent: claude

## Self-Review

- **Correctness — verified in the dev preview across all five footers:**
  - Blog index (page accent **blue** `#223f89`) footer button hover resolves to
    `var(--red)` `#c11d19` — the #428 "white footers hover red" intent, now in a
    single rule, decoupled from page accent.
  - Project-detail (matchline, accent `#333`) footer is `--detail`,
    `matchesRedOverride: false` → keeps the per-project accent hover.
  - Resume footer: grid cell `2/-2` row 6, white; `@media print` hides
    `.site-footer--resume` (verified via CSSOM); at ≤1023 it moves to row 8 and
    stacks/centers. The sensitive #420 print layout is intact.
  - Blog post footer: canvas cell, red hover applies.
- **Regression risk:** Medium (touches every footer). Mitigated: both canvas
  footers share one ≤1023 row-8 reposition (caught a second `.blog-canvas-footer`
  rule that would otherwise have stranded the blog footer); a grep confirms zero
  remaining old footer-class selectors/markup; `npm run test` green (188/188).
- **Style:** Buttons keep `.project-action` (no new button duplication); CMOS em
  dashes; motion stays on existing tokens (no bare ms/easing). Index footer
  buttons adopt `.project-action`'s `0.14em` letter-spacing — an intentional
  consistency fix in the #428/#429 spirit.
- **Test coverage:** `tests/resume.test.js` footer assertion updated to
  `.site-footer--resume`; `project-pages.test.js` still valid (filters
  `.project-action` by hero-CTA label). Full build (29 pages) + 188 tests pass.
- **Security / dependency hygiene:** No deps, runtime JS, or secrets; one new
  presentational Astro component.
