### PR TITLE
fix(a11y): prefers-reduced-motion for .nav-button and Mux autoplay (#468)

### DIFF
--- a/specs/project-pages.md
+++ b/specs/project-pages.md
@@ -150,6 +150,7 @@ Any project can render a vertical Mux video in the hero instead of a static scre
 - **Analytics**: pages with a Mux hero load `mux-embed` before registering `<mux-background-video>`. Mux Data monitoring is automatic for the background video and infers the env key from the `stream.mux.com` URL; no `PUBLIC_MUX_ENV_KEY` is read by this site.
 - **Fallback**: the existing `screenshotSrc` image renders in `<noscript>` and is also the autoplay-failure fallback. On JavaScript-enabled pages, the Mux thumbnail renders inside `<mux-background-video>` as the pre-upgrade poster; if the custom element fails to register, the media errors, or the shadow `<video>` does not make real playback progress within the autoplay window, the component lazy-loads the `screenshotSrc` GIF, fades the stalled video out, and reveals a compact manual play button.
 - **Bundle cost**: the Mux custom element is registered only when a page contains a `<mux-background-video>` element. Projects without `muxPlaybackId` do not load `mux-embed` or the background-video package at runtime.
+- **Reduced motion (#468)**: when `prefers-reduced-motion: reduce` matches, the hero never autoplays — the video holds on its poster frame with the manual play button visible, and the animated-GIF fallback is suppressed the same way (a looping GIF is the same continuous motion). Both motion paths re-enable only after the user explicitly presses play.
 
 ### Aspect ratio
 

--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -350,6 +350,15 @@ if (isSvgFallback) {
   // The component's Mux Data hook reads globalThis.mux during registration and
   // infers the env key from the stream.mux.com URL.
   if (muxHero) {
+    // #468: set `noautoplay` BEFORE the custom element is imported and
+    // upgraded — the component constructor only puts `autoplay` on its
+    // shadow <video> when the host lacks this attribute at upgrade time
+    // (verified against @mux/mux-background-video dist/html.js), so this
+    // prevents autoplay outright rather than racing to pause it. The
+    // pause guard in monitorMuxPlayback stays as defense-in-depth.
+    if (prefersReducedMotion) {
+      muxHero.setAttribute('noautoplay', '');
+    }
     loadMuxEmbed().finally(() => {
       import('@mux/mux-background-video/html')
         .then(() => customElements.whenDefined('mux-background-video'))

--- a/src/components/ProjectMuxPlayer.astro
+++ b/src/components/ProjectMuxPlayer.astro
@@ -16,6 +16,13 @@
 // When autoplay fails, swaps to the Mux-generated `fallbackSrc` GIF so the
 // hero still reads like an animated product capture. When `playbackId` is
 // unset, falls back to the `fallbackSrc` image directly.
+//
+// prefers-reduced-motion (#468): when the media query matches, the hero
+// never autoplays — the video is held paused on its poster frame with the
+// manual play button visible, so playback stays available on explicit
+// request. The animated-GIF fallback path is gated the same way (a looping
+// GIF is the same continuous motion autoplay would be); the GIF is only
+// swapped in after the user has explicitly requested playback.
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -149,6 +156,13 @@ if (isSvgFallback) {
   // networks; short enough that a blocked hero reads as intentional fallback.
   const AUTOPLAY_FALLBACK_DELAY = 2800;
 
+  // #468: ambient autoplay and a looping GIF are exactly the continuous
+  // motion prefers-reduced-motion exists to suppress. Evaluated once at
+  // load (matching the site-wide CSS treatment); explicit user playback
+  // requests flip userRequestedPlayback and re-enable the motion paths.
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  let userRequestedPlayback = false;
+
   function hidePlayButton() {
     if (playButton instanceof HTMLButtonElement) {
       playButton.hidden = true;
@@ -163,6 +177,19 @@ if (isSvgFallback) {
 
   function showAnimatedFallback(manualPlayAvailable = false) {
     if (!muxFrame || muxFrame.dataset.playbackState === 'playing') return;
+
+    // #468: don't trade blocked autoplay for a looping GIF when the user
+    // prefers reduced motion — hold the poster instead, keeping the play
+    // affordance when manual playback is possible.
+    if (prefersReducedMotion && !userRequestedPlayback) {
+      muxFrame.dataset.playbackState = 'paused';
+      if (manualPlayAvailable) {
+        showPlayButton();
+      } else {
+        hidePlayButton();
+      }
+      return;
+    }
 
     if (gifFallback instanceof HTMLImageElement && gifFallback.dataset.src && !gifFallback.src) {
       gifFallback.src = gifFallback.dataset.src;
@@ -187,6 +214,9 @@ if (isSvgFallback) {
   function requestManualPlayback(video) {
     if (!muxFrame) return;
 
+    // Explicit request: the user opted into motion, so the normal
+    // playback/fallback paths (including the animated GIF) apply (#468).
+    userRequestedPlayback = true;
     muxFrame.dataset.playbackState = 'loading';
     hidePlayButton();
 
@@ -207,6 +237,34 @@ if (isSvgFallback) {
     if (!muxHero || !muxFrame) return;
 
     const video = muxHero.shadowRoot?.querySelector('video');
+
+    // #468: under prefers-reduced-motion, never autoplay. Hold the hero on
+    // the poster frame with the play button visible so playback remains
+    // available on explicit request. The 'playing' guard re-pauses the
+    // component if its internal autoplay orchestration wins the race
+    // before this monitor attaches.
+    if (prefersReducedMotion && video) {
+      video.autoplay = false;
+      video.pause();
+      muxFrame.dataset.playbackState = 'paused';
+      showPlayButton();
+
+      const handleProgress = () => {
+        if (!userRequestedPlayback) {
+          video.pause();
+          return;
+        }
+        if (video.currentTime > 0) {
+          muxFrame.dataset.playbackState = 'playing';
+          hidePlayButton();
+        }
+      };
+      video.addEventListener('playing', handleProgress);
+      video.addEventListener('timeupdate', handleProgress);
+      playButton?.addEventListener('click', () => requestManualPlayback(video));
+      return;
+    }
+
     let sawPlayback = false;
     const fallbackTimer = window.setTimeout(() => {
       if (!sawPlayback) showAnimatedFallback(true);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1436,6 +1436,22 @@ body.blog-page {
   transform: translateY(calc(var(--shift-small) * -1));
 }
 
+/* #468: mirror the .link-arrow reduced-motion treatment — the universal
+   rule zeroes the transition duration, but the hover lift itself must
+   also be neutralized or the button still jumps between resting and
+   raised positions. The background/color swap stays (instant, not
+   motion). */
+@media (prefers-reduced-motion: reduce) {
+  .nav-button {
+    transition: none;
+  }
+
+  .nav-button:hover,
+  .nav-button:focus-visible {
+    transform: none;
+  }
+}
+
 /* ── Redesigned Project Detail ── Hero, Metadata, Related, Footer ── */
 
 /* Hero header — accent bar, no gradient (gradient is on the metadata surface) */

--- a/tests/responsive/swipe-watch-mux-fallback.spec.ts
+++ b/tests/responsive/swipe-watch-mux-fallback.spec.ts
@@ -27,3 +27,38 @@ test('Swipe Watch swaps to the Mux GIF fallback when the stream cannot autoplay'
   await expect(frame).toHaveAttribute('data-playback-state', 'fallback', { timeout: 7000 });
   await expect(playButton).toBeVisible();
 });
+
+test('Swipe Watch hero honors prefers-reduced-motion: no autoplay, poster + play button, GIF only after explicit play (#468)', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'Desktop 1440', 'One viewport covers this media contract.');
+
+  // Abort the stream like the fallback test so the run is deterministic and
+  // offline-safe; the reduced-motion contract is about state choreography,
+  // not real playback.
+  await page.route('https://stream.mux.com/**', (route) => route.abort());
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await page.goto('/projects/swipe-watch/');
+
+  const frame = page.locator('.project-screenshot__mux-shell');
+  const playButton = frame.locator('.project-screenshot__mux-play');
+  const fallback = frame.locator('.project-screenshot__mux-gif-fallback');
+
+  // No autoplay: the hero parks on the poster with playback available on
+  // request, and the looping GIF is NOT lazy-loaded.
+  await expect(frame).toHaveAttribute('data-playback-state', 'paused', { timeout: 7000 });
+  await expect(playButton).toBeVisible();
+  expect(await fallback.getAttribute('src')).toBeNull();
+  expect(
+    await page.evaluate(() => {
+      const v = document
+        .querySelector('mux-background-video')
+        ?.shadowRoot?.querySelector('video');
+      return v ? v.paused : null;
+    })
+  ).toBe(true);
+
+  // Explicit play is an opt-in to motion: with the stream aborted, the
+  // normal failure path now applies and the animated GIF may load.
+  await playButton.click();
+  await expect(frame).toHaveAttribute('data-playback-state', 'fallback', { timeout: 7000 });
+  await expect(fallback).toHaveAttribute('src', /\/images\/projects\/swipe-watch-hero\.gif$/);
+});


### PR DESCRIPTION
Closes #468
Part of #463

Authoring-Agent: claude

## What

**`.nav-button`** — adds the reduced-motion block mirroring the `.link-arrow` pattern (global.css ~:907): `transition: none` plus `transform: none` on hover/focus, so the hover lift never jumps between resting and raised positions. The background/color swap stays — it's an instant state change, not motion.

**`ProjectMuxPlayer.astro`** — when `matchMedia('(prefers-reduced-motion: reduce)')` matches:
- The hero never autoplays: the shadow `<video>` gets `autoplay = false` + `pause()`, the shell parks on `data-playback-state="paused"` (default CSS already shows the poster in that state — only `fallback` has special styling), and the existing play button is shown so playback stays available on explicit request. A `playing`-event guard re-pauses the component if its internal autoplay orchestration wins the race before the monitor attaches.
- The animated-GIF fallback path is gated the same way: a looping GIF is the same continuous motion autoplay would be, so `showAnimatedFallback` holds the poster instead, keeping the play affordance when manual playback is possible.
- An explicit play press flips `userRequestedPlayback` — from then on the normal playback/fallback choreography (including the GIF) applies, since the user opted into motion.
- Behavior documented in the component header and in `specs/project-pages.md` § "What happens automatically".

## Verification

- `npm run lint` clean; `npm run test` green (21 files, 193 tests).
- **New e2e test** (`swipe-watch-mux-fallback.spec.ts`) using the repo's existing `emulateMedia({ reducedMotion: 'reduce' })` pattern, deterministic via stream-route abort: asserts `paused` state, visible play button, GIF **not** lazy-loaded, shadow video actually paused — then clicks play and asserts the opt-in path reaches the GIF fallback.
- Full `npm run test:e2e`: 299 passed, 33 skipped, 0 failed.
- Note: the pre-existing Mux fallback e2e (and the new one) fail when Playwright reuses a long-running **dev** server on :4321 instead of its configured `npm run preview` production server (`reuseExistingServer: !CI`). Verified the pre-existing test fails the same way on unmodified main under a dev server, and both pass against the production preview server — environment quirk, not a regression from this PR.

## Self-Review

- **Correctness:** The reduced-motion path returns early from `monitorMuxPlayback` before any autoplay timers attach, so no stray `showAnimatedFallback` fires from the normal flow; the explicit-play path reuses `requestManualPlayback` unchanged, and its progress listener flips state to `playing` so the manual timer no-ops.
- **Regression risk:** Non-reduced-motion flow is untouched (the new branch is guarded and returns). `paused` is a new data-state value with no CSS hooks needed — default styling is the poster view.
- **Style:** Comments cite #468; the CSS block copies the `.link-arrow` precedent verbatim in structure.
- **Test coverage:** New deterministic e2e contract for both halves of the behavior (no-autoplay, opt-in).
- **Security/dependency hygiene:** No new dependencies; the existing SVG sanitization paths untouched.