### PR TITLE
[codex] Update projects copy and order

### DIFF
--- a/src/content/projects/device-source-of-truth.md
+++ b/src/content/projects/device-source-of-truth.md
@@ -3,7 +3,7 @@ title: "Device Source of Truth"
 slug: "device-source-of-truth"
 description: "A single web application for understanding partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN."
 kicker: "AI × Enterprise × Data"
-order: 5
+order: 4
 screenshotAspect: "wide"
 screenshotSrc: "/images/projects/device-source-of-truth-hero.png"
 accentColor: "#5b5f64"

--- a/src/content/projects/friends-and-family-billing.md
+++ b/src/content/projects/friends-and-family-billing.md
@@ -3,7 +3,7 @@ title: "Friends & Family Billing"
 slug: "friends-and-family-billing"
 description: "A cloud-synced billing tool that turns recurring shared costs into clear invoices, payment tracking, and shareable summaries."
 kicker: "AI × Utility × Finance"
-order: 4
+order: 3
 screenshotAspect: "wide"
 screenshotSrc: "/images/projects/friends-and-family-billing-hero-v2.png"
 accentColor: "#2080ca"

--- a/src/content/projects/matchline.md
+++ b/src/content/projects/matchline.md
@@ -1,7 +1,7 @@
 ---
 title: "Matchline"
 slug: "matchline"
-description: "A career CRM for one person running a serious job search. Turns work history into structured, reusable evidence, maps that evidence against specific job requirements, and generates applications grounded in what the user has actually done. Not a resume builder—a discipline."
+description: "A career CRM for one person running a serious job search. Turns work history into structured, reusable evidence, maps that evidence against specific job requirements, and generates applications grounded in demonstrated work. Not a resume builder—a discipline."
 kicker: "AI × Product × Career Tools"
 order: 1
 status: "IN PROGRESS"

--- a/src/content/projects/swipe-watch.md
+++ b/src/content/projects/swipe-watch.md
@@ -3,7 +3,7 @@ title: "Swipe Watch"
 slug: "swipe-watch"
 description: "A swipe-based discovery experiment for Disney+ and Hulu that turns taste signals into a faster, more active recommendation loop."
 kicker: "AI × Consumer × Streaming"
-order: 3
+order: 5
 screenshotAspect: "narrow"
 screenshotSrc: "/images/projects/swipe-watch-hero.gif"
 muxPlaybackId: "wNCRY97981o2uDAJrJ3ExPeK379yldRRFJgUIgSYz00k"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -121,9 +121,8 @@ const homepageJsonLd = {
         <div class="panel-label" tabindex="0" role="button" aria-label="Open Projects section">Projects</div>
         <div class="panel-content">
           <div class="content-inner">
-            <span class="eyebrow">Built with Agents</span>
-            <h2>Projects</h2>
-            <p>Every project started as a real problem. Each one was built end-to-end with AI agents—Claude Code, Codex, and Cursor—within a multi-agent code review system I designed to catch failure modes that agents don’t catch on their own.</p>
+            <h2>Built with Agents</h2>
+            <p>Every project started as a real problem and shipped end-to-end—Claude Code, Codex, and Cursor, working inside a multi-agent review system I designed to catch the failure modes agents miss.</p>
             <div class="project-list">
               <div class="project-item">
                 <div class="p-head">
@@ -135,31 +134,31 @@ const homepageJsonLd = {
                 <div class="p-head">
                   <a class="p-name p-name-link" href="/projects/matchline/" aria-label="Read the Matchline project page">Matchline<span class="link-arrow" aria-hidden="true">→</span></a>
                 </div>
-                <p>A career CRM for one person running a serious job search. Turns work history into structured, reusable evidence, maps that evidence against specific job requirements, and generates applications grounded in what the user has actually done.</p>
+                <p>A career CRM for one person running a serious job search—turns work history into structured, reusable evidence, maps it against specific job requirements, and generates applications grounded in demonstrated work.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">
                   <a class="p-name p-name-link" href="/projects/override/" aria-label="Read the Override project page">Override<span class="link-arrow" aria-hidden="true">→</span></a>
                 </div>
-                <p>The financial operating system for Broadway productions. Structure your capitalization, model investor returns, manage ownership, and share live deals with backers—without spreadsheets or PDF workflows.</p>
-              </div>
-              <div class="project-item">
-                <div class="p-head">
-                  <a class="p-name p-name-link" href="/projects/swipe-watch/" aria-label="Read the Swipe Watch project page">Swipe Watch<span class="link-arrow" aria-hidden="true">→</span></a>
-                </div>
-                <p>A swipe-based discovery experiment for Disney+ and Hulu. Train your recommendations, earn coins, and build your next watchlist—built in vanilla JS over a weekend.</p>
+                <p>A financial operating system for Broadway productions—models capitalization and investor returns, manages ownership, and shares live deals with backers without spreadsheet or PDF workflows.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">
                   <a class="p-name p-name-link" href="/projects/friends-and-family-billing/" aria-label="Read the Friends and Family Billing project page">Friends &amp; Family Billing<span class="link-arrow" aria-hidden="true">→</span></a>
                 </div>
-                <p>Cloud-synced shared-bill coordination for families and friend groups, turning monthly and annual costs into clear annual invoices, payment tracking, and shareable summaries.</p>
+                <p>Cloud-synced shared-bill coordination for families and friend groups—turns recurring costs into clear annual invoices, payment tracking, and shareable summaries.</p>
               </div>
               <div class="project-item">
                 <div class="p-head">
                   <a class="p-name p-name-link" href="/projects/device-source-of-truth/" aria-label="Read the Device Source of Truth project page">Device Source of Truth<span class="link-arrow" aria-hidden="true">→</span></a>
                 </div>
-                <p>A single web application for understanding partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN.</p>
+                <p>A single web application that tracks partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN.</p>
+              </div>
+              <div class="project-item">
+                <div class="p-head">
+                  <a class="p-name p-name-link" href="/projects/swipe-watch/" aria-label="Read the Swipe Watch project page">Swipe Watch<span class="link-arrow" aria-hidden="true">→</span></a>
+                </div>
+                <p>A swipe-based discovery experiment for Disney+ and Hulu that turns recommendation training and watchlist building into a game—built in vanilla JS over a weekend.</p>
               </div>
             </div>
             <div class="stack-ribbon">

--- a/src/pages/og-templates/projects/matchline.astro
+++ b/src/pages/og-templates/projects/matchline.astro
@@ -5,6 +5,6 @@ import OgCard from '../../../layouts/OgCard.astro';
 <OgCard
   label="nathanpayne.com / projects"
   heading="Matchline"
-  description="A career CRM for one person running a serious job search. Turns work history into structured, reusable evidence and assembles applications grounded in what the user has actually done."
+  description="A career CRM for one person running a serious job search. Turns work history into structured, reusable evidence and assembles applications grounded in demonstrated work."
   meta="AI · Product · Career Tools"
 />

--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -20,6 +20,24 @@ const projectSlugs = [
   'swipe-watch',
 ];
 
+const canonicalProjectCards = [
+  { title: 'Mergepath', href: '/projects/mergepath/' },
+  { title: 'Matchline', href: '/projects/matchline/' },
+  { title: 'Override', href: '/projects/override/' },
+  { title: 'Friends & Family Billing', href: '/projects/friends-and-family-billing/' },
+  { title: 'Device Source of Truth', href: '/projects/device-source-of-truth/' },
+  { title: 'Swipe Watch', href: '/projects/swipe-watch/' },
+];
+
+const homepageProjectDescriptions = [
+  'A deterministic repository standard that keeps humans and AI coding agents aligned—the enforcement layer underneath every other project on this site.',
+  'A career CRM for one person running a serious job search—turns work history into structured, reusable evidence, maps it against specific job requirements, and generates applications grounded in demonstrated work.',
+  'A financial operating system for Broadway productions—models capitalization and investor returns, manages ownership, and shares live deals with backers without spreadsheet or PDF workflows.',
+  'Cloud-synced shared-bill coordination for families and friend groups—turns recurring costs into clear annual invoices, payment tracking, and shareable summaries.',
+  'A single web application that tracks partner-device hardware, DRM, codec support, and operational readiness across Disney+, Hulu, and ESPN.',
+  'A swipe-based discovery experiment for Disney+ and Hulu that turns recommendation training and watchlist building into a game—built in vanilla JS over a weekend.',
+];
+
 // Projects without a deployed live URL — the "View Live Product" CTA
 // is suppressed on the detail page, the project card, and the homepage
 // Builds section. The SoftwareApplication JSON-LD entity is also
@@ -80,6 +98,45 @@ describe('Project Pages — routes', () => {
       'Every build started as a real problem. Each one became a systems design exercise—from first commit to deploy, on top of an enforcement system I designed to make agent output reliable. The infrastructure behind these projects is documented in Agent Approval Workflow and the Genesis of Mergepath.',
     );
     expect(deckText).not.toContain('built with AI agents');
+  });
+
+  it('the homepage Projects panel keeps wayfinding labels while promoting the Built with Agents heading', () => {
+    setupDOM(readDistHtml('index.html'));
+
+    const panel = document.querySelector('[data-panel="projects"]');
+    const panelLabel = panel?.querySelector('.panel-label');
+    const projectItems = [...panel.querySelectorAll('.project-item')];
+
+    expect(panel, 'homepage Projects panel missing').not.toBeNull();
+    expect(panel.getAttribute('data-label')).toBe('Projects');
+    expect(panelLabel?.textContent).toBe('Projects');
+    expect(panelLabel?.getAttribute('aria-label')).toBe('Open Projects section');
+    expect(panel.querySelector('.content-inner > .eyebrow')).toBeNull();
+    expect(panel.querySelector('h2')?.textContent).toBe('Built with Agents');
+    expect(panel.querySelector('.content-inner > p')?.textContent).toBe(
+      'Every project started as a real problem and shipped end-to-end—Claude Code, Codex, and Cursor, working inside a multi-agent review system I designed to catch the failure modes agents miss.',
+    );
+    expect(projectItems.map((item) => item.querySelector('.p-name')?.textContent.replace('→', '').trim())).toEqual(
+      canonicalProjectCards.map((card) => card.title),
+    );
+    expect(projectItems.map((item) => item.querySelector('.p-name')?.getAttribute('href'))).toEqual(
+      canonicalProjectCards.map((card) => card.href),
+    );
+    expect(projectItems.map((item) => item.querySelector('p')?.textContent)).toEqual(homepageProjectDescriptions);
+    expect(homepageProjectDescriptions.join(' ')).not.toMatch(/\b(?:you|your)\b/i);
+  });
+
+  it('the projects index renders the canonical project order and updated Matchline copy', () => {
+    setupDOM(readDistHtml('projects/index.html'));
+
+    const links = [...document.querySelectorAll('.blog-grid .post-title a')];
+    const matchlineCard = links.find((link) => link.textContent === 'Matchline')?.closest('.post-card');
+    const matchlineDescription = matchlineCard?.querySelector('.post-desc')?.textContent;
+
+    expect(links.map((link) => link.textContent)).toEqual(canonicalProjectCards.map((card) => card.title));
+    expect(links.map((link) => link.getAttribute('href'))).toEqual(canonicalProjectCards.map((card) => card.href));
+    expect(matchlineDescription).toContain('generates applications grounded in demonstrated work');
+    expect(matchlineDescription).not.toContain('what the user has actually done');
   });
 
   it('the collection source has the same number of non-draft projects as the index renders', () => {


### PR DESCRIPTION
Authoring-Agent: codex

## Summary
- Promotes the homepage Projects panel heading to "Built with Agents" and removes the duplicate eyebrow.
- Normalizes homepage project-card copy to one descriptive voice and removes second-person product-marketing phrasing.
- Applies the canonical project order on the homepage and `/projects/`, and updates Matchline's index/detail OG phrasing to "demonstrated work".
- Adds focused tests for the homepage Projects panel contract and `/projects/` ordering/copy.

Closes #493
Closes #494

## Self-Review
- Confirmed the homepage panel label, `data-label`, and `aria-label="Open Projects section"` still read "Projects".
- Confirmed `/resume/` source files were not touched.
- Confirmed the home OG template is generic and does not bake in the changed Projects panel copy, so no checked-in home OG asset was regenerated.
- Confirmed the rendered desktop and mobile homepage have no horizontal overflow with the longer "Built with Agents" heading.

## Validation
- `npm run test -- project-pages.test.js`
- `npm run test`
- `npm run test:e2e`
- `npm run lint`
- Local Playwright rendered check against `http://127.0.0.1:4321/` and `/projects/` for order, headings, Matchline copy, overflow, and console errors.
