### PR TITLE
Link resume project titles

### DIFF
--- a/specs/resume.md
+++ b/specs/resume.md
@@ -134,6 +134,8 @@ The `resumeProjects` collection must remain separate from the existing
 - In-content links and the header contact links use the site's `--blue`
   accent (via `--resume-link`), with the `→` arrow convention on the project
   and writing links.
+- Each project title links to its matching `/projects/<slug>/` detail page
+  while preserving the existing live/repo link.
 - Skills render as inline `·`-joined lists.
 - Any transition uses the `--motion-*`/`--ease-*` tokens (no bare `ms`/`ease`).
 

--- a/src/components/resume/ProjectsSection.astro
+++ b/src/components/resume/ProjectsSection.astro
@@ -25,9 +25,12 @@ function displayUrl(url: string): string {
   {rendered.map(({ entry, Content }) => {
     const d = entry.data;
     const link = d.url ?? d.repo;
+    const projectHref = `/projects/${entry.id}/`;
     return (
       <article class="resume-entry">
-        <h3 class="resume-entry__title">{d.name}</h3>
+        <h3 class="resume-entry__title">
+          <a href={projectHref}>{d.name}</a>
+        </h3>
         <p class="resume-entry__tech">{d.tech.join(' · ')}</p>
         {link && (
           <p class="resume-entry__link">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4231,6 +4231,21 @@ body.resume-page {
   margin-bottom: 0.05rem;
 }
 
+.resume-projects .resume-entry__title a {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid color-mix(in srgb, var(--resume-link) 35%, transparent);
+  transition:
+    color var(--motion-hover) var(--ease-standard),
+    border-color var(--motion-hover) var(--ease-standard);
+}
+
+.resume-projects .resume-entry__title a:hover,
+.resume-projects .resume-entry__title a:focus-visible {
+  color: var(--resume-link);
+  border-bottom-color: var(--resume-link);
+}
+
 .resume-entry__tech {
   margin-top: 0.25rem;
   font-size: clamp(0.8rem, 0.78rem + 0.1vw, 0.88rem);

--- a/tests/resume.test.js
+++ b/tests/resume.test.js
@@ -166,6 +166,28 @@ describe('Resume — page structure', () => {
     expect(proj.querySelectorAll('h3.resume-entry__title').length).toBe(6);
   });
 
+  it('links each resume project title to its matching project page', () => {
+    const proj = document.querySelector('.resume-projects');
+    const links = Array.from(proj.querySelectorAll('h3.resume-entry__title a'));
+    expect(links.length).toBe(6);
+    expect(links.map((link) => link.getAttribute('href'))).toEqual([
+      '/projects/mergepath/',
+      '/projects/matchline/',
+      '/projects/device-source-of-truth/',
+      '/projects/override/',
+      '/projects/swipe-watch/',
+      '/projects/friends-and-family-billing/',
+    ]);
+    expect(links.map((link) => link.textContent.trim())).toEqual([
+      'Mergepath – Agent Governance Infrastructure',
+      'Matchline – AI Career CRM',
+      'Device Source of Truth – Partner Device Intelligence Platform',
+      'Override – Broadway Financial Operating System',
+      'Swipe Watch – Content Discovery Prototype',
+      'Friends & Family Billing – Shared-Bill Coordination',
+    ]);
+  });
+
   it('renders three Certifications; CSP-PO is attributed to Scrum Alliance', () => {
     const certs = document.querySelectorAll('.resume-certifications .resume-cert');
     expect(certs.length).toBe(3);


### PR DESCRIPTION
Authoring-Agent: codex

## Summary
- Link each `/resume/` project title to its matching `/projects/<slug>/` page.
- Preserve the existing live/repo link line for each project.
- Document the revised resume contract and add regression coverage.
- Note: #486 originally included a Projects-heading index link, but the final requested scope removes that link as inconsistent.

Closes #486

## Testing
- [x] Tests pass: `npm run test`
- [x] Build succeeds: covered by `npm run test` / Astro build
- [x] End-to-end checks pass: `npm run test:e2e`
- [x] Lint passes: `npm run lint`
- [x] Manual verification completed: browser readback shows `Projects` heading has zero links, six project title links are present, no horizontal overflow
- [x] Print verification completed: Chromium Letter PDF render remains 3 pages via `qpdf --show-npages /tmp/resume-486.pdf`

## Self-Review
- [x] Correctness: project titles link to the matching `/projects/<slug>/` pages and the requested heading index link was removed per follow-up.
- [x] Regression risk: existing live/repo project links are preserved, and `/resume/` print output remains 3 pages.
- [x] Style and conventions: CSS uses existing resume link conventions, `--resume-link`, and motion tokens; no new dependencies or design-system bypasses.
- [x] Test coverage: resume tests assert all six title links and existing test/e2e suites pass.
- [x] Security and dependency hygiene: no new dependencies, secrets, or external script behavior introduced.