### PR TITLE
fix(security): contain refresh-hero-images writes to public/

### DIFF
--- a/scripts/lib/contain-path.mjs
+++ b/scripts/lib/contain-path.mjs
@@ -1,0 +1,21 @@
+/**
+ * Path-containment helper (#456).
+ *
+ * Frontmatter-supplied asset paths (e.g. `screenshotSrc: "/images/x.png"`)
+ * are joined into a base directory before writing. A value containing `..`
+ * segments (`/../../etc/x`) would escape the base after normalization, so
+ * callers must resolve through this helper instead of join()ing directly.
+ */
+import { resolve, sep } from 'node:path';
+
+/**
+ * Resolve a "/"-rooted child path against baseDir, returning the absolute
+ * destination only when it stays strictly inside baseDir — null otherwise
+ * (including for the base directory itself, which is never a valid file
+ * destination).
+ */
+export function containedJoin(baseDir, childPath) {
+  const base = resolve(baseDir);
+  const dest = resolve(base, String(childPath).replace(/^\/+/, ''));
+  return dest.startsWith(base + sep) ? dest : null;
+}

--- a/scripts/refresh-hero-images.mjs
+++ b/scripts/refresh-hero-images.mjs
@@ -25,6 +25,7 @@ import { readFile, writeFile, readdir } from 'node:fs/promises';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseFrontmatter } from './lib/parse-frontmatter.mjs';
+import { containedJoin } from './lib/contain-path.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -111,7 +112,13 @@ async function main() {
       console.warn(`[refresh-hero-images] ${file}: screenshotSrc must be an absolute path — skipping`);
       continue;
     }
-    const destPath = join(publicDir, screenshotSrc);
+    // Containment, not just shape (#456): a screenshotSrc with `..` segments
+    // would escape public/ after join() normalizes it.
+    const destPath = containedJoin(publicDir, screenshotSrc);
+    if (!destPath) {
+      console.warn(`[refresh-hero-images] ${file}: screenshotSrc resolves outside public/ — skipping`);
+      continue;
+    }
     try {
       const imageUrl = await fetchGithubSocialImageUrl(repo.owner, repo.repo);
       const bytes = await downloadImage(imageUrl, destPath);

--- a/tests/contain-path.test.js
+++ b/tests/contain-path.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { sep } from 'node:path';
+import { containedJoin } from '../scripts/lib/contain-path.mjs';
+
+// #456: screenshotSrc values from frontmatter must not be able to direct
+// writes outside public/. The helper is the single containment gate.
+describe('containedJoin', () => {
+  const base = `${sep}repo${sep}public`;
+
+  it('resolves a normal asset path inside the base', () => {
+    expect(containedJoin(base, '/images/projects/x-hero.png')).toBe(
+      `${base}${sep}images${sep}projects${sep}x-hero.png`,
+    );
+  });
+
+  it('rejects direct parent traversal', () => {
+    expect(containedJoin(base, '/../secrets.txt')).toBeNull();
+  });
+
+  it('rejects traversal buried in a nested path', () => {
+    expect(containedJoin(base, '/images/../../../etc/passwd')).toBeNull();
+  });
+
+  it('rejects the base directory itself', () => {
+    expect(containedJoin(base, '/')).toBeNull();
+    expect(containedJoin(base, '/images/..')).toBeNull();
+  });
+
+  it('accepts .. segments that stay inside the base after normalization', () => {
+    expect(containedJoin(base, '/images/../fonts/a.woff2')).toBe(
+      `${base}${sep}fonts${sep}a.woff2`,
+    );
+  });
+});


### PR DESCRIPTION
Closes #456 (from the mergepath#425 weekly-sweep validation; original finding was PR #193's CodeRabbit Critical).

Authoring-Agent: claude

## What

`scripts/refresh-hero-images.mjs` joined frontmatter-supplied `screenshotSrc` into `public/` with only a `startsWith('/')` shape check, so `/../../<anything>` escaped the directory after `join()` normalization — an arbitrary-file-write primitive gated only by repo-content trust.

Destinations now resolve through `scripts/lib/contain-path.mjs#containedJoin(baseDir, childPath)`, which resolves the joined path and returns it only when strictly inside the base (the base dir itself is rejected — never a valid file destination). Escaping values are skipped with a warning, matching the script's existing fail-soft posture (a bad path keeps the existing image; the build continues).

The helper is a separate module because importing `refresh-hero-images.mjs` executes `main()` at module load — `scripts/lib/` is the established home for shared script helpers (`parse-frontmatter.mjs`).

## Verification

- New `tests/contain-path.test.js`: normal path, direct traversal, nested traversal (`/images/../../../etc/passwd`), base-dir itself, and the legitimate inside-base `..` case — 5/5.
- Full suite: 193/193 vitest.
- Smoke-ran the script: behavior unchanged (`no projects opted in — skipping` — current content has no `github-social` opt-ins, so the live path is exercised only when a project opts back in; the unit tests carry the contract).

## Self-Review

- **Correctness:** Containment compares against `resolve(base) + sep` so prefix-collision paths (`/repo/public-evil`) can't pass, and the leading-slash strip means the "/"-rooted frontmatter convention resolves relative to `public/` exactly as before for well-formed values.
- **Regression risk:** Minimal — well-formed `screenshotSrc` values resolve to byte-identical destinations; only escaping values change behavior (write → warn + skip).
- **Style:** Helper + JSDoc matches `scripts/lib/` conventions; warning message format matches the script's existing ones.
- **Test coverage:** The traversal cases from the finding are pinned in unit tests.
- **Security/dependency hygiene:** No new dependencies. This PR is itself the security fix; no secrets, no protected paths. ~60 lines — under the external-review threshold.