### PR TITLE
fix(typography): shared .eyebrow utility for micro-labels (#467)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -82,23 +82,23 @@ const homepageJsonLd = {
             <p class="lead">Most product decisions are invisible—until they aren’t.</p>
             <div class="about-blocks">
               <div class="about-block">
-                <span class="about-label">Context</span>
+                <span class="eyebrow about-label">Context</span>
                 <p>Over the past ten years, I have built the streaming platforms behind Disney+, Hulu, and ESPN. I started at MLB.com and BAMTECH, joined Disney through the 2017 acquisition, and have spent the last five years leading the Native Client Platform across PlayStation, Xbox, Amazon Fire TV, Linux set-top boxes, and smart TVs.</p>
               </div>
               <div class="about-block">
-                <span class="about-label">Approach</span>
+                <span class="eyebrow about-label">Approach</span>
                 <p>The work that matters most is usually at the seam between systems—where a codec mismatch, a certification gap, or a failed-fix loop becomes a support burden at scale. I treat operational ambiguity as a product problem.</p>
               </div>
               <div class="about-block about-block--now">
-                <span class="about-label">Now</span>
+                <span class="eyebrow about-label">Now</span>
                 <NowContent />
               </div>
               <div class="about-block about-block--resume">
-                <span class="about-label">Résumé</span>
+                <span class="eyebrow about-label">Résumé</span>
                 <p>Open to new platform &amp; product roles. <a href="/resume/" class="p-name-link">Read my <span class="no-break">résumé<span class="link-arrow" aria-hidden="true">→</span></span></a></p>
               </div>
               <div class="about-block about-block--writing">
-                <span class="about-label">Writing</span>
+                <span class="eyebrow about-label">Writing</span>
                 <p>Three pieces on building with AI coding agents: where they fail, what makes them reliable, and how to get real work out of them.</p>
                 <ul class="writing-list">
                   <li><a href="/blog/six-prs-one-bug-agent-failure-modes/" class="p-name-link">Six PRs, One Bug: What AI Agents Actually Get <span class="no-break">Wrong<span class="link-arrow" aria-hidden="true">→</span></span></a></li>
@@ -107,7 +107,7 @@ const homepageJsonLd = {
                 </ul>
               </div>
               <div class="now-ribbon">
-                <span class="now-ribbon-label">Last updated</span>
+                <span class="eyebrow now-ribbon-label">Last updated</span>
                 <span class="now-ribbon-date">{nowEntry.data.lastUpdated}</span>
               </div>
             </div>
@@ -162,7 +162,7 @@ const homepageJsonLd = {
               </div>
             </div>
             <div class="stack-ribbon">
-              <span class="stack-label">Stack</span>
+              <span class="eyebrow stack-label">Stack</span>
               <span class="stack-items">Bash · TypeScript · Vanilla JS · React · Next.js · Vite · Tailwind CSS · Zod · Vitest · Playwright · Firebase · Express · GitHub Actions · Anthropic · OpenAI · Claude Code · Codex · Cursor · CodeRabbit</span>
             </div>
           </div>
@@ -198,7 +198,7 @@ const homepageJsonLd = {
               </li>
             </ul>
             <div class="impact-ribbon">
-              <span class="impact-label">Scope</span>
+              <span class="eyebrow impact-label">Scope</span>
               <span class="impact-items">Health Access · Housing Stability · Economic Mobility · Community Leadership · Strategic Philanthropy</span>
             </div>
           </div>
@@ -251,7 +251,7 @@ const homepageJsonLd = {
                 } catch (_e) { /* leave href as "#" — noscript covers the fallback */ }
               })();
             </script>
-            <span class="connect-label">Elsewhere</span>
+            <span class="eyebrow connect-label">Elsewhere</span>
             <div class="social-stack">
               <a href="https://www.linkedin.com/in/nathanpayne/" target="_blank" rel="noopener" class="social-row social-row--linkedin">
                 <span class="s-icon" aria-hidden="true">
@@ -332,7 +332,7 @@ const homepageJsonLd = {
             </div>
             {latestPost && (
               <div class="blog-callout">
-                <span class="blog-callout-label">Latest Post</span>
+                <span class="eyebrow blog-callout-label">Latest Post</span>
                 <a href={`/blog/${latestPost.id}/`} class="blog-callout-link">{latestPost.data.title}<span class="link-arrow" aria-hidden="true">→</span></a>
               </div>
             )}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -543,12 +543,32 @@ html[data-fonts-pending] .panel-label {
   margin-bottom: 0;
 }
 
-.about-label {
-  display: block;
+/* Shared eyebrow micro-label (#467). One utility for the fixed-size
+   uppercase label voice that was hand-rolled under five names
+   (.about-label, .connect-label, .stack-label, .impact-label,
+   .now-ribbon-label, .blog-callout-label). Markup carries both classes
+   (e.g. class="eyebrow about-label"); the per-name rules below keep only
+   layout duties (display, margins) and deliberate color overrides — the
+   warm-tinted About/Connect inks and the panel-scoped closed-state
+   colors still win by source order / specificity.
+   Decision (#467): the clamp-sized dt eyebrows (.metadata-strip dt,
+   .project-stack__label, .blog-sidebar-meta dt, .resume-canvas-meta dt)
+   stay separate rather than joining via an --eyebrow--fluid modifier:
+   they split into two sub-patterns (two clamp() formulas, --ink-62 vs
+   0.48 ink) and are element-scoped dt rules, so a shared modifier would
+   still need every override and would only add markup churn. */
+.eyebrow {
   font-size: 0.56rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
   font-weight: 500;
+  color: var(--ink-50);
+}
+
+.about-label {
+  display: block;
+  /* Warm-tinted 50% ink (not --ink-50): matches the open parchment
+     surface; deliberate, kept as an override on the shared .eyebrow. */
   color: rgba(23, 19, 15, 0.50);
   margin-bottom: calc(var(--su) * 0.5);
 }
@@ -617,10 +637,7 @@ html[data-fonts-pending] .panel-label {
   display: block;
   margin-top: var(--su);
   margin-bottom: var(--su);
-  font-size: 0.56rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  font-weight: 500;
+  /* Warm-tinted 50% ink (not --ink-50): see .about-label note (#467). */
   color: rgba(25, 22, 17, 0.50);
 }
 
@@ -969,15 +986,8 @@ a:focus-visible .link-arrow,
   word-spacing: 0.08em;
 }
 
-.stack-label,
-.impact-label,
-.now-ribbon-label {
-  font-size: 0.56rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  font-weight: 500;
-  color: var(--ink-50);
-}
+/* .stack-label / .impact-label / .now-ribbon-label typography moved to
+   the shared .eyebrow utility (#467); they carry no layout duties. */
 
 .stack-items,
 .impact-items,
@@ -999,13 +1009,8 @@ a:focus-visible .link-arrow,
   border-top: 1px solid var(--rule);
 }
 
-.blog-callout-label {
-  font-size: 0.56rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  font-weight: 500;
-  color: var(--ink-50);
-}
+/* .blog-callout-label typography moved to the shared .eyebrow utility
+   (#467); the .panel--blue overrides below still set its color. */
 
 .content-inner .blog-callout-link {
   font-size: 0.68rem;


### PR DESCRIPTION
Closes #467
Part of #463

Authoring-Agent: claude

## What

- Adds a shared `.eyebrow` utility (font-size 0.56rem, letter-spacing 0.16em, uppercase, weight 500, `color: var(--ink-50)` — consuming #466's ramp token, no fresh literal).
- The six hand-rolled label rules (`.about-label`, `.connect-label`, `.stack-label`, `.impact-label`, `.now-ribbon-label`, `.blog-callout-label`) lose their duplicated typography; markup in `index.astro` now carries `class="eyebrow <name>"`. Per-name rules keep only layout duties and deliberate color overrides.
- Preserved overrides, verified by computed style: the warm-tinted About/Connect 50% inks (deliberate, commented), the `.panel--blue .blog-callout-label` closed-state color, the stack-mode (≤1023px) size/letter-spacing rule, and all `.panel--* <label>` closed-state colors (descendant selectors outrank the utility; the stack-mode single-class rule wins by source order).

## Judgment call (per issue)

The clamp-sized dt eyebrows (`.metadata-strip dt`, `.project-stack__label`, `.blog-sidebar-meta dt`, `.resume-canvas-meta dt`) **stay separate** rather than joining via an `--eyebrow--fluid` modifier: they split into two sub-patterns (two different clamp() formulas; `--ink-62` vs 0.48 ink) and are element-scoped `dt` rules, so a shared modifier would still need every per-site override and would only add markup churn. Documented in the utility's header comment.

## Verification

- `npm run lint` clean; `npm run test` green (21 files, 193 tests).
- Dev-server computed-style checks at desktop (1440px) and stack (narrow) widths across all six sites: size/spacing/weight/colors identical to pre-change values in both modes (desktop: 8.96px / 1.4336px / 500; stack mode: the five panel labels correctly drop to the 0.15em stack rule, `.blog-callout-label` correctly stays 0.16em as before).
- No console errors.

## Self-Review

- **Correctness:** Utility specificity (0,1,0) sits below every override that previously won (descendant selectors 0,2,0; stack-mode rule same specificity but later in source). Verified computed equality at both breakpoints rather than reasoning alone.
- **Regression risk:** Low; the one structural change is markup classes, which only add the shared typography that the per-name rules previously duplicated.
- **Style:** Decision comments follow the issue-citing convention.
- **Test coverage:** Existing interaction/layout vitest suites pass; no new behavior.
- **Security/dependency hygiene:** CSS + class attribute changes only.