### PR TITLE
[codex] Update blog and projects labels

### DIFF
--- a/specs/resume.md
+++ b/specs/resume.md
@@ -71,7 +71,7 @@ The `resumeProjects` collection must remain separate from the existing
 - **Writing** is a compact inline section (no collection) linking the blog
   and a few selected essays.
 - **Projects** opens with the same compact lead pattern before its entries:
-  a bold **Builds** tag, a link to the project index
+  a bold **Built with Agents** tag, a link to the project index
   (nathanpayne.com/projects → `/projects/`), and a one-line intro
   (`.resume-projects__lead` / `.resume-projects__desc`, sharing the Writing
   lead styling).
@@ -156,7 +156,7 @@ The `resumeProjects` collection must remain separate from the existing
   CTA linking nathanpayne.com/blog); the blurb, the "Selected essays" label,
   and the essay list are hidden, since their links can't be followed on
   paper. The on-screen Writing section is unchanged.
-- The **Projects** intro collapses the same way: the Builds lead
+- The **Projects** intro collapses the same way: the Built with Agents lead
   (nathanpayne.com/projects) prints; the one-line blurb is hidden.
 - Section divider rules (the `border-top` between sections) are dropped in
   print and the reserved padding reclaimed; the bold section titles carry the

--- a/src/components/ProjectHero.astro
+++ b/src/components/ProjectHero.astro
@@ -16,7 +16,7 @@
  * - `title`: project headline rendered as the page `h1`.
  * - `deck`: one-line standfirst under the title.
  * - `breadcrumbLabel`: current-page (third) crumb; first two crumbs are
- *   fixed (home → Builds).
+ *   fixed (home → Projects).
  * - `liveUrl` (optional): external product link — first CTA when present.
  * - `githubUrl`: repository link — always rendered.
  */
@@ -41,7 +41,7 @@ const { variant, title, deck, breadcrumbLabel, liveUrl, githubUrl } = Astro.prop
         class="breadcrumbs--inset"
         items={[
           { label: "Nathan Payne", href: "/" },
-          { label: "Builds", href: "/projects/" },
+          { label: "Projects", href: "/projects/" },
           { label: breadcrumbLabel },
         ]}
       />

--- a/src/components/resume/ProjectsSection.astro
+++ b/src/components/resume/ProjectsSection.astro
@@ -23,11 +23,11 @@ function displayUrl(url: string): string {
 ---
 
 <ResumeSection type="projects" heading="Projects"><p class="resume-projects__lead">
-    <strong>Builds</strong> –
+    <strong>Built with Agents</strong> –
     <a href="/projects/">nathanpayne.com/projects <span class="link-arrow" aria-hidden="true">→</span></a>
   </p>
   <p class="resume-projects__desc">
-    Each one a real problem turned into a systems design exercise—built with AI agents from first commit to deploy.
+    Each one a real problem turned into a systems design exercise—from first commit to deploy.
   </p>
   {rendered.map(({ entry, Content }) => {
     const d = entry.data;

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -5,6 +5,10 @@ import { estimateReadingMinutes } from '../../lib/reading-time';
 import Footer from '../../components/Footer.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 
+const BLOG_TITLE = 'The AI-Augmented PM';
+const BLOG_PAGE_TITLE = `${BLOG_TITLE} | Nathan Payne`;
+const BLOG_DESCRIPTION = 'A product manager’s notes on shipping real systems with AI coding agents—the architecture decisions, the failure modes, and what actually works.';
+
 const posts = (await getCollection('blog', ({ data }) => !data.draft))
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 
@@ -15,8 +19,8 @@ const jsonLd = {
       "@type": "CollectionPage",
       "@id": "https://nathanpayne.com/blog/#webpage",
       "url": "https://nathanpayne.com/blog/",
-      "name": "Blog | Nathan Payne",
-      "description": "A product manager’s notes on shipping real systems with AI coding agents—the architecture decisions, the failure modes, and what actually works.",
+      "name": BLOG_PAGE_TITLE,
+      "description": BLOG_DESCRIPTION,
       "isPartOf": { "@id": "https://nathanpayne.com/#website" },
     },
     {
@@ -48,10 +52,10 @@ function readingTime(body: string | undefined): string {
 ---
 
 <BaseLayout
-  title="Blog | Nathan Payne"
-  description="A product manager’s notes on shipping real systems with AI coding agents—the architecture decisions, the failure modes, and what actually works."
+  title={BLOG_PAGE_TITLE}
+  description={BLOG_DESCRIPTION}
   ogImage="https://nathanpayne.com/og/blog.png"
-  ogImageAlt="Blog index open graph image"
+  ogImageAlt={`${BLOG_TITLE} open graph image`}
   bodyClass="project-page blog-page"
   dataAccent="blue"
   jsonLd={jsonLd}
@@ -62,8 +66,8 @@ function readingTime(body: string | undefined): string {
       {/* ── Hero ── */}
       <header class="hero">
         <Breadcrumbs items={[{ label: "Nathan Payne", href: "/" }, { label: "Blog" }]} />
-        <h1>Field Notes</h1>
-        <p class="deck">A product manager’s notes on shipping real systems with AI coding agents—the architecture decisions, the failure modes, and what actually works.</p>
+        <h1>{BLOG_TITLE}</h1>
+        <p class="deck">{BLOG_DESCRIPTION}</p>
       </header>
 
       {/* ── Mondrian Blog Grid ──

--- a/src/pages/og-templates/blog.astro
+++ b/src/pages/og-templates/blog.astro
@@ -4,6 +4,6 @@ import OgCard from '../../layouts/OgCard.astro';
 
 <OgCard
   label="nathanpayne.com / blog"
-  heading="Field Notes"
+  heading="The AI-Augmented PM"
   description="A product manager’s notes on shipping real systems with AI coding agents—the architecture decisions, the failure modes, and what actually works."
 />

--- a/src/pages/og-templates/projects.astro
+++ b/src/pages/og-templates/projects.astro
@@ -4,6 +4,6 @@ import OgCard from '../../layouts/OgCard.astro';
 
 <OgCard
   label="nathanpayne.com / projects"
-  heading="Builds"
-  description="Builds from a product manager—each one a real problem turned into a systems design exercise."
+  heading="Built with Agents"
+  description="Each one a real problem turned into a systems design exercise—from first commit to deploy."
 />

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -57,7 +57,7 @@ const jsonLd = {
       "@id": `https://nathanpayne.com/projects/${data.slug}/#breadcrumb`,
       "itemListElement": [
         { "@type": "ListItem", "position": 1, "name": "Nathan Payne", "item": "https://nathanpayne.com/" },
-        { "@type": "ListItem", "position": 2, "name": "Builds", "item": "https://nathanpayne.com/projects/" },
+        { "@type": "ListItem", "position": 2, "name": "Projects", "item": "https://nathanpayne.com/projects/" },
         { "@type": "ListItem", "position": 3, "name": data.title, "item": `https://nathanpayne.com/projects/${data.slug}/` },
       ],
     },

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -4,6 +4,12 @@ import { getCollection } from 'astro:content';
 import Footer from '../../components/Footer.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 
+const PROJECTS_TITLE = 'Projects';
+const PROJECTS_PAGE_TITLE = `${PROJECTS_TITLE} | Nathan Payne`;
+const PROJECTS_HEADING = 'Built with Agents';
+const PROJECTS_DESCRIPTION = 'Projects from a product manager—each one a real problem turned into a systems design exercise.';
+const PROJECTS_OG_DESCRIPTION = 'Each one a real problem turned into a systems design exercise—from first commit to deploy.';
+
 const allProjects = await getCollection('projects', ({ data }) => !data.draft);
 const projects = allProjects.sort((a, b) => a.data.order - b.data.order);
 
@@ -14,8 +20,8 @@ const jsonLd = {
       "@type": "CollectionPage",
       "@id": "https://nathanpayne.com/projects/#webpage",
       "url": "https://nathanpayne.com/projects/",
-      "name": "Builds | Nathan Payne",
-      "description": "Builds from a product manager—each one a real problem turned into a systems design exercise.",
+      "name": PROJECTS_PAGE_TITLE,
+      "description": PROJECTS_DESCRIPTION,
       "isPartOf": { "@id": "https://nathanpayne.com/#website" },
     },
     {
@@ -23,7 +29,7 @@ const jsonLd = {
       "@id": "https://nathanpayne.com/projects/#breadcrumb",
       "itemListElement": [
         { "@type": "ListItem", "position": 1, "name": "Nathan Payne", "item": "https://nathanpayne.com/" },
-        { "@type": "ListItem", "position": 2, "name": "Builds", "item": "https://nathanpayne.com/projects/" },
+        { "@type": "ListItem", "position": 2, "name": PROJECTS_TITLE, "item": "https://nathanpayne.com/projects/" },
       ],
     },
   ],
@@ -31,10 +37,11 @@ const jsonLd = {
 ---
 
 <BaseLayout
-  title="Builds | Nathan Payne"
-  description="Builds from a product manager—each one a real problem turned into a systems design exercise."
+  title={PROJECTS_PAGE_TITLE}
+  description={PROJECTS_DESCRIPTION}
+  ogDescription={PROJECTS_OG_DESCRIPTION}
   ogImage="https://nathanpayne.com/og/projects.png"
-  ogImageAlt="Builds index open graph image"
+  ogImageAlt={`${PROJECTS_HEADING} projects index open graph image`}
   bodyClass="project-page blog-page"
   dataAccent="yellow"
   jsonLd={jsonLd}
@@ -44,9 +51,9 @@ const jsonLd = {
 
       {/* ── Hero ── */}
       <header class="hero">
-        <Breadcrumbs items={[{ label: "Nathan Payne", href: "/" }, { label: "Builds" }]} />
-        <h1>Builds</h1>
-        <p class="deck">Every build started as a real problem. Each one became a systems design exercise&mdash;built with AI agents from first commit to deploy, on top of an enforcement system I designed to make agent output reliable. The infrastructure behind these projects is documented in <a href="/blog/agent-approval-workflow-genesis-of-mergepath/" class="p-link">Agent Approval Workflow and the Genesis of Mergepath</a>.</p>
+        <Breadcrumbs items={[{ label: "Nathan Payne", href: "/" }, { label: PROJECTS_TITLE }]} />
+        <h1>{PROJECTS_HEADING}</h1>
+        <p class="deck">Every build started as a real problem. Each one became a systems design exercise&mdash;from first commit to deploy, on top of an enforcement system I designed to make agent output reliable. The infrastructure behind these projects is documented in <a href="/blog/agent-approval-workflow-genesis-of-mergepath/" class="p-link">Agent Approval Workflow and the Genesis of Mergepath</a>.</p>
       </header>
 
       {/* ── Project Grid ──

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -7,7 +7,7 @@ export async function GET(context: APIContext) {
     .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 
   return rss({
-    title: 'Nathan Payne—Blog',
+    title: 'The AI-Augmented PM',
     description: 'Essays and notes on AI agents, product systems, debugging, and engineering.',
     site: context.site!.toString(),
     items: posts.map((post) => ({

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4587,7 +4587,7 @@ body.resume-page {
      lead prints; the blurb, the "Selected essays" label, and the essay list
      are hidden. This also drops the page-tail the essay list used to push
      past the bottom margin. The Projects intro collapses the same way: its
-     "Builds / nathanpayne.com/projects" lead prints, the blurb is hidden. */
+     "Built with Agents / nathanpayne.com/projects" lead prints, the blurb is hidden. */
   .resume-projects__desc,
   .resume-writing__desc,
   .resume-writing__label,

--- a/tests/blog-pages.test.js
+++ b/tests/blog-pages.test.js
@@ -45,7 +45,7 @@ describe('Blog Pages', () => {
     // platforms re-fetch the image after each deploy (see commit 49d2c39).
     // The base URL stays stable; only the query varies.
     expect(ogImage?.getAttribute('content')).toMatch(
-      /^https:\/\/nathanpayne\.com\/og\/blog\.png(\?v=\d+)?$/,
+      /^https:\/\/nathanpayne\.com\/og\/blog\.png(\?v=[A-Za-z0-9_-]+)?$/,
     );
   });
 

--- a/tests/blog-pages.test.js
+++ b/tests/blog-pages.test.js
@@ -41,11 +41,11 @@ describe('Blog Pages', () => {
     expect(postLink).not.toBeNull();
     expect(ogTitle?.getAttribute('content')).toBe('The AI-Augmented PM | Nathan Payne');
     expect(twitterTitle?.getAttribute('content')).toBe('The AI-Augmented PM | Nathan Payne');
-    // og:image carries an optional ?v=<hash> cache-busting query so social
+    // og:image carries a ?v=<hash> cache-busting query so social
     // platforms re-fetch the image after each deploy (see commit 49d2c39).
     // The base URL stays stable; only the query varies.
     expect(ogImage?.getAttribute('content')).toMatch(
-      /^https:\/\/nathanpayne\.com\/og\/blog\.png(\?v=[A-Za-z0-9_-]+)?$/,
+      /^https:\/\/nathanpayne\.com\/og\/blog\.png\?v=[A-Za-z0-9_-]+$/,
     );
   });
 

--- a/tests/blog-pages.test.js
+++ b/tests/blog-pages.test.js
@@ -27,12 +27,20 @@ describe('Blog Pages', () => {
   it('blog index page has canonical metadata and links to the generated post', () => {
     setupDOM(blogIndexHtml);
 
+    const title = document.querySelector('title');
+    const heading = document.querySelector('h1');
     const canonical = document.querySelector('link[rel="canonical"]');
     const postLink = document.querySelector('a[href="/blog/six-prs-one-bug-agent-failure-modes/"]');
+    const ogTitle = document.querySelector('meta[property="og:title"]');
     const ogImage = document.querySelector('meta[property="og:image"]');
+    const twitterTitle = document.querySelector('meta[name="twitter:title"]');
 
+    expect(title?.textContent).toBe('The AI-Augmented PM | Nathan Payne');
+    expect(heading?.textContent).toBe('The AI-Augmented PM');
     expect(canonical?.getAttribute('href')).toBe('https://nathanpayne.com/blog/');
     expect(postLink).not.toBeNull();
+    expect(ogTitle?.getAttribute('content')).toBe('The AI-Augmented PM | Nathan Payne');
+    expect(twitterTitle?.getAttribute('content')).toBe('The AI-Augmented PM | Nathan Payne');
     // og:image carries an optional ?v=<hash> cache-busting query so social
     // platforms re-fetch the image after each deploy (see commit 49d2c39).
     // The base URL stays stable; only the query varies.

--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -75,8 +75,11 @@ describe('Project Pages — routes', () => {
     expect(ogDescription?.getAttribute('content')).toBe(
       'Each one a real problem turned into a systems design exercise—from first commit to deploy.',
     );
-    expect(deck?.textContent).toContain('systems design exercise—from first commit to deploy');
-    expect(deck?.textContent).not.toContain('built with AI agents');
+    const deckText = deck?.textContent?.replace(/\s+/g, ' ').trim();
+    expect(deckText).toBe(
+      'Every build started as a real problem. Each one became a systems design exercise—from first commit to deploy, on top of an enforcement system I designed to make agent output reliable. The infrastructure behind these projects is documented in Agent Approval Workflow and the Genesis of Mergepath.',
+    );
+    expect(deckText).not.toContain('built with AI agents');
   });
 
   it('the collection source has the same number of non-draft projects as the index renders', () => {

--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -56,6 +56,29 @@ describe('Project Pages — routes', () => {
     }
   });
 
+  it('the projects index keeps the route title while branding the H1 as Built with Agents', () => {
+    setupDOM(readDistHtml('projects/index.html'));
+
+    const title = document.querySelector('title');
+    const heading = document.querySelector('h1');
+    const breadcrumb = document.querySelector('.breadcrumbs');
+    const canonical = document.querySelector('link[rel="canonical"]');
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    const ogDescription = document.querySelector('meta[property="og:description"]');
+    const deck = document.querySelector('.hero .deck');
+
+    expect(title?.textContent).toBe('Projects | Nathan Payne');
+    expect(heading?.textContent).toBe('Built with Agents');
+    expect(breadcrumb?.textContent).toContain('Projects');
+    expect(canonical?.getAttribute('href')).toBe('https://nathanpayne.com/projects/');
+    expect(ogTitle?.getAttribute('content')).toBe('Projects | Nathan Payne');
+    expect(ogDescription?.getAttribute('content')).toBe(
+      'Each one a real problem turned into a systems design exercise—from first commit to deploy.',
+    );
+    expect(deck?.textContent).toContain('systems design exercise—from first commit to deploy');
+    expect(deck?.textContent).not.toContain('built with AI agents');
+  });
+
   it('the collection source has the same number of non-draft projects as the index renders', () => {
     const sourceFiles = readdirSync(CONTENT).filter((f) => f.endsWith('.md'));
     const nonDraftSources = sourceFiles.filter((f) => {

--- a/tests/resume.test.js
+++ b/tests/resume.test.js
@@ -166,18 +166,19 @@ describe('Resume — page structure', () => {
     expect(proj.querySelectorAll('h3.resume-entry__title').length).toBe(6);
   });
 
-  it('opens Projects with a Builds lead — tag, intro, and /projects/ index link (Writing pattern)', () => {
+  it('opens Projects with a Built with Agents lead — tag, intro, and /projects/ index link (Writing pattern)', () => {
     const proj = document.querySelector('.resume-projects');
     expect(proj, 'projects section missing').not.toBeNull();
     const lead = proj.querySelector('.resume-projects__lead');
     expect(lead, 'projects lead missing').not.toBeNull();
-    expect(lead.querySelector('strong')?.textContent).toBe('Builds');
+    expect(lead.querySelector('strong')?.textContent).toBe('Built with Agents');
     const link = lead.querySelector('a');
     expect(link.getAttribute('href')).toBe('/projects/');
     expect(link.textContent).toContain('nathanpayne.com/projects');
     const desc = proj.querySelector('.resume-projects__desc');
     expect(desc, 'projects intro missing').not.toBeNull();
-    expect(desc.textContent).toContain('systems design exercise');
+    expect(desc.textContent).toContain('systems design exercise—from first commit to deploy.');
+    expect(desc.textContent).not.toContain('built with AI agents');
     // The lead precedes the first project entry.
     const firstEntry = proj.querySelector('.resume-entry');
     expect(


### PR DESCRIPTION
Authoring-Agent: codex

## Summary
- Renames the blog surface from Field Notes to The AI-Augmented PM across the blog index, OG card, RSS title, and covered metadata.
- Resolves #490 by branding the resume Projects lead and projects index H1 as Built with Agents while keeping /projects/ route, breadcrumbs, and title metadata as Projects.
- Updates the projects OG card/subtitle to the requested first-commit-to-deploy sentence and keeps the relevant resume/project specs and tests in sync.

Closes #490

## Testing
- [x] Tests pass: `npm run test` (21 files / 196 tests)
- [x] Build succeeds: covered by `npm run test`
- [x] E2E passes: `npm run test:e2e` (299 passed, 33 skipped)
- [x] Manual verification completed: browser-checked `/projects/` and `/resume/` desktop/mobile copy and link targets, verified regenerated `dist/og/projects.png`, rendered `/resume/` to a temporary PDF and confirmed 3 pages with `qpdf --show-npages`.

## Self-Review
- [x] Correctness: issue #490 copy and the follow-up OG sentence are applied exactly; `/projects/` route/link targets remain unchanged.
- [x] Regression risk: limited to content/metadata/OG template surfaces; homepage Builds panel remains intentionally unchanged.
- [x] Style and conventions: follows existing Astro constants and test patterns.
- [x] Test coverage: added focused Vitest assertions for blog title metadata, projects index branding/OG metadata, and resume lead copy.
- [x] Security and dependency hygiene: no dependency or secret changes.