### PR TITLE
docs(css): naming conventions + 560px orphan breakpoint (#473)

### DIFF
--- a/docs/agents/code-modification-rules.md
+++ b/docs/agents/code-modification-rules.md
@@ -108,6 +108,7 @@ Static assets (favicons, robots.txt, OG fonts) live in `public/` and are copied 
 ### CSS
 
 - Design tokens in `:root`—always use or extend them.
+- **Selector naming:** loose BEM (block / `__element` / `--modifier`) with `.is-*` state classes; the canonical convention block, including the `p-`/`s-`/`e-`/`og-` prefix glossary, lives at the top of `src/styles/global.css` (#473).
 - **Motion system:** All durations use `--motion-fast` / `--motion-hover` / `--motion-plane` / `--motion-load`. All easing uses `--ease-standard` / `--ease-sharp` / `--ease-linear`. Translation magnitude uses `--shift-small` / `--shift-medium`. No hard-coded `ms` values or bare `ease` keywords.
 - Homepage panel states are driven by `data-focus` attribute on the grid container. CSS defines `grid-template-columns` + `grid-template-rows` for each `data-focus` value.
 - Fluid sizing via `clamp()`; no fixed-breakpoint font overrides.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,35 @@
+/* ──────────────────────────────────────────────────────────────────────
+   Naming conventions (#473)
+
+   Selectors follow a loose BEM dialect:
+   - Block      .metadata-strip, .project-hero, .resume-entry
+   - Element    double underscore: .metadata-strip__item,
+                .project-hero__gradient, .resume-entry__meta
+   - Modifier   double dash, on the block or element it modifies. `--`
+                encodes BOTH theme variants (.panel--red, .block--gray-e)
+                and semantic/layout variants (.about-block--writing,
+                .project-hero--wide, .breadcrumbs--inset); the two are
+                not distinguished syntactically — read the value.
+   - State      .is-* classes toggled by JS (.is-open,
+                .is-content-visible, .is-scrolling) and data-*
+                attributes for machine-driven state (data-focus,
+                data-accent, data-playback-state).
+
+   Abbreviated prefix glossary (legacy short names; renaming them is
+   explicitly out of scope per #473 — markup churn for no user value):
+   - .p-*   homepage Builds-panel project-list interiors
+            (.p-head, .p-name, .p-name-link, .p-link)
+   - .s-*   homepage Connect-panel social-row interiors
+            (.s-icon, .s-arrow)
+   - .e-*   404 error-page Mondrian blocks (.e-red, .e-white-a, …)
+   - .og-*  OG-image template blocks (.og-card, .og-label, …) —
+            build-time render context only (see OgCard.astro)
+
+   Tokens: --su / --sp-* spacing (#472), --ink-NN opacity ramp (#466),
+   --bp-* breakpoints. CSS cannot read custom properties inside @media
+   conditions, so raw px values in media queries carry a comment naming
+   the token they mirror (#330/#332).
+   ────────────────────────────────────────────────────────────────── */
 :root {
   --ink: #11100d;
   --paper: #ffffff;
@@ -2384,6 +2416,7 @@ a.tag:hover {
   border-top: 1px solid var(--ink);
 }
 
+/* 1023px is one below --bp-stack (1024px) on :root. (#332) */
 @media (max-width: 1023px) {
   .site-footer {
     flex-direction: column;
@@ -3409,6 +3442,8 @@ a:focus-visible {
 
 }
 
+/* 1023px is one below --bp-stack (1024px) on :root — the homepage
+   stack-mode boundary. (#332) */
 @media (max-width: 1023px) {
   :root { --line: 6px; }
 
@@ -4177,6 +4212,12 @@ body.resume-page {
   color: rgba(17, 16, 13, 0.82);
 }
 
+/* 560px is a documented one-off, not a --bp-* token (#473): the
+   two-column skills row wraps at its own content-driven width — label +
+   inline skill list collide between --bp-narrow (480px) and --bp-tablet
+   (768px), and neither token matches where the collision actually
+   happens. Single use site; promote to a token only if a second
+   consumer appears. (#332 comment-alignment pattern) */
 @media (max-width: 560px) {
   .resume-skills__row {
     grid-template-columns: 1fr;


### PR DESCRIPTION
Closes #473
Part of #463

Authoring-Agent: claude

## What (comments/docs only — zero rendered-output change)

- **Naming-convention block** at the top of `src/styles/global.css`: the loose BEM dialect (block / `__element` / `--modifier`), the explicit note that `--` encodes BOTH theme variants (`.panel--red`) and semantic variants (`.about-block--writing`) with no syntactic distinction, `.is-*`/`data-*` state conventions, and the abbreviated-prefix glossary verified against the live selector inventory: `.p-*` (Builds-panel project-list interiors), `.s-*` (Connect-panel social rows), `.e-*` (404 Mondrian blocks), `.og-*` (OG templates). Renaming the prefixes is explicitly out of scope, stated in the block.
- **560px orphan resolved as a documented one-off** (judgment call, per the #332 comment-alignment pattern): the `.resume-skills__row` collapse happens at its own content-driven width between `--bp-narrow` (480) and `--bp-tablet` (768) — neither token matches where the label/skill-list collision actually occurs, and it's a single use site. The comment says to promote it to a token only if a second consumer appears. A one-use token would be noise.
- **Comment-aligned the two remaining raw `@media` values** that lacked their token comment: the `.site-footer` 1023px block and the homepage stack-mode 1023px block (both noted as one-below-`--bp-stack`). The other raw values (480/768/1023 ×4) already carried #332 comments — re-verified rather than assumed.
- **Cross-check** (per the issue): `docs/agents/code-modification-rules.md` § CSS gains a one-line pointer to the canonical block; `rules/repo_rules.md` deliberately untouched (it holds binding structural invariants — a comment convention isn't one); `.ai_context.md`'s `global.css` entry already accurate.

## Verification

`npm run lint` clean; `npm run test` green (193 tests) — comments only, clean build is the contract per the issue.

## Self-Review

- **Correctness:** Glossary entries grep-verified against the actual class inventory (e.g. `.p-head` exists, `.p-meta` does not — the block lists only real selectors).
- **Regression risk:** None — comment and doc changes only.
- **Style:** Convention block follows the file's long-form documented-decision idiom; breakpoint comments reuse the exact #332 phrasing pattern.
- **Test coverage:** N/A.
- **Security/dependency hygiene:** N/A.