### PR TITLE
refactor(css): semantic rename of shared project-* chrome (#438)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -11,7 +11,7 @@
  *   - canvas → white footer cell inside the framed blog/resume canvas
  *   - detail → plain block in the single-column project-detail article
  *
- * Buttons reuse the shared `.project-action`; white footers share one red
+ * Buttons reuse the shared `.nav-button`; white footers share one red
  * hover affordance, while the color-themed project-detail footer keeps its
  * per-project accent (see `.site-footer` rules in global.css).
  */
@@ -46,7 +46,7 @@ const classList = [
   <p class="site-footer__attribution">{attribution} &middot; San Francisco</p>
   <nav class="site-footer__nav" aria-label="Footer navigation">
     {links.map((link) => (
-      <a class="project-action" href={link.href}>{link.label}</a>
+      <a class="nav-button" href={link.href}>{link.label}</a>
     ))}
   </nav>
 </footer>

--- a/src/components/HeroNarrow.astro
+++ b/src/components/HeroNarrow.astro
@@ -24,12 +24,12 @@ const { title, deck, breadcrumbLabel, liveUrl, githubUrl } = Astro.props;
         ]}
       />
       <h1 class="project-title">{title}</h1>
-      <p class="project-deck">{deck}</p>
+      <p class="deck deck--inset">{deck}</p>
       <div class="project-actions">
         {liveUrl && (
-          <a class="project-action" href={liveUrl} target="_blank" rel="noopener noreferrer">View Live Product</a>
+          <a class="nav-button" href={liveUrl} target="_blank" rel="noopener noreferrer">View Live Product</a>
         )}
-        <a class="project-action" href={githubUrl} target="_blank" rel="noopener noreferrer">View on GitHub</a>
+        <a class="nav-button" href={githubUrl} target="_blank" rel="noopener noreferrer">View on GitHub</a>
       </div>
     </div>
   </div>

--- a/src/components/HeroWide.astro
+++ b/src/components/HeroWide.astro
@@ -24,12 +24,12 @@ const { title, deck, breadcrumbLabel, liveUrl, githubUrl } = Astro.props;
         ]}
       />
       <h1 class="project-title">{title}</h1>
-      <p class="project-deck">{deck}</p>
+      <p class="deck deck--inset">{deck}</p>
       <div class="project-actions">
         {liveUrl && (
-          <a class="project-action" href={liveUrl} target="_blank" rel="noopener noreferrer">View Live Product</a>
+          <a class="nav-button" href={liveUrl} target="_blank" rel="noopener noreferrer">View Live Product</a>
         )}
-        <a class="project-action" href={githubUrl} target="_blank" rel="noopener noreferrer">View on GitHub</a>
+        <a class="nav-button" href={githubUrl} target="_blank" rel="noopener noreferrer">View on GitHub</a>
       </div>
     </div>
   </div>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -146,7 +146,7 @@ const jsonLd = {
   jsonLd={jsonLd}
   articleMeta={{ published: isoDate, author, tags }}
 >
-  <main class="project-shell">
+  <main class="page-shell">
     {/* ── Mondrian Canvas Grid ──────────────────────────────────
          3-column composition: accent margin | content | sidebar
          Grid lines are the --ink background showing through gaps.
@@ -169,7 +169,7 @@ const jsonLd = {
           ]}
         />
         <h1>{title}</h1>
-        <p class="project-deck">{description}</p>
+        <p class="deck deck--inset">{description}</p>
       </header>
 
       {/* ── Sidebar: metadata panel ── */}

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -95,7 +95,7 @@ const topics = kicker.split(/\s*×\s*/).join(' · ');
   ogImageAlt={ogImageAlt}
 >
   <main
-    class="project-shell"
+    class="page-shell"
     style={`--project-accent: ${accentColor}; --project-gradient-from: ${gradientFrom}; --project-gradient-to: ${gradientTo};`}
   >
     <article class="project-detail page-canvas">

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -17,10 +17,10 @@ import Breadcrumbs from '../components/Breadcrumbs.astro';
         <h1>Page not found</h1>
         <p class="deck">The page you're looking for doesn't exist or has been moved.</p>
         <div class="project-actions">
-          <a class="project-action" href="/">Homepage</a>
-          <a class="project-action" href="/resume/">Résumé</a>
-          <a class="project-action" href="/projects/">Builds</a>
-          <a class="project-action" href="/blog/">Blog</a>
+          <a class="nav-button" href="/">Homepage</a>
+          <a class="nav-button" href="/resume/">Résumé</a>
+          <a class="nav-button" href="/projects/">Builds</a>
+          <a class="nav-button" href="/blog/">Blog</a>
         </div>
       </div>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1283,7 +1283,7 @@ body.resume-page {
   --project-bg: #dde1e5;
 }
 
-.project-shell {
+.page-shell {
   min-height: 100vh;
   /* 2rem side gutter keeps the centered box's 14px drop shadow off the
      viewport edge on narrow screens, matching .error-shell. */
@@ -1332,14 +1332,7 @@ body.resume-page {
   text-wrap: balance;
 }
 
-.project-deck {
-  max-width: 38rem;
-  margin-top: calc(var(--su) * 1.6);
-  padding-left: clamp(1rem, 2.2vw, 1.6rem);
-  font-size: clamp(1.05rem, 1rem + 0.42vw, 1.4rem);
-  line-height: 1.45;
-  font-family: "Cormorant Garamond", Garamond, serif;
-}
+/* (project hero deck unified into the shared .deck / .deck--inset system, #438) */
 
 .project-actions {
   display: flex;
@@ -1349,7 +1342,7 @@ body.resume-page {
   padding-left: clamp(1rem, 2.2vw, 1.6rem);
 }
 
-.project-action {
+.nav-button {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
@@ -1368,8 +1361,8 @@ body.resume-page {
     transform var(--motion-hover) var(--ease-standard);
 }
 
-.project-action:hover,
-.project-action:focus-visible {
+.nav-button:hover,
+.nav-button:focus-visible {
   background: var(--project-accent);
   color: var(--project-accent-foreground, #f5f0e4);
   transform: translateY(calc(var(--shift-small) * -1));
@@ -1960,6 +1953,16 @@ body.resume-page {
   color: rgba(17, 16, 13, 0.72);
 }
 
+/* Canvas-header deck variant (#438): indented, for the project hero. Core
+   (font/size/line-height/max-width) comes from .deck above; this adds the inset
+   indent + tighter top margin and keeps the hero's inherited (undimmed) color.
+   Placed after .deck so its single-class overrides win by source order. */
+.deck--inset {
+  margin-top: calc(var(--su) * 1.6);
+  padding-left: clamp(1rem, 2.2vw, 1.6rem);
+  color: inherit;
+}
+
 /* ── Mondrian Blog Grid ── */
 .blog-grid {
   display: grid;
@@ -2202,7 +2205,7 @@ a.tag:hover {
    One footer: attribution + nav actions across the blog index, projects
    index, blog post, project detail, and resume. The cosmetic content lives
    here so a change lands on every page; per-page placement/chrome is a thin
-   modifier. Buttons reuse .project-action. See src/components/Footer.astro. */
+   modifier. Buttons reuse .nav-button. See src/components/Footer.astro. */
 .site-footer {
   display: flex;
   flex-wrap: wrap;
@@ -2228,8 +2231,8 @@ a.tag:hover {
 
 /* White footers (index, blog post, resume) share one red hover affordance;
    only the color-themed project-detail footer keeps its per-project accent. */
-.site-footer:not(.site-footer--detail) .project-action:hover,
-.site-footer:not(.site-footer--detail) .project-action:focus-visible {
+.site-footer:not(.site-footer--detail) .nav-button:hover,
+.site-footer:not(.site-footer--detail) .nav-button:focus-visible {
   background: var(--red);
   color: var(--cream);
 }
@@ -2591,7 +2594,7 @@ a.tag:hover {
   margin-bottom: 1.2rem;
 }
 
-.blog-canvas-header .project-deck {
+.blog-canvas-header .deck {
   font-family: "Inter", system-ui, sans-serif;
   font-style: normal;
   font-weight: 400;
@@ -3271,7 +3274,7 @@ a:focus-visible {
     font-size: 1.75rem;
   }
 
-  .project-deck {
+  .deck--inset {
     padding-left: 0.5rem;
   }
 
@@ -3280,7 +3283,7 @@ a:focus-visible {
     flex-direction: column;
   }
 
-  .project-action {
+  .nav-button {
     width: 100%;
     justify-content: center;
   }

--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -143,11 +143,11 @@ describe('Project Pages — render', () => {
       });
 
       it('renders the appropriate CTA actions for the project', () => {
-        const actions = Array.from(document.querySelectorAll('.project-action')).map(
+        const actions = Array.from(document.querySelectorAll('.nav-button')).map(
           (a) => a.textContent.trim(),
         );
         // The "Back to Projects" / "Back to Homepage" footer actions also
-        // share the .project-action class, so filter to the hero CTAs by
+        // share the .nav-button class, so filter to the hero CTAs by
         // checking for the canonical labels we render in HeroWide/Narrow.
         if (noLiveUrlSlugs.includes(slug)) {
           expect(actions).not.toContain('View Live Product');


### PR DESCRIPTION
## Summary

Semantic rename of the shared, site-wide chrome that the `project-*` prefix
mislabeled — the explicitly highest-risk step, kept isolated.

- `.project-shell` → **`.page-shell`** (3 sites)
- `.project-action` → **`.nav-button`** (button class + the footer red-hover
  override + 19 refs). The `.project-actions` **layout container** is
  intentionally left as-is (distinct concern; word-boundary rename spares it).
- `.project-deck` → **`.deck`** via a merge with the existing `.deck`: a
  `.deck--inset` modifier carries the hero indent + tighter top margin and keeps
  the hero's **inherited (undimmed) color**; the `.blog-canvas-header` context
  and the `≤480` rule retarget to `.deck`.

`project-*` now denotes genuinely project-only styling (`.project-detail`,
`.project-hero`, `.project-screenshot`, `.project-stack`, `.project-related`).

73 lines. Closes #438. Part of #429.

Authoring-Agent: claude

## Self-Review

- **Correctness — verified in preview:**
  - `.page-shell` present with the 32px (`--page-gutter`) gutter on project
    detail + blog post.
  - `.nav-button` keeps the dual hover: base `var(--project-accent)` (project
    detail hero/footer) **and** the white-footer `var(--red)` override (the
    `.site-footer:not(.site-footer--detail) .nav-button:hover` rule renamed
    with it).
  - `.deck--inset` (project hero) computes **full ink `rgb(17,16,13)`** — the
    `color: inherit` preserves the old `.project-deck` behavior rather than
    inheriting `.deck`'s `0.72` dim — plus 25.6px indent + Cormorant. The blog
    post deck still resolves to `0.62` / Inter / 54ch via the retargeted
    `.blog-canvas-header .deck`.
- **Regression risk:** Medium (broad rename). Mitigated: word-boundary rename
  (`\bproject-action\b`) spared the `.project-actions` container (6 refs intact);
  grep shows zero `project-shell` / `project-action` / `project-deck` remaining;
  `.deck--inset` placed after `.deck` so single-class overrides win by source
  order; build + 188 tests green.
- **Style:** `page-shell` / `nav-button` / `deck` follow the #429 note's
  semantic targets; no bare motion values.
- **Test coverage:** `tests/project-pages.test.js` CTA selector updated to
  `.nav-button`; 29-page build + 188 tests pass.
- **Security / dependency hygiene:** CSS + class attributes only; no deps,
  runtime JS, or secrets.
