### PR TITLE
feat(resume): open Projects with a Builds index lead (tag, intro, link)

### DIFF
--- a/specs/resume.md
+++ b/specs/resume.md
@@ -70,6 +70,11 @@ The `resumeProjects` collection must remain separate from the existing
   from `astro:content`.
 - **Writing** is a compact inline section (no collection) linking the blog
   and a few selected essays.
+- **Projects** opens with the same compact lead pattern before its entries:
+  a bold **Builds** tag, a link to the project index
+  (nathanpayne.com/projects → `/projects/`), and a one-line intro
+  (`.resume-projects__lead` / `.resume-projects__desc`, sharing the Writing
+  lead styling).
 
 ## Semantics & structure
 
@@ -151,6 +156,8 @@ The `resumeProjects` collection must remain separate from the existing
   CTA linking nathanpayne.com/blog); the blurb, the "Selected essays" label,
   and the essay list are hidden, since their links can't be followed on
   paper. The on-screen Writing section is unchanged.
+- The **Projects** intro collapses the same way: the Builds lead
+  (nathanpayne.com/projects) prints; the one-line blurb is hidden.
 - Section divider rules (the `border-top` between sections) are dropped in
   print and the reserved padding reclaimed; the bold section titles carry the
   separation. This buys vertical space toward the three-page fit.

--- a/src/components/resume/ProjectsSection.astro
+++ b/src/components/resume/ProjectsSection.astro
@@ -1,9 +1,10 @@
 ---
 /**
  * ProjectsSection — selected projects from the `resumeProjects` collection
- * (distinct from `projects`). Each entry: <h3> name, an inline tech list, a
- * link (live URL or repo) using the site's → arrow convention, and the
- * markdown body rendered with render().
+ * (distinct from `projects`). Opens with a compact lead linking the /projects
+ * index (the WritingSection tag/intro/link pattern), then each entry: <h3>
+ * name, an inline tech list, a link (live URL or repo) using the site's →
+ * arrow convention, and the markdown body rendered with render().
  * Section/heading scaffolding via the shared ResumeSection wrapper (#471).
  */
 import ResumeSection from './ResumeSection.astro';
@@ -21,7 +22,13 @@ function displayUrl(url: string): string {
 }
 ---
 
-<ResumeSection type="projects" heading="Projects">
+<ResumeSection type="projects" heading="Projects"><p class="resume-projects__lead">
+    <strong>Builds</strong> –
+    <a href="/projects/">nathanpayne.com/projects <span class="link-arrow" aria-hidden="true">→</span></a>
+  </p>
+  <p class="resume-projects__desc">
+    Each one a real problem turned into a systems design exercise—built with AI agents from first commit to deploy.
+  </p>
   {rendered.map(({ entry, Content }) => {
     const d = entry.data;
     const link = d.url ?? d.repo;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4307,21 +4307,32 @@ body.resume-page {
   color: var(--ink-62);
 }
 
-/* ── Writing (compact inline section) ── */
+/* ── Writing (compact inline section) ──
+   The Projects section opens with the same tag/intro/link lead (linking the
+   /projects index), so its __lead/__desc classes share these rules. */
+.resume-projects__lead,
 .resume-writing__lead {
   font-size: clamp(0.94rem, 0.92rem + 0.12vw, 1.02rem);
   line-height: 1.55;
 }
 
+.resume-projects__lead strong,
 .resume-writing__lead strong {
   font-weight: 700;
 }
 
+.resume-projects__desc,
 .resume-writing__desc {
   margin-top: 0.4rem;
   font-size: clamp(0.9rem, 0.88rem + 0.12vw, 0.98rem);
   line-height: 1.55;
   color: rgba(17, 16, 13, 0.82);
+}
+
+/* The gap to the first project entry lives here because
+   .resume-entry:first-of-type zeroes its own top margin. */
+.resume-projects__desc {
+  margin-bottom: 1.5rem;
 }
 
 .resume-writing__label {
@@ -4356,6 +4367,7 @@ body.resume-page {
   background: var(--resume-link);
 }
 
+.resume-projects__lead a,
 .resume-writing__lead a,
 .resume-writing__essays a {
   color: var(--resume-link);
@@ -4364,6 +4376,8 @@ body.resume-page {
   transition: border-color var(--motion-hover) var(--ease-standard);
 }
 
+.resume-projects__lead a:hover,
+.resume-projects__lead a:focus-visible,
 .resume-writing__lead a:hover,
 .resume-writing__lead a:focus-visible,
 .resume-writing__essays a:hover,
@@ -4551,9 +4565,9 @@ body.resume-page {
 
   /* Render the URL after any descriptive-text external link for hard copy.
      Links whose visible text is ALREADY the URL — the contact line, the
-     project links, and the Writing lead (nathanpayne.com/blog) — suppress
-     this to avoid duplication. (The essay list is hidden in print; see the
-     Writing-collapse rule below.) */
+     project links, and the Writing/Projects leads (nathanpayne.com/blog,
+     nathanpayne.com/projects) — suppress this to avoid duplication. (The
+     essay list is hidden in print; see the Writing-collapse rule below.) */
   .resume-canvas a[href^="http"]::after {
     content: " (" attr(href) ")";
     font-size: 0.85em;
@@ -4562,6 +4576,7 @@ body.resume-page {
 
   .resume-contact a[href^="http"]::after,
   .resume-entry__link a[href^="http"]::after,
+  .resume-projects__lead a[href^="http"]::after,
   .resume-writing__lead a[href^="http"]::after {
     content: "";
   }
@@ -4571,12 +4586,18 @@ body.resume-page {
      dead on paper, so only the "The AI-Augmented PM / nathanpayne.com/blog"
      lead prints; the blurb, the "Selected essays" label, and the essay list
      are hidden. This also drops the page-tail the essay list used to push
-     past the bottom margin. */
+     past the bottom margin. The Projects intro collapses the same way: its
+     "Builds / nathanpayne.com/projects" lead prints, the blurb is hidden. */
+  .resume-projects__desc,
   .resume-writing__desc,
   .resume-writing__label,
   .resume-writing__essays {
     display: none;
   }
+
+  /* With the intro hidden, the Projects lead carries the gap to the first
+     entry (.resume-entry:first-of-type zeroes its own top margin). */
+  .resume-projects__lead { margin-bottom: 0.52rem; }
 
   /* Print density — restore the screen rhythm to fill three balanced
      US-Letter pages. The earlier tuning crushed these gaps to their floor to
@@ -4647,6 +4668,7 @@ body.resume-page {
   .resume-cert__name { font-size: 9.5pt; }
   .resume-cert__meta,
   .resume-entry__tech { font-size: 9pt; }
+  .resume-projects__lead,
   .resume-writing__lead { font-size: 9.5pt; line-height: 1.35; }
 
   /* Project link matches the new body size (issue #420 R-05). At the old

--- a/tests/resume.test.js
+++ b/tests/resume.test.js
@@ -168,6 +168,7 @@ describe('Resume — page structure', () => {
 
   it('opens Projects with a Builds lead — tag, intro, and /projects/ index link (Writing pattern)', () => {
     const proj = document.querySelector('.resume-projects');
+    expect(proj, 'projects section missing').not.toBeNull();
     const lead = proj.querySelector('.resume-projects__lead');
     expect(lead, 'projects lead missing').not.toBeNull();
     expect(lead.querySelector('strong')?.textContent).toBe('Builds');

--- a/tests/resume.test.js
+++ b/tests/resume.test.js
@@ -166,6 +166,25 @@ describe('Resume — page structure', () => {
     expect(proj.querySelectorAll('h3.resume-entry__title').length).toBe(6);
   });
 
+  it('opens Projects with a Builds lead — tag, intro, and /projects/ index link (Writing pattern)', () => {
+    const proj = document.querySelector('.resume-projects');
+    const lead = proj.querySelector('.resume-projects__lead');
+    expect(lead, 'projects lead missing').not.toBeNull();
+    expect(lead.querySelector('strong')?.textContent).toBe('Builds');
+    const link = lead.querySelector('a');
+    expect(link.getAttribute('href')).toBe('/projects/');
+    expect(link.textContent).toContain('nathanpayne.com/projects');
+    const desc = proj.querySelector('.resume-projects__desc');
+    expect(desc, 'projects intro missing').not.toBeNull();
+    expect(desc.textContent).toContain('systems design exercise');
+    // The lead precedes the first project entry.
+    const firstEntry = proj.querySelector('.resume-entry');
+    expect(
+      lead.compareDocumentPosition(firstEntry) & Node.DOCUMENT_POSITION_FOLLOWING,
+      'lead should render before the first project entry',
+    ).toBeTruthy();
+  });
+
   it('links each resume project title to its matching project page', () => {
     const proj = document.querySelector('.resume-projects');
     const links = Array.from(proj.querySelectorAll('h3.resume-entry__title a'));


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Mirrors the Writing section's compact lead pattern at the top of the resume **Projects** section, so the six entries open with a pointer to the full project index:

- **Tag:** a bold **Builds** label (the `/projects` index title)
- **Link:** `nathanpayne.com/projects →` linking `/projects/` (the site's arrow convention)
- **Intro:** a one-line blurb adapted from the index deck ("Each one a real problem turned into a systems design exercise—built with AI agents from first commit to deploy.")

### Implementation

- `ProjectsSection.astro`: lead + desc paragraphs before the entries, hugging the `ResumeSection` opening tag per the #471 slot-whitespace rule.
- `global.css`: `.resume-projects__lead`/`__desc` join the existing Writing lead selectors (comma groups, no duplicated rules). A `margin-bottom` on the desc carries the gap to the first entry because `.resume-entry:first-of-type` zeroes its own top margin.
- Print: mirrors the Writing collapse — the Builds lead line prints (9.5pt, URL-suffix suppressed since the visible text is already the URL); the intro blurb is hidden.
- `specs/resume.md` documents the lead on screen and in print; `tests/resume.test.js` adds an assertion for tag/intro/link and lead-before-entries ordering.

## Self-Review

- **Correctness:** `npm test` (astro build + vitest) passes — 195/195, including the new Projects-lead test. Verified in the browser at `/resume/#projects`: lead, intro, and `/projects/` link render and match the Writing section's look.
- **Regression risk:** Low. `article.resume-entry:first-of-type` still matches the first project entry (the new siblings are `<p>` elements, so first-of-type for `article` is unchanged); existing six-entries/title-link tests still pass. Print adds one 9.5pt line to the Projects section — the #420 three-page fit has slack for it, and the fine-tune dial is documented if page 3 ever spills.
- **Style:** Reuses the existing Writing lead pattern and classes via comma selectors rather than duplicating rules; en-dash separator and `→` arrow convention match the Writing lead; em dash in the intro is unspaced per CMOS.
- **Test coverage:** New test asserts the Builds tag, the `/projects/` href, the visible URL text, the intro presence, and that the lead precedes the first entry.
- **Security/dependency hygiene:** No new dependencies, no scripts, content-only template/CSS/spec/test change.