### PR TITLE
refactor(css): extract shared .page-canvas envelope (#435)

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -149,7 +149,7 @@ const jsonLd = {
          3-column composition: accent margin | content | sidebar
          Grid lines are the --ink background showing through gaps.
          ──────────────────────────────────────────────────────── */}
-    <article class="blog-canvas">
+    <article class="blog-canvas page-canvas">
 
       {/* ── Left margin: per-row Mondrian accent blocks ── */}
       <div class="blog-margin blog-margin--header" aria-hidden="true"></div>

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -97,7 +97,7 @@ const topics = kicker.split(/\s*×\s*/).join(' · ');
     class="project-shell"
     style={`--project-accent: ${accentColor}; --project-gradient-from: ${gradientFrom}; --project-gradient-to: ${gradientTo};`}
   >
-    <article class="project-detail">
+    <article class="project-detail page-canvas">
 
       {screenshotAspect === 'narrow' ? (
         <HeroNarrow

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -9,7 +9,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   noindex
 >
   <main class="error-shell">
-    <div class="error-mondrian">
+    <div class="error-mondrian page-canvas">
       <div class="e-content">
         <nav class="breadcrumbs" aria-label="Breadcrumb">
           <a href="/">Nathan Payne</a>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -55,7 +55,7 @@ function readingTime(body: string | undefined): string {
   jsonLd={jsonLd}
 >
   <main class="shell">
-    <div class="frame">
+    <div class="frame page-canvas">
 
       {/* ── Hero ── */}
       <header class="hero">

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -38,7 +38,7 @@ const jsonLd = {
   jsonLd={jsonLd}
 >
   <main class="shell">
-    <div class="frame">
+    <div class="frame page-canvas">
 
       {/* ── Hero ── */}
       <header class="hero">

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -145,7 +145,7 @@ const jsonLd = {
          3-column grid: accent margin | content | sidebar. The --ink
          background shows through the var(--line) gaps as grid lines.
          Mirrors src/layouts/BlogPost.astro. ─────────────────────── */}
-    <article class="resume-canvas">
+    <article class="resume-canvas page-canvas">
 
       {/* Left margin: per-row Mondrian accent blocks (decorative) */}
       <div class="resume-canvas-margin resume-canvas-margin--header" aria-hidden="true"></div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1285,13 +1285,22 @@ body.resume-page {
   padding: clamp(0.9rem, 2.5vw, 1.8rem) var(--page-gutter);
 }
 
-.project-detail {
-  width: min(100%, 72rem);
+/* ── Shared page canvas (#435) ──────────────────────────────────────────
+   The framed/centered "black box" envelope shared by every page canvas
+   (.frame, .project-detail, .blog-canvas, .resume-canvas, .error-mondrian):
+   width, horizontal centering, and the drop shadow. Page-specific grid,
+   background, border, and overflow stay on each canvas's own class. Width is
+   --canvas-width (72rem default; the 404 card overrides to 64rem). */
+.page-canvas {
+  width: min(100%, var(--canvas-width, 72rem));
   margin: 0 auto;
+  box-shadow: var(--canvas-shadow);
+}
+
+.project-detail {
   background: var(--surface);
   border: var(--line) solid var(--grid-border);
   overflow-x: hidden;
-  box-shadow: var(--canvas-shadow);
 }
 
 .project-hero {
@@ -1907,12 +1916,9 @@ body.resume-page {
 }
 
 .frame {
-  width: min(100%, 72rem);
-  margin: 0 auto;
   background: var(--surface);
   border: var(--line) solid var(--grid-border);
   overflow: hidden;
-  box-shadow: var(--canvas-shadow);
 }
 
 /* ── Hero ── */
@@ -2285,10 +2291,11 @@ a.tag:hover {
 }
 
 .error-mondrian {
-  /* Size from the padded content width (like .frame/.blog-canvas/.resume-canvas
-     use min(100%, 72rem)) rather than 95vw, so the card never depends on
-     flex-shrink to fit inside .error-shell's 2rem gutter on narrow screens. */
-  width: min(100%, 64rem);
+  /* 64rem (narrower than the 72rem default), supplied to the shared
+     .page-canvas via --canvas-width; width/centering/shadow live there.
+     Sizing from the padded content width (not 95vw) keeps the card off
+     .error-shell's gutter without depending on flex-shrink. */
+  --canvas-width: 64rem;
   display: grid;
   grid-template-columns:
     var(--line) 2.4fr var(--line) 1fr var(--line) 1.2fr var(--line) 0.5fr var(--line);
@@ -2296,7 +2303,6 @@ a.tag:hover {
     var(--line) auto var(--line) 5rem var(--line) 3.5rem var(--line);
   background: var(--black);
   border: 1px solid var(--grid-border);
-  box-shadow: var(--canvas-shadow);
 }
 
 .e-content {
@@ -2501,9 +2507,6 @@ a.tag:hover {
     var(--line) auto           /* footer row */
     var(--line);
   background: var(--ink);
-  width: min(100%, 72rem);
-  margin: 0 auto;
-  box-shadow: var(--canvas-shadow);
   /* Use clip instead of hidden — hidden creates a scroll container
      which breaks position:sticky on .blog-sidebar-inner. clip
      provides the same visual clipping without a new scroll context. */
@@ -3607,9 +3610,6 @@ body.resume-page {
     var(--line) auto           /* footer row */
     var(--line);
   background: var(--ink);
-  width: min(100%, 72rem);
-  margin: 0 auto;
-  box-shadow: var(--canvas-shadow);
   /* clip (not hidden) so position:sticky on the sidebar still works. */
   overflow: clip;
 }


### PR DESCRIPTION
## Summary

Factors the shared framed-box envelope—**width, horizontal centering, drop
shadow**—out of the five page canvases into one `.page-canvas` class.

- `.frame`, `.project-detail`, `.blog-canvas`, `.resume-canvas`,
  `.error-mondrian` each dropped their duplicated `width` / `margin: 0 auto` /
  `box-shadow`; all now carry `page-canvas` alongside their own class.
- Width is the `--canvas-width` token (72rem default; the 404 card sets `64rem`).
- Page-specific **grid, background, border, and overflow** stay on each canvas's
  own class. The `.project-detail` `@1023` `8px` shadow reduction and the resume
  `@media print` override still win by source order (verified).

A small markup-class addition + CSS de-duplication; no component (the canvases
are page-specific grids, so a shared **class** is the "equivalent shared wrapper"
the issue allows). 46 lines changed.

Closes #435. Part of #429.

Authoring-Agent: claude

## Self-Review

- **Correctness — verified in preview:**
  - `.frame` (blog index): shadow `14px 14px 0`, width 1152px (72rem), equal
    112px auto-margins, 9px `--line` border (own class).
  - `.error-mondrian` (404): width 1024px (`--canvas-width: 64rem`), **leftGap ==
    rightGap == 208px** → still centered (the `margin: 0 auto` centers it in the
    flex `.error-shell` identically to the prior flex-only centering).
  - `.resume-canvas`: grid intact (7 tracks), shadow correct, and the
    `@media print` rule still targets `.resume-canvas` (`box-shadow: none;
    width: 100%; margin: 0`) → #420 print layout preserved.
- **Regression risk:** Low. Only width/centering/shadow moved; values identical.
  Confirmed the two non-canvas `var(--canvas-shadow)` users (`.og-card` build
  template, `.error-mondrian @768` re-assert) are untouched/unaffected.
- **Style:** `--canvas-width` follows the #429 token plan; canvases keep their
  semantic classes (rename is #438); no bare motion values.
- **Test coverage:** `npm run test` green — 29-page build + 188 tests
  (resume/blog/project structural assertions still pass; the canvas classes
  remain in markup).
- **Security / dependency hygiene:** None affected; CSS + class attributes only.
