### PR TITLE
fix(og): enlarge social card typography

### DIFF
--- a/src/layouts/OgCard.astro
+++ b/src/layouts/OgCard.astro
@@ -20,6 +20,12 @@ interface Props {
 }
 
 const { label, heading, description, meta } = Astro.props;
+const headingClass = [
+  'og-heading',
+  !description ? 'og-heading--title-only' : '',
+  description ? 'og-heading--with-description' : '',
+  !description && heading.length > 52 ? 'og-heading--long' : '',
+].filter(Boolean).join(' ');
 ---
 
 <!DOCTYPE html>
@@ -56,7 +62,7 @@ const { label, heading, description, meta } = Astro.props;
     <div class="og-card">
       <div class="og-content">
         <div class="og-label">{label}</div>
-        <h1 class="og-heading">{heading}</h1>
+        <h1 class={headingClass}>{heading}</h1>
         {description && <p class="og-description">{description}</p>}
         {meta && <p class="og-meta">{meta}</p>}
       </div>

--- a/src/pages/og-templates/blog/[slug].astro
+++ b/src/pages/og-templates/blog/[slug].astro
@@ -18,7 +18,7 @@ export async function getStaticPaths() {
     return {
       params: { slug: post.id },
       props: {
-        title: post.data.title,
+        title: post.data.shortTitle ?? post.data.title,
         meta: metaParts.join(' · '),
       },
     };

--- a/src/pages/og-templates/blog/[slug].astro
+++ b/src/pages/og-templates/blog/[slug].astro
@@ -18,7 +18,7 @@ export async function getStaticPaths() {
     return {
       params: { slug: post.id },
       props: {
-        title: post.data.shortTitle ?? post.data.title,
+        title: post.data.shortTitle?.trim() || post.data.title,
         meta: metaParts.join(' · '),
       },
     };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2481,7 +2481,7 @@ a.tag:hover {
 .og-heading--title-only {
   font-size: 80px;
   line-height: 1.04;
-  text-wrap: normal;
+  text-wrap: wrap;
 }
 
 .og-heading--long {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2451,7 +2451,7 @@ a.tag:hover {
   grid-column: 2 / 7;
   grid-row: 2;
   background: var(--surface);
-  padding: 48px;
+  padding: 52px 56px;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -2460,35 +2460,55 @@ a.tag:hover {
 
 .og-label {
   font-family: "Inter", system-ui, sans-serif;
-  font-size: 14px;
+  font-size: 16px;
   font-weight: 500;
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: #888;
-  margin-bottom: 12px;
+  margin-bottom: 14px;
 }
 
 .og-heading {
-  font-family: "Cormorant Garamond", Garamond, serif;
-  font-size: 64px;
+  font-family: "Cormorant Garamond", garamond, serif;
+  font-size: 92px;
   font-weight: 600;
-  line-height: 1.05;
+  line-height: 1.02;
   color: var(--ink);
-  margin: 0 0 12px;
+  margin: 0 0 14px;
+  text-wrap: balance;
+}
+
+.og-heading--title-only {
+  font-size: 80px;
+  line-height: 1.04;
+  text-wrap: normal;
+}
+
+.og-heading--long {
+  font-size: 74px;
+  line-height: 1.04;
+  text-wrap: balance;
+}
+
+.og-heading--with-description {
+  font-size: 84px;
+  line-height: 1.04;
+  margin-bottom: 12px;
 }
 
 .og-description {
   font-family: "Inter", system-ui, sans-serif;
-  font-size: 20px;
-  line-height: 1.45;
+  font-size: 24px;
+  line-height: 1.3;
   color: #555;
-  margin: 0 0 8px;
-  max-width: 640px;
+  margin: 0 0 10px;
+  max-width: 780px;
+  text-wrap: balance;
 }
 
 .og-meta {
   font-family: "Inter", system-ui, sans-serif;
-  font-size: 14px;
+  font-size: 16px;
   color: #888;
   margin: 0;
   letter-spacing: 0.04em;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2459,7 +2459,7 @@ a.tag:hover {
 }
 
 .og-label {
-  font-family: "Inter", system-ui, sans-serif;
+  font-family: Inter, system-ui, sans-serif;
   font-size: 16px;
   font-weight: 500;
   letter-spacing: 0.18em;
@@ -2497,7 +2497,7 @@ a.tag:hover {
 }
 
 .og-description {
-  font-family: "Inter", system-ui, sans-serif;
+  font-family: Inter, system-ui, sans-serif;
   font-size: 24px;
   line-height: 1.3;
   color: #555;
@@ -2507,7 +2507,7 @@ a.tag:hover {
 }
 
 .og-meta {
-  font-family: "Inter", system-ui, sans-serif;
+  font-family: Inter, system-ui, sans-serif;
   font-size: 16px;
   color: #888;
   margin: 0;

--- a/tests/responsive/mondrian-rebalance-animation.spec.ts
+++ b/tests/responsive/mondrian-rebalance-animation.spec.ts
@@ -16,6 +16,13 @@ import { test, expect, Page } from '@playwright/test';
 
 const PANELS = ['about', 'projects', 'community', 'connect'] as const;
 type PanelName = (typeof PANELS)[number];
+type RecordedEvent = { order: number; t: number; kind: string; value: string };
+
+declare global {
+  interface Window {
+    __events: RecordedEvent[];
+  }
+}
 
 // Skip the entire file on viewports where the state machine is disabled.
 // playwright.config.ts has 1440 as the only desktop viewport; the others
@@ -137,12 +144,11 @@ test('about/projects/connect panels are exactly content-sized in their focus sta
  */
 async function installEventRecorder(page: Page) {
   await page.evaluate(() => {
-    type Event = { order: number; t: number; kind: string; value: string };
-    (window as any).__events = [] as Event[];
+    window.__events = [];
     let order = 0;
     const start = performance.now();
     const push = (kind: string, value: string) => {
-      (window as any).__events.push({ order: ++order, t: performance.now() - start, kind, value });
+      window.__events.push({ order: ++order, t: performance.now() - start, kind, value });
     };
     const grid = document.getElementById('mondrian')!;
     new MutationObserver((muts) => {
@@ -177,8 +183,6 @@ async function installEventRecorder(page: Page) {
   });
 }
 
-type RecordedEvent = { order: number; t: number; kind: string; value: string };
-
 test('open sequence: data-focus precedes is-content-visible; grid-template transition fires', async ({ page }) => {
   await installEventRecorder(page);
 
@@ -190,13 +194,13 @@ test('open sequence: data-focus precedes is-content-visible; grid-template trans
   // is-content-visible, the read of __events could race the transitionend
   // event and miss the geometry-settled entry.
   await page.waitForFunction(() => {
-    const events = (window as any).__events as Array<{ kind: string; value: string }>;
+    const events = window.__events;
     const hasSettled = events.some((e) => e.kind === 'geometry-settled');
     const hasContent = events.some((e) => e.kind === 'is-content-visible:about' && e.value === 'on');
     return hasSettled && hasContent;
   });
 
-  const events: RecordedEvent[] = await page.evaluate(() => (window as any).__events);
+  const events: RecordedEvent[] = await page.evaluate(() => window.__events);
   const focusOn = events.find((e) => e.kind === 'data-focus' && e.value === 'about');
   const settled = events.find((e) => e.kind === 'geometry-settled');
   const contentOn = events.find((e) => e.kind === 'is-content-visible:about' && e.value === 'on');
@@ -229,7 +233,7 @@ test('close sequence: is-content-visible is removed before data-focus clears', a
     () => !document.querySelector('[data-panel="about"]')!.classList.contains('is-open'),
   );
 
-  const events: RecordedEvent[] = await page.evaluate(() => (window as any).__events);
+  const events: RecordedEvent[] = await page.evaluate(() => window.__events);
   const contentOff = events.find((e) => e.kind === 'is-content-visible:about' && e.value === 'off');
   const focusCleared = events.find((e) => e.kind === 'data-focus' && e.value === '');
   expect(contentOff, 'is-content-visible:about=off event captured').toBeTruthy();


### PR DESCRIPTION
## Summary

Improves generated Open Graph card readability after LinkedIn previews showed the text looking too small and soft once downscaled.

- Enlarges the shared OG card label, heading, description, and metadata type.
- Adds title-shape variants so description-backed project/resume cards get more breathing room while title-only blog cards can stay on one line.
- Wires blog post OG cards to use existing `shortTitle` frontmatter before falling back to the full article title.
- Removes the lingering lint warnings in the Mondrian responsive test by typing the test-only `window.__events` recorder.

## Docs

No docs update needed. The change uses the existing `shortTitle` field that is already present in the content schema and documented in the content conventions; deploy and repo workflows are unchanged.

## Validation

- `npm run build` -> regenerated all 14 OG images at 2400x1260.
- Visual spot checks: `dist/og/projects/friends-and-family-billing.png` and `dist/og/blog/agent-approval-workflow-genesis-of-mergepath.png` now have more readable spacing.
- `npm run lint` -> passed with no warnings.
- `npm run test` -> 20 files / 188 tests passed.
- `npm run test:e2e` -> 298 passed, 30 skipped.

## Self-Review

- Correctness: the OG renderer still outputs 2x retina PNGs; only the card typography and short-title selection changed.
- Regression risk: long/future title-only cards retain a smaller wrapped fallback; description-backed cards use a moderated scale to avoid crowding metadata.
- Scope: no page-route, schema, dependency, deployment, or production credential changes.

Authoring-Agent: codex
