### PR TITLE
refactor(resume): extract ResumeSection wrapper (#471)

### DIFF
--- a/src/components/resume/AwardsSection.astro
+++ b/src/components/resume/AwardsSection.astro
@@ -1,16 +1,18 @@
 ---
 /**
  * AwardsSection — hackathons / awards. Plumbed but renders nothing (no
- * header) when the `awards` collection is empty, per #394.
+ * header) when the `awards` collection is empty, per #394 — the guard
+ * wraps the shared wrapper, so an empty collection emits no shell.
+ * Section/heading scaffolding via the shared ResumeSection wrapper (#471).
  */
+import ResumeSection from './ResumeSection.astro';
+
 const { entries } = Astro.props;
 const sorted = [...entries].sort((a, b) => (a.data.order ?? 99) - (b.data.order ?? 99));
 ---
 
 {sorted.length > 0 && (
-  <section id="awards" class="resume-section resume-awards" aria-labelledby="resume-awards-heading">
-    <h2 id="resume-awards-heading" class="resume-section__title">Hackathons &amp; Awards</h2>
-    <ul class="resume-awards__list">
+  <ResumeSection type="awards" heading="Hackathons & Awards"><ul class="resume-awards__list">
       {sorted.map((entry) => {
         const d = entry.data;
         const meta = [d.issuer, d.year].filter(Boolean).join(' · ');
@@ -23,6 +25,5 @@ const sorted = [...entries].sort((a, b) => (a.data.order ?? 99) - (b.data.order 
           </li>
         );
       })}
-    </ul>
-  </section>
+    </ul></ResumeSection>
 )}

--- a/src/components/resume/CertificationsSection.astro
+++ b/src/components/resume/CertificationsSection.astro
@@ -2,16 +2,16 @@
 /**
  * CertificationsSection — credentials, with a small CompanyLogo (decorative)
  * keyed off the issuer / website. No body copy.
+ * Section/heading scaffolding via the shared ResumeSection wrapper (#471).
  */
+import ResumeSection from './ResumeSection.astro';
 import CompanyLogo from './CompanyLogo.astro';
 
 const { entries } = Astro.props;
 const sorted = [...entries].sort((a, b) => (a.data.order ?? 99) - (b.data.order ?? 99));
 ---
 
-<section id="certifications" class="resume-section resume-certifications" aria-labelledby="resume-certifications-heading">
-  <h2 id="resume-certifications-heading" class="resume-section__title">Certifications</h2>
-  <ul class="resume-certs">
+<ResumeSection type="certifications" heading="Certifications"><ul class="resume-certs">
     {sorted.map((entry) => {
       const d = entry.data;
       return (
@@ -24,5 +24,4 @@ const sorted = [...entries].sort((a, b) => (a.data.order ?? 99) - (b.data.order 
         </li>
       );
     })}
-  </ul>
-</section>
+  </ul></ResumeSection>

--- a/src/components/resume/EducationSection.astro
+++ b/src/components/resume/EducationSection.astro
@@ -2,15 +2,16 @@
 /**
  * EducationSection — degree(s), most-recent-first. CompanyLogo (decorative)
  * keyed off the school name / website. No body copy.
+ * Section/heading scaffolding via the shared ResumeSection wrapper (#471).
  */
+import ResumeSection from './ResumeSection.astro';
 import CompanyLogo from './CompanyLogo.astro';
 
 const { entries } = Astro.props;
 const sorted = [...entries].sort((a, b) => b.data.year - a.data.year);
 ---
 
-<section id="education" class="resume-section resume-education" aria-labelledby="resume-education-heading">
-  <h2 id="resume-education-heading" class="resume-section__title">Education</h2>
+<ResumeSection type="education" heading="Education">
   {sorted.map((entry) => {
     const d = entry.data;
     const meta = [d.school, d.location, d.year].filter(Boolean).join(' · ');
@@ -26,4 +27,4 @@ const sorted = [...entries].sort((a, b) => b.data.year - a.data.year);
       </article>
     );
   })}
-</section>
+</ResumeSection>

--- a/src/components/resume/ExperienceSection.astro
+++ b/src/components/resume/ExperienceSection.astro
@@ -5,7 +5,9 @@
  * "Role – Company" + a meta line (team · location · year range), then the
  * markdown body (intro paragraph + bullets) below at full width so it wraps
  * under the logo. Rendered with render().
+ * Section/heading scaffolding via the shared ResumeSection wrapper (#471).
  */
+import ResumeSection from './ResumeSection.astro';
 import { render } from 'astro:content';
 import CompanyLogo from './CompanyLogo.astro';
 
@@ -16,8 +18,7 @@ const rendered = await Promise.all(
 );
 ---
 
-<section id="experience" class="resume-section resume-experience" aria-labelledby="resume-experience-heading">
-  <h2 id="resume-experience-heading" class="resume-section__title">Experience</h2>
+<ResumeSection type="experience" heading="Experience">
   {rendered.map(({ entry, Content }) => {
     const d = entry.data;
     const range = `${d.startYear}–${d.endYear ?? 'Present'}`;
@@ -37,4 +38,4 @@ const rendered = await Promise.all(
       </article>
     );
   })}
-</section>
+</ResumeSection>

--- a/src/components/resume/ProjectsSection.astro
+++ b/src/components/resume/ProjectsSection.astro
@@ -4,7 +4,9 @@
  * (distinct from `projects`). Each entry: <h3> name, an inline tech list, a
  * link (live URL or repo) using the site's → arrow convention, and the
  * markdown body rendered with render().
+ * Section/heading scaffolding via the shared ResumeSection wrapper (#471).
  */
+import ResumeSection from './ResumeSection.astro';
 import { render } from 'astro:content';
 
 const { entries } = Astro.props;
@@ -19,8 +21,7 @@ function displayUrl(url: string): string {
 }
 ---
 
-<section id="projects" class="resume-section resume-projects" aria-labelledby="resume-projects-heading">
-  <h2 id="resume-projects-heading" class="resume-section__title">Projects</h2>
+<ResumeSection type="projects" heading="Projects">
   {rendered.map(({ entry, Content }) => {
     const d = entry.data;
     const link = d.url ?? d.repo;
@@ -39,4 +40,4 @@ function displayUrl(url: string): string {
       </article>
     );
   })}
-</section>
+</ResumeSection>

--- a/src/components/resume/ResumeSection.astro
+++ b/src/components/resume/ResumeSection.astro
@@ -1,0 +1,36 @@
+---
+/**
+ * ResumeSection — shared wrapper for the /resume section boilerplate
+ * (#471). Renders the section/heading scaffolding every resume section
+ * repeated by hand:
+ *
+ *   <section id="{type}" class="resume-section resume-{type}"
+ *            aria-labelledby="resume-{type}-heading">
+ *     <h2 id="resume-{type}-heading" class="resume-section__title">…</h2>
+ *     <slot />
+ *   </section>
+ *
+ * The wrapper renders unconditionally — sections with #394 empty-state
+ * behavior (e.g. AwardsSection renders nothing when the collection is
+ * empty) keep their own guard AROUND this wrapper, so an empty section
+ * still produces no shell at all.
+ *
+ * Slot whitespace: element children should hug the ResumeSection tags
+ * (`<ResumeSection …><ul>` / `</ul></ResumeSection>`) — compressHTML
+ * keeps one boundary space from this template's own newlines, and a
+ * second from the child template would diverge from the pre-#471
+ * byte-identical output. Expression children ({list.map(…)}) are
+ * whitespace-trimmed by the compiler and can stay on their own lines.
+ */
+interface Props {
+  type: string;
+  heading: string;
+}
+
+const { type, heading } = Astro.props;
+---
+
+<section id={type} class={`resume-section resume-${type}`} aria-labelledby={`resume-${type}-heading`}>
+  <h2 id={`resume-${type}-heading`} class="resume-section__title">{heading}</h2>
+  <slot />
+</section>

--- a/src/components/resume/SkillsSection.astro
+++ b/src/components/resume/SkillsSection.astro
@@ -3,19 +3,18 @@
  * SkillsSection — one row per skill category (sorted by `priority`),
  * each rendered as an inline middle-dot-joined list to match the site's
  * inline-list aesthetic. Only the category label is restyled.
+ * Section/heading scaffolding via the shared ResumeSection wrapper (#471).
  */
+import ResumeSection from './ResumeSection.astro';
 const { categories } = Astro.props;
 const sorted = [...categories].sort((a, b) => a.data.priority - b.data.priority);
 ---
 
-<section id="skills" class="resume-section resume-skills" aria-labelledby="resume-skills-heading">
-  <h2 id="resume-skills-heading" class="resume-section__title">Skills</h2>
-  <dl class="resume-skills__list">
+<ResumeSection type="skills" heading="Skills"><dl class="resume-skills__list">
     {sorted.map((category) => (
       <div class="resume-skills__row">
         <dt class="resume-skills__label">{category.data.label}</dt>
         <dd class="resume-skills__values">{category.data.skills.join(' · ')}</dd>
       </div>
     ))}
-  </dl>
-</section>
+  </dl></ResumeSection>

--- a/src/components/resume/SummarySection.astro
+++ b/src/components/resume/SummarySection.astro
@@ -2,16 +2,15 @@
 /**
  * SummarySection — renders the two-paragraph summary from the single
  * `myself` collection entry, using render() like blog/project bodies.
+ * Section/heading scaffolding via the shared ResumeSection wrapper (#471).
  */
+import ResumeSection from './ResumeSection.astro';
 import { render } from 'astro:content';
 
 const { entry } = Astro.props;
 const { Content } = await render(entry);
 ---
 
-<section id="summary" class="resume-section resume-summary" aria-labelledby="resume-summary-heading">
-  <h2 id="resume-summary-heading" class="resume-section__title">Summary</h2>
-  <div class="resume-prose">
+<ResumeSection type="summary" heading="Summary"><div class="resume-prose">
     <Content />
-  </div>
-</section>
+  </div></ResumeSection>

--- a/src/components/resume/WritingSection.astro
+++ b/src/components/resume/WritingSection.astro
@@ -3,7 +3,9 @@
  * WritingSection — a compact inline section (no collection; per #394 the
  * homepage and /blog already cover writing). Links the blog and a few
  * selected essays, using the site's → arrow convention.
+ * Section/heading scaffolding via the shared ResumeSection wrapper (#471).
  */
+import ResumeSection from './ResumeSection.astro';
 const essays = [
   {
     title: 'Agent Approval Workflow and the Genesis of Mergepath',
@@ -20,9 +22,7 @@ const essays = [
 ];
 ---
 
-<section id="writing" class="resume-section resume-writing" aria-labelledby="resume-writing-heading">
-  <h2 id="resume-writing-heading" class="resume-section__title">Writing</h2>
-  <p class="resume-writing__lead">
+<ResumeSection type="writing" heading="Writing"><p class="resume-writing__lead">
     <strong>The AI-Augmented PM</strong> –
     <a href="/blog/">nathanpayne.com/blog <span class="link-arrow" aria-hidden="true">→</span></a>
   </p>
@@ -36,5 +36,4 @@ const essays = [
         <a href={essay.href}>{essay.title} <span class="link-arrow" aria-hidden="true">→</span></a>
       </li>
     ))}
-  </ul>
-</section>
+  </ul></ResumeSection>


### PR DESCRIPTION
Closes #471
Part of #463

Authoring-Agent: claude

## What

- Adds `ResumeSection.astro` (`type`/`heading` props + default slot) rendering the `<section id class aria-labelledby>` + `<h2 class="resume-section__title">` scaffolding that all eight resume section components repeated by hand.
- Migrates Summary, Experience, Education, Skills, Certifications, Awards, Writing, and Projects onto it; each keeps its existing header comment plus a one-line note about the shared wrapper.
- **#394 empty-state preserved exactly**: AwardsSection keeps its `sorted.length > 0` guard *around* the wrapper (documented in both files), so an empty awards collection still renders no shell — confirmed in the built output, which contains no awards section before or after.
- The `Hackathons & Awards` heading passes through prop interpolation and still renders `&amp;` (Astro escapes text expressions) — verified in the byte diff.

## Byte-identical verification (the issue's hard requirement)

Built `/resume` HTML diffed against the pre-change build: **byte-identical** modulo the OG-image cache-buster (`?v=NNN`), a per-build stamp baked into meta tags by the OG pipeline regardless of this change. Getting there surfaced an Astro `compressHTML` nuance worth documenting: element children of a slot contribute one boundary space while expression children (`{list.map(…)}`) are whitespace-trimmed, so element children must hug the wrapper tags or the output gains a second space. Documented in the wrapper's header comment so future sections stay consistent; the first diff attempt (8 stray spaces) is what proved the rule.

Since the HTML is byte-identical and no CSS changed, print rendering (`specs/resume.md`) is unchanged by construction.

## Verification

- `npm run lint` clean; `npm run test` green (193 tests).
- Built-output scaffolding census: identical `<section>`/`<h2>` tag sets before and after.

## Self-Review

- **Correctness:** Byte-diff is the strongest possible check for a markup refactor; it passed.
- **Regression risk:** None observable — output unchanged.
- **Style:** Wrapper doc covers props, the empty-state contract, and the slot-whitespace rule.
- **Test coverage:** Existing resume route tests; no behavior change to cover.
- **Security/dependency hygiene:** No dependencies; no dynamic HTML paths touched.