### PR TITLE
feat(spacing): commit to --su; define the named spacing scale (#472)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -22,7 +22,29 @@
   --github-green-4: #0FBF3E;
   --github-green-2: #8CF2A6;
   --line: 9px;
+  /* Spacing (#472). --su (0.42rem) is the base spacing unit. The audit
+     pegged it at ~4% adoption, but the real count is 27 declarations —
+     11 direct uses and 16 calc() multiples — concentrated in the
+     homepage panel interiors, where it sets the content rhythm. So the
+     decision (#472) is to COMMIT to the unit: the named steps below
+     give the dominant multiples stable handles for new code and for
+     the follow-up migration of high-traffic ad-hoc rem values (panel
+     content, project hero, blog prose — tracked separately; #472
+     defines the scale only and migrates nothing).
+     Two deliberate boundaries on the system:
+     - Larger layout spacing (page gutters, section breaks, hero
+       padding) stays content-driven via clamp()/rem. Those values are
+       tuned against the viewport, not a modular scale, and naming
+       them would misrepresent how they're chosen.
+     - Existing tuned multiples (e.g. calc(var(--su) * 0.85)) remain
+       valid; collapse onto named steps only where visually safe,
+       per-area, during the migration. */
   --su: 0.42rem;
+  --sp-2xs: calc(var(--su) * 0.5);   /* 0.21rem — hairline gaps */
+  --sp-xs: calc(var(--su) * 0.75);   /* 0.315rem — tight list/label gaps */
+  --sp-sm: var(--su);                /* 0.42rem — base step */
+  --sp-md: calc(var(--su) * 1.5);    /* 0.63rem — block separation */
+  --sp-lg: calc(var(--su) * 2);      /* 0.84rem — section-level gaps */
   --grid-border: #1a1814;
   --cream: #f5f0e4;
   --surface: rgba(244, 239, 229, 0.96);


### PR DESCRIPTION
Closes #472
Part of #463
Follow-up migration: #482

Authoring-Agent: claude

## The decision (owner attention requested — this is the philosophy choice the issue flagged)

**Commit (option 1), not retire.** The deciding fact is an audit miscount: the issue says `--su` has ~7 uses (~4% of 179 spacing declarations), but the real count on main is **27 declarations — 11 direct `var(--su)` uses and 16 `calc(var(--su) * N)` multiples** — concentrated in the homepage panel interiors, where `--su` genuinely sets the content rhythm. At 7 uses, retirement was the honest call; at 27, retiring would inline structured values into magic numbers like `0.231rem` and `0.357rem` — strictly worse for maintainability. Per the audit-discrepancy rule, I fixed reality rather than the issue text and am noting the miscount here.

## What this PR does (scale definition + comment only, per the issue)

- Defines `--sp-2xs` (0.5×), `--sp-xs` (0.75×), `--sp-sm` (1×), `--sp-md` (1.5×), `--sp-lg` (2×) as named steps of the `--su` base — steps chosen from the multiples that dominate actual use (0.5/0.55/0.6, 0.75/0.85, 1, 1.5/1.6, 2.1 clusters).
- Documents two deliberate boundaries in the `:root` comment: larger layout spacing stays content-driven `clamp()`/rem (those values are tuned against the viewport — naming them would misrepresent how they're chosen), and existing tuned multiples remain valid until the per-area migration.
- **Migrates zero declarations.** Zero rendered change — the tokens have no consumers yet.
- Files the follow-up M-sized migration issue #482, scoped to the named high-traffic areas only (panel content, project hero, blog prose).

## Verification

`npm run lint` clean; `npm run test` green (193 tests). No consumer sites — the change is definitionally invisible.

## Self-Review

- **Correctness:** `--sp-sm: var(--su)` and the calc() steps resolve at use time; no consumers to break.
- **Regression risk:** None — additive token definitions.
- **Style:** Comment follows the issue-citing `:root` convention; scale notation matches the breadcrumb/ink-ramp precedent of documenting the system at the definition site.
- **Test coverage:** N/A (no behavior).
- **Security/dependency hygiene:** CSS-only.