### PR TITLE
fix(colors): replace hex literals duplicating existing tokens (#465)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -388,7 +388,7 @@ html[data-fonts-pending] .panel-label {
 
 .panel-label--name span {
   display: inline-block;
-  background: #11100d;
+  background: var(--ink);
   color: var(--cream);
   border: 1px solid rgba(245, 240, 228, 0.85);
   padding: 0.22em 0.52em 0.26em;
@@ -1221,8 +1221,8 @@ a:focus-visible .link-arrow,
 }
 
 .block--white-c { grid-column: 4 / 7; grid-row: 6; background: var(--paper); }
-.block--gray-e { grid-column: 8; grid-row: 6; background: #d4d4d4; }
-.block--gray-d { grid-column: 4 / 5; grid-row: 8; background: #d4d4d4; }
+.block--gray-e { grid-column: 8; grid-row: 6; background: var(--accent-gray); }
+.block--gray-d { grid-column: 4 / 5; grid-row: 8; background: var(--accent-gray); }
 
 .panel--blue {
   grid-column: 6 / 9;
@@ -1271,14 +1271,14 @@ body.blog-page {
    removed in #439 once all chrome migrated to consuming --accent directly. */
 
 [data-accent="red"] {
-  --accent: #c11d19;
-  --accent-contrast: #f5f0e4;
+  --accent: var(--red);
+  --accent-contrast: var(--cream);
   --accent-soft: rgba(193, 29, 25, 0.12);
   --project-bg: #d3c6bf;
 }
 
 [data-accent="yellow"] {
-  --accent: #d9b111;
+  --accent: var(--yellow);
   --accent-contrast: #171208;
   --accent-soft: rgba(217, 177, 17, 0.18);
   --project-bg: #d9d0b4;
@@ -1286,28 +1286,28 @@ body.blog-page {
 
 [data-accent="black"] {
   --accent: var(--accent-black);
-  --accent-contrast: #f5f0e4;
+  --accent-contrast: var(--cream);
   --accent-soft: rgba(51, 51, 51, 0.12);
   --project-bg: #d1cbc2;
 }
 
 [data-accent="blue"] {
-  --accent: #223f89;
-  --accent-contrast: #f5f0e4;
+  --accent: var(--blue);
+  --accent-contrast: var(--cream);
   --accent-soft: rgba(34, 63, 137, 0.12);
   --project-bg: #c7cfdf;
 }
 
 [data-accent="lightblue"] {
-  --accent: #2080ca;
-  --accent-contrast: #f5f0e4;
+  --accent: var(--lightblue);
+  --accent-contrast: var(--cream);
   --accent-soft: rgba(32, 128, 202, 0.12);
   --project-bg: #c4d6e6;
 }
 
 [data-accent="paper"] {
   --accent: #5b5f64;
-  --accent-contrast: #f5f0e4;
+  --accent-contrast: var(--cream);
   --accent-soft: rgba(91, 95, 100, 0.12);
   --project-bg: #dde1e5;
 }
@@ -1395,7 +1395,7 @@ body.blog-page {
 .nav-button:hover,
 .nav-button:focus-visible {
   background: var(--accent);
-  color: var(--accent-contrast, #f5f0e4);
+  color: var(--accent-contrast, var(--cream));
   transform: translateY(calc(var(--shift-small) * -1));
 }
 
@@ -2394,8 +2394,8 @@ a.tag:hover {
 .e-yellow-a  { grid-column: 2; grid-row: 4;   background: var(--yellow); }
 .e-blue      { grid-column: 4; grid-row: 4/7; background: var(--blue); }
 .e-black     { grid-column: 6; grid-row: 4;   background: var(--accent-black); }
-.e-white-a   { grid-column: 8; grid-row: 4;   background: #d4d4d4; }
-.e-white-b   { grid-column: 2; grid-row: 6;   background: #d4d4d4; }
+.e-white-a   { grid-column: 8; grid-row: 4;   background: var(--accent-gray); }
+.e-white-b   { grid-column: 2; grid-row: 6;   background: var(--accent-gray); }
 .e-yellow-b  { grid-column: 6; grid-row: 6;   background: var(--yellow); }
 .e-white-c   { grid-column: 8; grid-row: 6;   background: var(--paper); }
 
@@ -2526,8 +2526,8 @@ a.tag:hover {
 .og-yellow-a  { grid-column: 2; grid-row: 4;   background: var(--yellow); }
 .og-blue      { grid-column: 4; grid-row: 4/7; background: var(--blue); }
 .og-black     { grid-column: 6; grid-row: 4;   background: var(--accent-black); }
-.og-white-a   { grid-column: 8; grid-row: 4;   background: #d4d4d4; }
-.og-white-b   { grid-column: 2; grid-row: 6;   background: #d4d4d4; }
+.og-white-a   { grid-column: 8; grid-row: 4;   background: var(--accent-gray); }
+.og-white-b   { grid-column: 2; grid-row: 6;   background: var(--accent-gray); }
 .og-yellow-b  { grid-column: 6; grid-row: 6;   background: var(--yellow); }
 .og-white-c   { grid-column: 8; grid-row: 6;   background: var(--paper); }
 


### PR DESCRIPTION
Closes #465
Part of #463

Authoring-Agent: claude

## What

15 hex literals in `src/styles/global.css` replaced with their existing token equivalents (zero visual change — every swap is value-identical):

- 5× `--accent-contrast: #f5f0e4` → `var(--cream)` in the `[data-accent]` blocks, plus the `.nav-button` fallback `var(--accent-contrast, #f5f0e4)` → `var(--accent-contrast, var(--cream))`
- `--accent: #c11d19` → `var(--red)`, `#d9b111` → `var(--yellow)`, `#223f89` → `var(--blue)`, `#2080ca` → `var(--lightblue)`
- 6× `background: #d4d4d4` → `var(--accent-gray)`: `.block--gray-e`/`.block--gray-d` (homepage), `.e-white-a`/`.e-white-b` (404 page), `.og-white-a`/`.og-white-b` (OG templates)
- `.panel-label--name span` `background: #11100d` → `var(--ink)`

## Audit-count discrepancies (reality vs issue text)

- The issue's `#ffffff → var(--paper)` item (~:718) points into the `.social-row--x` brand gradient — that is a documented #302 exception, so it stays literal. No other `#ffffff` literal exists outside `:root`.
- The issue counted `#d9b111` ×2 and `#223f89` ×2; the second instance of each is a CSS comment, not code. Comments left as-is.
- The issue listed only `.block--gray-e/-d` for `#d4d4d4`, but `.e-white-a/-b` and `.og-white-a/-b` are exact duplicates too. Their sibling blocks (`.e-red`, `.og-red`, etc.) already consume `var(--red)`/`var(--yellow)`/`var(--blue)`, so these four are drift, not a deliberate exception — the OG decoratives exception covers the og-template-specific text grays and inline @font-face, not these. Migrated all four (total 15 vs the audit's ~11).
- The warm syntax-theme `#f5f0e4` values (`.blog-code-block` + `--astro-code-foreground`) are part of the documented syntax-highlighting exception and stay literal.

## Verification

- `npm run lint` clean; `npm run test` green (21 files, 193 tests; build regenerates all 14 OG images).
- Dev-server computed-style checks: homepage `.block--gray-*` and `.panel-label--name span` unchanged (rgb(212,212,212) / rgb(17,16,13)); project page `--accent`/`--accent-contrast` resolve to `#223f89`/`#f5f0e4` through the tokens; 404 `.e-white-*` unchanged. No console errors.

## Self-Review

- **Correctness:** Each replacement references a token whose value is character-identical to the removed literal; verified by grep that the only remaining occurrences are `:root` definitions, the #302 gradient, the syntax theme, and comments.
- **Regression risk:** Low. The one structural change is a nested-var fallback (`var(--accent-contrast, var(--cream))`), which is valid CSS and only matters where `--accent-contrast` is undefined (no-accent pages), where it resolves to the same #f5f0e4.
- **Style:** Matches the file's existing pattern (sibling decorative blocks already consume tokens).
- **Test coverage:** Existing build + vitest suite; no new behavior.
- **Security/dependency hygiene:** CSS-only, no dependencies touched.