### PR TITLE
fix(typography): add --font-body token; migrate font-family literals (#464)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -43,6 +43,10 @@
      token pattern so page families do not hand-roll near-identical h1/h2
      values. */
   --font-heading: "Cormorant Garamond", garamond, serif;
+  /* Body/UI sans stack (#464). Counterpart to --font-heading so neither
+     typeface is hand-rolled at use sites. OgCard.astro keeps its inline
+     @font-face stack — required for the static OG image render context. */
+  --font-body: "Inter", system-ui, sans-serif;
   --heading-weight: 600;
   --heading-letter-spacing: 0;
   --heading-display-size: clamp(2.8rem, 6vw, 5.4rem);
@@ -135,7 +139,7 @@ html, body {
   min-height: 100%;
   background: #bdbeb8;
   color: var(--ink);
-  font-family: "Inter", system-ui, sans-serif;
+  font-family: var(--font-body);
 }
 
 .stage {
@@ -350,7 +354,7 @@ html, body {
   text-transform: uppercase;
   text-align: left;
   pointer-events: none;
-  font-family: "Cormorant Garamond", Garamond, serif;
+  font-family: var(--font-heading);
   /* Visible by default so CSP-blocked-inline-script and JS-disabled
      users never hit invisible labels. The hide-while-fonts-load gate
      below is opt-IN: only triggers when the inline script in
@@ -473,7 +477,7 @@ html[data-fonts-pending] .panel-label {
 .content-inner p { margin-bottom: 0.5rem; }
 
 .lead {
-  font-family: "Cormorant Garamond", Garamond, serif;
+  font-family: var(--font-heading);
   font-size: 1.4rem;
   line-height: 1.42;
   font-weight: 500;
@@ -770,7 +774,7 @@ html[data-fonts-pending] .panel-label {
 }
 
 .p-name {
-  font-family: "Cormorant Garamond", Garamond, serif;
+  font-family: var(--font-heading);
   font-size: 1.15rem;
   font-weight: 700;
 }
@@ -778,7 +782,7 @@ html[data-fonts-pending] .panel-label {
 .p-name-link {
   color: inherit;
   text-decoration: none;
-  font-family: "Cormorant Garamond", Garamond, serif;
+  font-family: var(--font-heading);
   font-size: 1.15rem;
   font-weight: 700;
   line-height: 1.1;
@@ -1033,7 +1037,7 @@ a:focus-visible .link-arrow,
    serif treatment for item titles. */
 .effort-link {
   color: inherit;
-  font-family: "Cormorant Garamond", Garamond, serif;
+  font-family: var(--font-heading);
   font-size: 0.85rem;
   font-weight: 700;
   line-height: 1.16;
@@ -1997,7 +2001,7 @@ body.blog-page {
   margin-top: 1rem;
   font-size: clamp(1.05rem, 1rem + 0.42vw, 1.4rem);
   line-height: 1.45;
-  font-family: "Cormorant Garamond", Garamond, serif;
+  font-family: var(--font-heading);
   color: rgba(17, 16, 13, 0.72);
 }
 
@@ -2119,7 +2123,7 @@ body.blog-page {
 }
 
 .post-title {
-  font-family: "Cormorant Garamond", Garamond, serif;
+  font-family: var(--font-heading);
   font-size: clamp(1.6rem, 2.2vw, 2.4rem);
   line-height: 1.05;
   font-weight: 600;
@@ -2190,7 +2194,7 @@ a.tag:hover {
   right: clamp(0.8rem, 1.5vw, 1.2rem);
   writing-mode: vertical-rl;
   text-orientation: mixed;
-  font-family: "Cormorant Garamond", Garamond, serif;
+  font-family: var(--font-heading);
   font-size: clamp(0.72rem, 0.88vw, 0.84rem);
   letter-spacing: 0.22em;
   text-transform: uppercase;
@@ -2461,7 +2465,7 @@ a.tag:hover {
 }
 
 .og-label {
-  font-family: Inter, system-ui, sans-serif;
+  font-family: var(--font-body);
   font-size: 16px;
   font-weight: 500;
   letter-spacing: 0.18em;
@@ -2471,7 +2475,7 @@ a.tag:hover {
 }
 
 .og-heading {
-  font-family: "Cormorant Garamond", garamond, serif;
+  font-family: var(--font-heading);
   font-size: 92px;
   font-weight: 600;
   line-height: 1.02;
@@ -2499,7 +2503,7 @@ a.tag:hover {
 }
 
 .og-description {
-  font-family: Inter, system-ui, sans-serif;
+  font-family: var(--font-body);
   font-size: 24px;
   line-height: 1.3;
   color: #555;
@@ -2509,7 +2513,7 @@ a.tag:hover {
 }
 
 .og-meta {
-  font-family: Inter, system-ui, sans-serif;
+  font-family: var(--font-body);
   font-size: 16px;
   color: #888;
   margin: 0;
@@ -2630,7 +2634,7 @@ a.tag:hover {
   /* Keeps the title-to-deck gap the dropped deck--inset used to provide
      (#455 finding 8); base .deck opens it to 1rem. */
   margin-top: calc(var(--su) * 1.6);
-  font-family: "Inter", system-ui, sans-serif;
+  font-family: var(--font-body);
   font-style: normal;
   font-weight: 400;
   font-size: clamp(0.85rem, 1vw, 1rem);
@@ -2664,7 +2668,7 @@ a.tag:hover {
   padding: 0.18rem 0.45rem;
   background: rgba(17, 16, 13, 0.08);
   border-radius: 2px;
-  font-family: "Inter", system-ui, sans-serif;
+  font-family: var(--font-body);
   font-size: 0.6rem;
   font-weight: 600;
   letter-spacing: 0.12em;
@@ -2688,7 +2692,7 @@ a.tag:hover {
 }
 
 .blog-sidebar-meta dd {
-  font-family: "Cormorant Garamond", Garamond, serif;
+  font-family: var(--font-heading);
   font-weight: 500;
   font-size: clamp(0.88rem, 0.92vw, 0.98rem);
 }
@@ -2740,7 +2744,7 @@ a.tag:hover {
   text-transform: uppercase;
   color: rgba(17, 16, 13, 0.62);
   margin-bottom: 0.55rem;
-  font-family: "Inter", system-ui, sans-serif;
+  font-family: var(--font-body);
   font-weight: 600;
 }
 
@@ -2786,7 +2790,7 @@ a.tag:hover {
 .blog-sidebar-pullquote--blue   { border-left-color: var(--blue); }
 
 .blog-sidebar-pullquote p {
-  font-family: "Cormorant Garamond", Garamond, serif;
+  font-family: var(--font-heading);
   font-size: clamp(0.92rem, 0.98vw, 1.04rem);
   line-height: 1.38;
   font-style: italic;
@@ -3177,7 +3181,7 @@ a.tag:hover {
 
 .blog-diagram-arrow,
 .blog-diagram-loop {
-  font-family: "Cormorant Garamond", Garamond, serif;
+  font-family: var(--font-heading);
   font-size: 1.8rem;
   line-height: 1;
   color: rgba(17, 16, 13, 0.62);
@@ -3713,7 +3717,7 @@ body.resume-page {
   color: rgba(17, 16, 13, 0.48);
 }
 .resume-canvas-meta dd {
-  font-family: "Cormorant Garamond", Garamond, serif;
+  font-family: var(--font-heading);
   font-weight: 500;
   font-size: clamp(0.88rem, 0.92vw, 0.98rem);
   line-height: 1.25;
@@ -3729,7 +3733,7 @@ body.resume-page {
   padding: 0.18rem 0.45rem;
   background: rgba(17, 16, 13, 0.08);
   border-radius: 2px;
-  font-family: "Inter", system-ui, sans-serif;
+  font-family: var(--font-body);
   font-size: 0.6rem;
   font-weight: 600;
   letter-spacing: 0.12em;
@@ -3772,7 +3776,7 @@ body.resume-page {
 }
 .resume-canvas-heading {
   margin-bottom: 0.55rem;
-  font-family: "Inter", system-ui, sans-serif;
+  font-family: var(--font-body);
   font-weight: 600;
   /* Size floor + ink raised per #455 finding 2 — matches .blog-sidebar-heading. */
   font-size: clamp(0.7rem, 0.9vw, 0.78rem);
@@ -3832,7 +3836,7 @@ body.resume-page {
 .resume-highlight--blue   { border-left-color: var(--blue); }
 .resume-highlight p {
   margin: 0;
-  font-family: "Cormorant Garamond", Garamond, serif;
+  font-family: var(--font-heading);
   font-size: clamp(0.95rem, 1vw, 1.08rem);
   font-style: italic;
   line-height: 1.32;
@@ -4012,7 +4016,7 @@ body.resume-page {
 }
 
 .resume-entry__title {
-  font-family: "Cormorant Garamond", Garamond, serif;
+  font-family: var(--font-heading);
   font-weight: 600;
   font-size: clamp(1.12rem, 1rem + 0.5vw, 1.4rem);
   line-height: 1.14;
@@ -4160,7 +4164,7 @@ body.resume-page {
 }
 
 .resume-cert__name {
-  font-family: "Cormorant Garamond", Garamond, serif;
+  font-family: var(--font-heading);
   font-weight: 600;
   font-size: clamp(0.92rem, 0.9rem + 0.1vw, 1rem);
   line-height: 1.25;


### PR DESCRIPTION
Closes #464
Part of #463

Authoring-Agent: claude

## What

- Adds `--font-body: "Inter", system-ui, sans-serif;` to `:root` in `src/styles/global.css`, with a comment noting the OgCard exception.
- Replaces all 16 literal `"Cormorant Garamond", Garamond, serif` declarations with `var(--font-heading)` (one of them was the lowercase-`garamond` variant at the old ~:2474 — font-family matching is case-insensitive, so this is value-identical).
- Replaces all 9 literal Inter declarations with `var(--font-body)` — 6 quoted (`"Inter", system-ui, sans-serif`) and 3 unquoted (`Inter, system-ui, sans-serif`).

## Exceptions preserved

- `src/layouts/OgCard.astro` inline `@font-face` — required for the static OG image generation context.
- The SFMono monospace stack (code context, global.css ~:2964).

## Verification

- `npm run lint` clean; `npm run test` green (21 files, 193 tests).
- Dev-server computed-style check on homepage, /resume, and /projects/mergepath: headings resolve to `"Cormorant Garamond", garamond, serif`, body/meta to `Inter, system-ui, sans-serif`; both tokens resolve at `:root`. No console errors.
- Zero rendered-output change expected and observed.

## Self-Review

- **Correctness:** Pure find-and-replace to var() references whose token values are character-identical to the replaced literals (modulo the case-insensitive `Garamond` fallback). Verified by grep that no `Cormorant`/`Inter` font-family literals remain outside comments and the token definitions.
- **Regression risk:** Low. var() substitution happens at computed-value time; the FOUT gate near `.panel-label` keys on opacity/`data-fonts-pending`, not on the font-family value, so font-loading choreography is unaffected.
- **Style:** Token comment follows the existing `:root` comment convention (issue-cited, explains the exception).
- **Test coverage:** Existing vitest suite covers build + route rendering; no new behavior to test.
- **Security/dependency hygiene:** CSS-only change, no dependencies touched.