### PR TITLE
refactor(css): extract shared Breadcrumbs component (#436)

### DIFF
--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -6,8 +6,9 @@
  * blog index, projects index, blog post, project detail, resume, and 404. The
  * markup lives here; per-context styling stays scoped in global.css.
  *
- * Items with an `href` render as links; the final (or any href-less) item
- * renders as the current page (`.breadcrumb-current` + `aria-current="page"`).
+ * The final item renders as the current page (`.breadcrumb-current` +
+ * `aria-current="page"`); earlier items render as links when they have an
+ * `href`. Current-ness is by position, not a missing `href`.
  * Pass `class="breadcrumbs--inset"` for the indented/dimmed canvas-header
  * variant used by the project detail, blog post, and resume headers.
  */
@@ -30,10 +31,12 @@ const classList = ["breadcrumbs", extra].filter(Boolean).join(" ");
     items.map((item, i) => (
       <Fragment>
         {i > 0 && <span class="breadcrumb-sep">/</span>}
-        {item.href ? (
+        {i === items.length - 1 ? (
+          <span class="breadcrumb-current" aria-current="page">{item.label}</span>
+        ) : item.href ? (
           <a href={item.href}>{item.label}</a>
         ) : (
-          <span class="breadcrumb-current" aria-current="page">{item.label}</span>
+          <span>{item.label}</span>
         )}
       </Fragment>
     ))

--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -1,0 +1,41 @@
+---
+/**
+ * Shared breadcrumb nav (#436).
+ *
+ * One implementation of the "Nathan Payne / … / current" trail used across the
+ * blog index, projects index, blog post, project detail, resume, and 404. The
+ * markup lives here; per-context styling stays scoped in global.css.
+ *
+ * Items with an `href` render as links; the final (or any href-less) item
+ * renders as the current page (`.breadcrumb-current` + `aria-current="page"`).
+ * Pass `class="breadcrumbs--inset"` for the indented/dimmed canvas-header
+ * variant used by the project detail, blog post, and resume headers.
+ */
+interface Crumb {
+  label: string;
+  href?: string;
+}
+
+interface Props {
+  items: Crumb[];
+  class?: string;
+}
+
+const { items, class: extra } = Astro.props;
+const classList = ["breadcrumbs", extra].filter(Boolean).join(" ");
+---
+
+<nav class={classList} aria-label="Breadcrumb">
+  {
+    items.map((item, i) => (
+      <Fragment>
+        {i > 0 && <span class="breadcrumb-sep">/</span>}
+        {item.href ? (
+          <a href={item.href}>{item.label}</a>
+        ) : (
+          <span class="breadcrumb-current" aria-current="page">{item.label}</span>
+        )}
+      </Fragment>
+    ))
+  }
+</nav>

--- a/src/components/HeroNarrow.astro
+++ b/src/components/HeroNarrow.astro
@@ -1,4 +1,6 @@
 ---
+import Breadcrumbs from './Breadcrumbs.astro';
+
 interface Props {
   title: string;
   deck: string;
@@ -13,13 +15,14 @@ const { title, deck, breadcrumbLabel, liveUrl, githubUrl } = Astro.props;
 <header class="project-hero project-hero--narrow">
   <div class="project-hero__gradient">
     <div class="project-hero__header">
-      <nav class="project-breadcrumbs" aria-label="Breadcrumb">
-        <a href="/">Nathan Payne</a>
-        <span class="breadcrumb-sep">/</span>
-        <a href="/projects/">Builds</a>
-        <span class="breadcrumb-sep">/</span>
-        <span class="breadcrumb-current" aria-current="page">{breadcrumbLabel}</span>
-      </nav>
+      <Breadcrumbs
+        class="breadcrumbs--inset"
+        items={[
+          { label: "Nathan Payne", href: "/" },
+          { label: "Builds", href: "/projects/" },
+          { label: breadcrumbLabel },
+        ]}
+      />
       <h1 class="project-title">{title}</h1>
       <p class="project-deck">{deck}</p>
       <div class="project-actions">

--- a/src/components/HeroWide.astro
+++ b/src/components/HeroWide.astro
@@ -1,4 +1,6 @@
 ---
+import Breadcrumbs from './Breadcrumbs.astro';
+
 interface Props {
   title: string;
   deck: string;
@@ -13,13 +15,14 @@ const { title, deck, breadcrumbLabel, liveUrl, githubUrl } = Astro.props;
 <header class="project-hero project-hero--wide">
   <div class="project-hero__gradient">
     <div class="project-hero__header">
-      <nav class="project-breadcrumbs" aria-label="Breadcrumb">
-        <a href="/">Nathan Payne</a>
-        <span class="breadcrumb-sep">/</span>
-        <a href="/projects/">Builds</a>
-        <span class="breadcrumb-sep">/</span>
-        <span class="breadcrumb-current" aria-current="page">{breadcrumbLabel}</span>
-      </nav>
+      <Breadcrumbs
+        class="breadcrumbs--inset"
+        items={[
+          { label: "Nathan Payne", href: "/" },
+          { label: "Builds", href: "/projects/" },
+          { label: breadcrumbLabel },
+        ]}
+      />
       <h1 class="project-title">{title}</h1>
       <p class="project-deck">{deck}</p>
       <div class="project-actions">

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -21,6 +21,7 @@
  */
 import BaseLayout from './BaseLayout.astro';
 import Footer from '../components/Footer.astro';
+import Breadcrumbs from '../components/Breadcrumbs.astro';
 
 interface Props {
   title: string;
@@ -158,13 +159,14 @@ const jsonLd = {
 
       {/* ── Header ── */}
       <header class="blog-canvas-header">
-        <nav class="project-breadcrumbs" aria-label="Breadcrumb">
-          <a href="/">Nathan Payne</a>
-          <span class="breadcrumb-sep">/</span>
-          <a href="/blog/">Blog</a>
-          <span class="breadcrumb-sep">/</span>
-          <span class="breadcrumb-current">{shortTitle || 'Article'}</span>
-        </nav>
+        <Breadcrumbs
+          class="breadcrumbs--inset"
+          items={[
+            { label: "Nathan Payne", href: "/" },
+            { label: "Blog", href: "/blog/" },
+            { label: shortTitle || 'Article' },
+          ]}
+        />
         <h1>{title}</h1>
         <p class="project-deck">{description}</p>
       </header>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import Breadcrumbs from '../components/Breadcrumbs.astro';
 ---
 
 <BaseLayout
@@ -11,11 +12,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <main class="error-shell">
     <div class="error-mondrian page-canvas">
       <div class="e-content">
-        <nav class="breadcrumbs" aria-label="Breadcrumb">
-          <a href="/">Nathan Payne</a>
-          <span class="breadcrumb-sep">/</span>
-          <span>404</span>
-        </nav>
+        <Breadcrumbs items={[{ label: "Nathan Payne", href: "/" }, { label: "404" }]} />
         <h1>Page not found</h1>
         <p class="deck">The page you're looking for doesn't exist or has been moved.</p>
         <div class="project-actions">

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
 import { estimateReadingMinutes } from '../../lib/reading-time';
 import Footer from '../../components/Footer.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
 
 const posts = (await getCollection('blog', ({ data }) => !data.draft))
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
@@ -59,11 +60,7 @@ function readingTime(body: string | undefined): string {
 
       {/* ── Hero ── */}
       <header class="hero">
-        <nav class="breadcrumbs" aria-label="Breadcrumb">
-          <a href="/">Nathan Payne</a>
-          <span class="breadcrumb-sep">/</span>
-          <span>Blog</span>
-        </nav>
+        <Breadcrumbs items={[{ label: "Nathan Payne", href: "/" }, { label: "Blog" }]} />
         <h1>Field Notes</h1>
         <p class="deck">A product manager’s notes on shipping real systems with AI coding agents—the architecture decisions, the failure modes, and what actually works.</p>
       </header>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
 import Footer from '../../components/Footer.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
 
 const allProjects = await getCollection('projects', ({ data }) => !data.draft);
 const projects = allProjects.sort((a, b) => a.data.order - b.data.order);
@@ -42,11 +43,7 @@ const jsonLd = {
 
       {/* ── Hero ── */}
       <header class="hero">
-        <nav class="breadcrumbs" aria-label="Breadcrumb">
-          <a href="/">Nathan Payne</a>
-          <span class="breadcrumb-sep">/</span>
-          <span>Builds</span>
-        </nav>
+        <Breadcrumbs items={[{ label: "Nathan Payne", href: "/" }, { label: "Builds" }]} />
         <h1>Builds</h1>
         <p class="deck">Every build started as a real problem. Each one became a systems design exercise&mdash;built with AI agents from first commit to deploy, on top of an enforcement system I designed to make agent output reliable. The infrastructure behind these projects is documented in <a href="/blog/agent-approval-workflow-genesis-of-mergepath/" class="p-link">Agent Approval Workflow and the Genesis of Mergepath</a>.</p>
       </header>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -12,6 +12,7 @@
 import { getCollection, getEntry } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Footer from '../components/Footer.astro';
+import Breadcrumbs from '../components/Breadcrumbs.astro';
 import SummarySection from '../components/resume/SummarySection.astro';
 import SkillsSection from '../components/resume/SkillsSection.astro';
 import ExperienceSection from '../components/resume/ExperienceSection.astro';
@@ -154,11 +155,13 @@ const jsonLd = {
 
       {/* Header — breadcrumbs, name, title, and contact (kept here so it prints) */}
       <header class="resume-canvas-header">
-        <nav class="project-breadcrumbs" aria-label="Breadcrumb">
-          <a href="/">Nathan Payne</a>
-          <span class="breadcrumb-sep">/</span>
-          <span class="breadcrumb-current">Resume</span>
-        </nav>
+        <Breadcrumbs
+          class="breadcrumbs--inset"
+          items={[
+            { label: "Nathan Payne", href: "/" },
+            { label: "Resume" },
+          ]}
+        />
         <h1 class="resume-name">{m.name}</h1>
         <p class="resume-title">{m.title}</p>
         <p class="resume-contact resume-contact--primary">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1317,31 +1317,7 @@ body.resume-page {
   background: var(--project-accent);
 }
 
-.project-breadcrumbs {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-  margin-bottom: calc(var(--su) * 1.5);
-  padding-left: clamp(1rem, 2.2vw, 1.6rem);
-  font-size: clamp(0.72rem, 0.92vw, 0.88rem);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: rgba(17, 16, 13, 0.38);
-}
-
-.project-breadcrumbs a {
-  color: inherit;
-  text-decoration: none;
-}
-
-.project-breadcrumbs a:hover {
-  text-decoration: underline;
-}
-
-.project-breadcrumbs .breadcrumb-sep {
-  user-select: none;
-}
+/* (project breadcrumbs unified into the shared .breadcrumbs / .breadcrumbs--inset system, #436) */
 
 .project-hero h1 {
   padding-left: clamp(1rem, 2.2vw, 1.6rem);
@@ -1949,6 +1925,18 @@ body.resume-page {
 
 .breadcrumbs .breadcrumb-sep {
   user-select: none;
+}
+
+/* Canvas-header breadcrumb variant (#436): indented + dimmed, for the project
+   detail, blog post, and resume headers. Core + link/separator styling come
+   from .breadcrumbs above; this adds only the inset extras. Placed after the
+   base so its single-class overrides win by source order, matching the prior
+   .project-breadcrumbs behavior. */
+.breadcrumbs--inset {
+  flex-wrap: wrap;
+  margin-bottom: calc(var(--su) * 1.5);
+  padding-left: clamp(1rem, 2.2vw, 1.6rem);
+  color: rgba(17, 16, 13, 0.38);
 }
 
 .hero h1 {
@@ -2560,17 +2548,17 @@ a.tag:hover {
 
 /* Header typography — explicit rules since blog-canvas-header
    is outside the .project-hero scope that normally provides these. */
-.blog-canvas-header .project-breadcrumbs {
+.blog-canvas-header .breadcrumbs {
   font-weight: 400;
   color: rgba(17, 16, 13, 0.38);
   margin-bottom: 1.5rem;
 }
 
-.blog-canvas-header .project-breadcrumbs a {
+.blog-canvas-header .breadcrumbs a {
   color: rgba(17, 16, 13, 0.38);
 }
 
-.blog-canvas-header .project-breadcrumbs a:hover {
+.blog-canvas-header .breadcrumbs a:hover {
   color: rgba(17, 16, 13, 0.62);
   text-decoration: none;
 }
@@ -3268,7 +3256,7 @@ a:focus-visible {
     padding: 1rem 1rem 1.15rem;
   }
 
-  .project-breadcrumbs {
+  .breadcrumbs--inset {
     padding-left: 0.5rem;
     font-size: 0.68rem;
   }
@@ -3655,7 +3643,7 @@ body.resume-page {
   flex-direction: column;
   justify-content: flex-end;
 }
-.resume-canvas-header .project-breadcrumbs {
+.resume-canvas-header .breadcrumbs {
   margin-bottom: 1.4rem;
   padding-left: 0;
 }
@@ -4320,7 +4308,7 @@ body.resume-page {
   .resume-canvas-meta,
   .resume-canvas-sidebar,
   .site-footer--resume,
-  .resume-canvas-header .project-breadcrumbs,
+  .resume-canvas-header .breadcrumbs,
   .company-logo {
     display: none !important;
   }

--- a/tests/resume.test.js
+++ b/tests/resume.test.js
@@ -81,7 +81,7 @@ describe('Resume — page structure', () => {
   });
 
   it('renders breadcrumbs (Nathan Payne / Resume) in the header', () => {
-    const crumbs = document.querySelector('.resume-canvas-header .project-breadcrumbs');
+    const crumbs = document.querySelector('.resume-canvas-header .breadcrumbs');
     expect(crumbs, 'breadcrumbs missing').not.toBeNull();
     const text = crumbs.textContent.replace(/\s+/g, ' ').trim();
     expect(text).toContain('Nathan Payne');


### PR DESCRIPTION
## Summary

Unifies the **two** breadcrumb implementations into one `Breadcrumbs.astro` +
one `.breadcrumbs` class set.

Before: `.breadcrumbs` (blog index, projects index, 404) and
`.project-breadcrumbs` (project detail via Hero, blog post, resume) — the same
trail built twice, with the markup copied across 7 sites.

After:
- **`src/components/Breadcrumbs.astro`** renders the shared "Nathan Payne / … /
  current" trail from `{ items, class? }`. Items with `href` are links; the
  href-less item is the current page (`.breadcrumb-current` + `aria-current="page"`).
- **One `.breadcrumbs` base** (index/404 unchanged). The indented/dimmed
  canvas-header look is a **`.breadcrumbs--inset`** modifier (project detail,
  blog post, resume).
- Context scopes retargeted from `.project-breadcrumbs` → `.breadcrumbs`:
  `.blog-canvas-header` (dimmed + 28ch truncated current), `.resume-canvas-header`
  (no indent, 1.4rem margin), the `≤480` responsive, and the resume `@media print`
  hide. The 404 `.e-content` scope already used `.breadcrumbs` (untouched).

**Scope note:** this PR is the breadcrumb half of #436. The `.project-action` →
`.nav-button` rename is folded into **#438** (semantic rename) so all the
`project-*` shared-class renames land atomically there, rather than introducing
an orphaned alias here. 177 lines.

Closes #436. Part of #429.

Authoring-Agent: claude

## Self-Review

- **Correctness — verified in preview across all five contexts:**
  - Blog index: `breadcrumbs` (plain) — `padding-left: 0`, inherited ink, 1rem margin.
  - Project detail (matchline): `breadcrumbs breadcrumbs--inset` — 25.6px indent,
    `rgba(17,16,13,0.38)`, `flex-wrap: wrap`, `aria-current="page"`.
  - Blog post: `--inset` + `.blog-canvas-header` — dimmed, `font-weight: 400`,
    1.5rem margin, indent kept, current truncates (max-width 28ch, ellipsis).
  - Resume: `--inset` + `.resume-canvas-header` — `padding-left: 0`, 1.4rem
    margin, and the `@media print` hide still targets it (`printHides: true`).
  - 404: `.breadcrumbs` + `.e-content` scope unchanged.
- **Regression risk:** Low–medium (touches every breadcrumb). Mitigated:
  `.breadcrumbs--inset` is placed *after* the base so its single-class overrides
  win by source order exactly as `.project-breadcrumbs` did; a grep shows zero
  remaining `.project-breadcrumbs` selectors/markup; build + 188 tests green.
- **Style:** Standardizing the current item to `.breadcrumb-current` +
  `aria-current` is an a11y win with no visual change (`.breadcrumb-current` has
  no base style; only the blog-canvas-header scope styles it, which 404/index
  don't match). No bare motion values.
- **Test coverage:** `tests/resume.test.js` breadcrumb selector updated to
  `.resume-canvas-header .breadcrumbs`; 29-page build + 188 tests pass.
- **Security / dependency hygiene:** One new presentational component; no deps,
  runtime JS, or secrets.
