### PR TITLE
fix(css): standardize breadcrumb treatment across pages

### DIFF
--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -4,13 +4,15 @@
  *
  * One implementation of the "Nathan Payne / … / current" trail used across the
  * blog index, projects index, blog post, project detail, resume, and 404. The
- * markup lives here; per-context styling stays scoped in global.css.
+ * markup lives here; the color treatment is the shared `.breadcrumbs` ramp in
+ * global.css (--breadcrumb-* tokens, #452) on every page — per-context CSS may
+ * adjust spacing only.
  *
  * The final item renders as the current page (`.breadcrumb-current` +
  * `aria-current="page"`); earlier items render as links when they have an
  * `href`. Current-ness is by position, not a missing `href`.
- * Pass `class="breadcrumbs--inset"` for the indented/dimmed canvas-header
- * variant used by the project detail, blog post, and resume headers.
+ * Pass `class="breadcrumbs--inset"` for the indented canvas-header variant
+ * used by the project detail and blog post headers.
  */
 interface Crumb {
   label: string;

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -157,7 +157,6 @@ const jsonLd = {
       {/* Header — breadcrumbs, name, title, and contact (kept here so it prints) */}
       <header class="resume-canvas-header">
         <Breadcrumbs
-          class="breadcrumbs--inset"
           items={[
             { label: "Nathan Payne", href: "/" },
             { label: "Resume" },

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -28,6 +28,15 @@
   --surface: rgba(244, 239, 229, 0.96);
   --rule: rgba(17, 16, 13, 0.18);
 
+  /* Breadcrumb chrome (#452): one quiet ink ramp on every page. Parent links
+     sit a step darker than the current segment (they're interactive), the
+     current segment stays muted, separators sit lightest. The component never
+     inherits color from its container. */
+  --breadcrumb-link: rgba(17, 16, 13, 0.52);
+  --breadcrumb-link-hover: rgba(17, 16, 13, 0.78);
+  --breadcrumb-current: rgba(17, 16, 13, 0.38);
+  --breadcrumb-sep: rgba(17, 16, 13, 0.22);
+
   /* Shared page-chrome primitives (#429). Frame width is --line (9px) above.
      --canvas-shadow: the drop shadow shared by every framed "black box"
      (.frame/.project-detail/.blog-canvas/.resume-canvas/.error-mondrian).
@@ -1894,39 +1903,54 @@ body.blog-page {
   border-bottom: var(--line) solid var(--ink);
 }
 
+/* One color treatment on every page (#452): the ramp comes from the
+   --breadcrumb-* tokens, never from the container, so the trail reads
+   identically on the hero indexes, the canvas headers, and the 404. */
 .breadcrumbs {
   display: flex;
   align-items: center;
   gap: 0.35rem;
   margin-bottom: 1rem;
   font-size: clamp(0.72rem, 0.92vw, 0.88rem);
+  font-weight: 400;
   letter-spacing: 0.12em;
   text-transform: uppercase;
+  color: var(--breadcrumb-current);
 }
 
 .breadcrumbs a {
-  color: inherit;
+  color: var(--breadcrumb-link);
   text-decoration: none;
 }
 
 .breadcrumbs a:hover {
+  color: var(--breadcrumb-link-hover);
   text-decoration: underline;
 }
 
 .breadcrumbs .breadcrumb-sep {
+  color: var(--breadcrumb-sep);
   user-select: none;
 }
 
-/* Canvas-header breadcrumb variant (#436): indented + dimmed, for the project
-   detail, blog post, and resume headers. Core + link/separator styling come
-   from .breadcrumbs above; this adds only the inset extras. Placed after the
-   base so its single-class overrides win by source order, matching the prior
-   .project-breadcrumbs behavior. */
+.breadcrumbs .breadcrumb-current {
+  color: var(--breadcrumb-current);
+  /* Long current segments (post/project titles) truncate instead of
+     wrapping under the trail. */
+  max-width: 28ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Canvas-header breadcrumb variant (#436): indented, for the project detail
+   and blog post headers. Layout-only — color comes from .breadcrumbs above
+   (#452). Placed after the base so its single-class overrides win by source
+   order, matching the prior .project-breadcrumbs behavior. */
 .breadcrumbs--inset {
   flex-wrap: wrap;
   margin-bottom: calc(var(--su) * 1.5);
   padding-left: clamp(1rem, 2.2vw, 1.6rem);
-  color: rgba(17, 16, 13, 0.38);
 }
 
 .hero h1 {
@@ -2314,22 +2338,10 @@ a.tag:hover {
   margin-bottom: 0;
 }
 
+/* Sizing + colors come from the shared .breadcrumbs rules (#452); only the
+   spacing to the h1 (which carries its own top margin) is local. */
 .e-content .breadcrumbs {
-  display: flex;
-  gap: 0.4rem;
-  font-size: clamp(0.68rem, 0.82vw, 0.78rem);
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
   margin-bottom: 0.5rem;
-}
-
-.e-content .breadcrumbs a {
-  color: inherit;
-  text-decoration: none;
-}
-
-.e-content .breadcrumbs a:hover {
-  text-decoration: underline;
 }
 
 .e-content .project-actions {
@@ -2546,35 +2558,10 @@ a.tag:hover {
   justify-content: flex-end;
 }
 
-/* Header typography — explicit rules since blog-canvas-header
-   is outside the .project-hero scope that normally provides these. */
+/* Breadcrumb colors/typography come from the shared .breadcrumbs rules
+   (#452); only the spacing to the h1 is local. */
 .blog-canvas-header .breadcrumbs {
-  font-weight: 400;
-  color: rgba(17, 16, 13, 0.38);
   margin-bottom: 1.5rem;
-}
-
-.blog-canvas-header .breadcrumbs a {
-  color: rgba(17, 16, 13, 0.38);
-}
-
-.blog-canvas-header .breadcrumbs a:hover {
-  color: rgba(17, 16, 13, 0.62);
-  text-decoration: none;
-}
-
-.blog-canvas-header .breadcrumb-sep {
-  color: rgba(17, 16, 13, 0.22);
-  user-select: none;
-}
-
-.blog-canvas-header .breadcrumb-current {
-  color: rgba(17, 16, 13, 0.52);
-  letter-spacing: 0.04em;
-  max-width: 28ch;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .blog-canvas-header h1 {
@@ -3258,7 +3245,6 @@ a:focus-visible {
 
   .breadcrumbs--inset {
     padding-left: 0.5rem;
-    font-size: 0.68rem;
   }
 
   .project-hero h1 {
@@ -3643,7 +3629,6 @@ body.resume-page {
 }
 .resume-canvas-header .breadcrumbs {
   margin-bottom: 1.4rem;
-  padding-left: 0;
 }
 
 /* Metadata panel (top-right; screen-only) */

--- a/tests/responsive/shared-chrome.spec.ts
+++ b/tests/responsive/shared-chrome.spec.ts
@@ -12,6 +12,9 @@ import { test, expect, type Page } from '@playwright/test';
  *     accent; only the color-themed project-detail footer keeps its accent;
  *   - one page-canvas: centered (equal gutters) with the shared drop shadow;
  *   - one breadcrumbs impl with an aria-current current item;
+ *   - one breadcrumb color ramp on every page (#452): token-driven, never
+ *     container-inherited, with parent links a step darker than the muted
+ *     current segment and an underline hover affordance;
  *   - the footer column-stack at <=1023px.
  *
  * Every invariant is checked at all four target breakpoints (320/375/800/1440)
@@ -23,6 +26,11 @@ import { test, expect, type Page } from '@playwright/test';
 
 const RED = 'rgb(193, 29, 25)'; // var(--red) #c11d19
 const BLACK_ACCENT = 'rgb(51, 51, 51)'; // matchline's per-project accent (#333)
+// The single breadcrumb ramp (#452) — the --breadcrumb-* tokens in :root.
+const CRUMB_LINK = 'rgba(17, 16, 13, 0.52)';
+const CRUMB_LINK_HOVER = 'rgba(17, 16, 13, 0.78)';
+const CRUMB_CURRENT = 'rgba(17, 16, 13, 0.38)';
+const CRUMB_SEP = 'rgba(17, 16, 13, 0.22)';
 // The shared ink drop shadow: var(--canvas-shadow) is 0.12; .project-detail
 // reduces it to 0.1 at <=1023. Accept both alphas, reject any other.
 const CANVAS_SHADOW = /rgba\(17, 16, 13, 0\.12?\)/;
@@ -93,21 +101,52 @@ for (const width of BREAKPOINTS) {
       }
     });
 
-    test.describe('shared breadcrumbs — one impl, current item flagged (#436)', () => {
+    test.describe('shared breadcrumbs — one impl, current item flagged (#436), one color ramp (#452)', () => {
       for (const path of CANVAS_PAGES) {
-        test(`${path} has one .breadcrumbs with an aria-current current item`, async ({ page }) => {
+        test(`${path} has one .breadcrumbs with an aria-current current item and the shared ramp`, async ({ page }) => {
           await page.goto(path);
           await page.waitForLoadState('domcontentloaded');
-          const result = await page.evaluate(() => ({
-            count: document.querySelectorAll('.breadcrumbs').length,
-            hasCurrent: !!document.querySelector(
-              '.breadcrumbs .breadcrumb-current[aria-current="page"]',
-            ),
-          }));
+          const result = await page.evaluate(() => {
+            const color = (sel: string) => {
+              const el = document.querySelector(sel);
+              return el ? getComputedStyle(el).color : null;
+            };
+            return {
+              count: document.querySelectorAll('.breadcrumbs').length,
+              hasCurrent: !!document.querySelector(
+                '.breadcrumbs .breadcrumb-current[aria-current="page"]',
+              ),
+              link: color('.breadcrumbs a'),
+              current: color('.breadcrumbs .breadcrumb-current'),
+              sep: color('.breadcrumbs .breadcrumb-sep'),
+            };
+          });
           expect(result.count).toBe(1);
           expect(result.hasCurrent).toBe(true);
+          // The ramp is the same on every page — token values, not the
+          // container's inherited color (#452). Parent links sit a step
+          // darker than the current segment so the hierarchy reads.
+          expect(result.link).toBe(CRUMB_LINK);
+          expect(result.current).toBe(CRUMB_CURRENT);
+          expect(result.sep).toBe(CRUMB_SEP);
         });
       }
+
+      test('parent links carry the hover affordance (underline + darker step)', async ({ page }) => {
+        await page.goto('/blog/');
+        await page.waitForLoadState('domcontentloaded');
+        await page.addStyleTag({
+          content: '*, *::before, *::after { transition: none !important; }',
+        });
+        await page.hover('.breadcrumbs a');
+        const hovered = await page.evaluate(() => {
+          const el = document.querySelector('.breadcrumbs a') as Element;
+          const style = getComputedStyle(el);
+          return { color: style.color, decoration: style.textDecorationLine };
+        });
+        expect(hovered.color).toBe(CRUMB_LINK_HOVER);
+        expect(hovered.decoration).toContain('underline');
+      });
     });
 
     test('footer is a centered column at <=1023px, a row above (#434)', async ({ page }) => {


### PR DESCRIPTION
Fixes #452

Authoring-Agent: claude

## Problem

The shared breadcrumb component (one impl since #436) rendered with three different color regimes because color came from the container, not the component:

- `/blog`, `/projects`, `/404` — no explicit color; inherited near-black `--ink` from the page, competing with the H1.
- `/blog/[slug]` — its own `.blog-canvas-header` palette, with the hierarchy *inverted*: the current segment (0.52) rendered darker than the parent links (0.38), and hover removed the underline.
- `/resume` + project heroes — flat `0.38` ink from `.breadcrumbs--inset`, no parent/current distinction.

## Fix (CSS-only, plus one class removal)

- Four `--breadcrumb-*` tokens in `:root`: link `0.52`, link-hover `0.78`, current `0.38`, separator `0.22` (ink alphas). The quiet post-page weight is the baseline, with parents a step darker than the current segment so the "you are here" hierarchy reads.
- Base `.breadcrumbs` rules apply the ramp explicitly (plus pinned `font-weight: 400`), so nothing inherits from the container. Parent links underline + darken on hover.
- `.breadcrumbs--inset` is now layout-only (indent/wrap); its color line is deleted along with the whole `.blog-canvas-header` breadcrumb palette and the 404's divergent `.e-content` sizing — only per-context spacing (margin-bottom) remains.
- The 28ch current-segment truncation moves from the blog-post override into the base, so long titles behave identically everywhere.
- `/resume` drops the `breadcrumbs--inset` class it only used to cancel (`padding-left: 0`) — the dimmed color it wanted is now the base.
- The ≤480px `--inset` font-size override is deleted (base `clamp()` already lands within 0.04rem of it), removing the last per-page sizing difference.

Markup already satisfied the structural criteria (single component, `<nav aria-label="Breadcrumb">`, non-linked `aria-current="page"` current segment) — unchanged.

## Acceptance criteria

- [x] Single shared component; no per-page or container-inherited color differences remain
- [x] Identical treatment on `/blog`, every `/blog/[slug]`, `/resume` (and `/projects`, project detail, `/404`)
- [x] Parent segments visually distinct from current (link affordance vs. muted plain text)
- [x] Current segment non-linked with `aria-current="page"` (pre-existing, now asserted with colors in e2e)
- [x] `<nav aria-label="Breadcrumb">` (pre-existing)
- [x] Colors reference design tokens

## Verification

- `npm run test` — build clean, 188/188 vitest
- `npm run test:e2e` — 298 passed; the shared-chrome spec now asserts the exact token ramp on all six canvas pages at 320/375/800/1440 plus the hover affordance (underline + darker step), so this class of drift is guarded
- Visual check in browser at `/blog`, `/blog/html-mockups-as-spec/`, `/resume` — identical quiet ramp; no console errors

## Self-Review

- **Correctness:** The ramp is applied by the base `.breadcrumbs` rules; no later stylesheet rule targets breadcrumb elements with a competing color (the only other `a`-color rules in breadcrumb ancestors are in `@media print`, where resume breadcrumbs are `display: none`). E2E asserts computed colors, which catches any specificity/order mistake.
- **Regression risk:** Low. Deleted overrides are all breadcrumb-scoped; spacing overrides (`margin-bottom`) were deliberately retained per context. The visible changes are intended: indexes/404 lose the near-black, post pages get the hierarchy un-inverted and title-segment tracking unified to 0.12em (truncation cap retained), resume parents gain the link step. The blog-post `font-weight: 400` was redundant (body default), now pinned in the base for container independence.
- **Style:** Tokens in `:root` next to the other chrome primitives, named per element role; comments follow the existing issue-annotated convention. No motion values introduced, so the motion-token rule is untouched.
- **Test coverage:** Acceptance criteria are encoded as assertions in `tests/responsive/shared-chrome.spec.ts` (color ramp identical across pages, hierarchy step, hover affordance), folded into the existing per-page navigation to avoid extra runtime.
- **Security/dependency hygiene:** No new dependencies, no secrets, no `.github/**` or protected-path changes. 149 lines changed — under the 300-line external-review threshold.