### PR TITLE
Fix projects accent cycle

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -122,7 +122,7 @@ const homepageJsonLd = {
         <div class="panel-content">
           <div class="content-inner">
             <h2>Built with Agents</h2>
-            <p>Every project started as a real problem and shipped end-to-end—Claude Code, Codex, and Cursor, working inside a multi-agent review system I designed to catch the failure modes agents miss.</p>
+            <p>Every project started as a real problem and shipped end-to-end—Claude Code, Codex, and Cursor—within a multi-agent review system I designed to catch the failure modes agents miss.</p>
             <div class="project-list">
               <div class="project-item">
                 <div class="p-head">

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -12,6 +12,14 @@ const PROJECTS_OG_DESCRIPTION = 'Each one a real problem turned into a systems d
 
 const allProjects = await getCollection('projects', ({ data }) => !data.draft);
 const projects = allProjects.sort((a, b) => a.data.order - b.data.order);
+const projectIndexRows = [
+  { rowClass: 'grid-row--1', accentClasses: ['accent-red', 'accent-blue'] },
+  { rowClass: 'grid-row--2', accentClasses: ['accent-black'] },
+  { rowClass: 'grid-row--3', accentClasses: ['accent-white'] },
+  { rowClass: 'grid-row--4', accentClasses: ['accent-yellow', 'accent-paper'] },
+  { rowClass: 'grid-row--overflow-a', accentClasses: ['accent-lightblue'] },
+  { rowClass: 'grid-row--overflow-b', accentClasses: ['accent-red'] },
+];
 
 const jsonLd = {
   "@context": "https://schema.org",
@@ -57,11 +65,12 @@ const jsonLd = {
       </header>
 
       {/* ── Project Grid ──
-           Rows 1–4 use fixed Mondrian accent blocks.
-           Projects beyond 4 overflow into alternating a/b rows. */}
+           Accent blocks follow the six-row Mondrian sequence captured in
+           #493/#494 follow-up screenshots, then restart for row 7+. */}
       <div class="blog-grid">
 
         {projects.map((project, i) => {
+          const row = projectIndexRows[i % projectIndexRows.length];
           const card = (
             <article class="post-card">
               {/* Status kicker renders on every card — consistency in the
@@ -80,53 +89,12 @@ const jsonLd = {
             </article>
           );
 
-          if (i === 0) return (
-            <div class="grid-row--1">
-              {card}
-              <div class="accent-red" aria-hidden="true"></div>
-              <div class="accent-blue" aria-hidden="true"></div>
-            </div>
-          );
-          // Row 2 hosts the in-progress anchor project. Black is the
-          // last unused Mondrian primary on the projects index and
-          // becomes Matchline's color block — unmarked composition,
-          // not a logo surface (the wordmark only renders on the
-          // detail page). See #275.
-          if (i === 1) return (
-            <div class="grid-row--2">
-              {card}
-              <div class="accent-black" aria-hidden="true"></div>
-            </div>
-          );
-          if (i === 2) return (
-            <div class="grid-row--3">
-              {card}
-              <div class="accent-white" aria-hidden="true"></div>
-            </div>
-          );
-          // Row 4 inherits the yellow that previously lived in row 2,
-          // so the Mondrian composition still has all four primaries
-          // visible on the index after the row 2 swap above.
-          if (i === 3) return (
-            <div class="grid-row--4">
-              {card}
-              <div class="accent-yellow" aria-hidden="true"></div>
-              <div class="accent-paper" aria-hidden="true"></div>
-            </div>
-          );
-          // Projects 5+ use alternating overflow rows. FFB gets the
-          // light-blue accent to match its detail-page variant; DSoT
-          // gets red so the bottom of the grid keeps a Mondrian
-          // primary in rotation rather than fading to paper.
-          const accentBySlug = {
-            'friends-and-family-billing': 'accent-lightblue',
-            'device-source-of-truth': 'accent-red',
-          };
-          const accentClass = accentBySlug[project.data.slug] ?? 'accent-paper';
           return (
-            <div class={i % 2 === 0 ? 'grid-row--overflow-a' : 'grid-row--overflow-b'}>
+            <div class={row.rowClass}>
               {card}
-              <div class={accentClass} aria-hidden="true"></div>
+              {row.accentClasses.map((accentClass) => (
+                <div class={accentClass} aria-hidden="true"></div>
+              ))}
             </div>
           );
         })}

--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -38,6 +38,15 @@ const homepageProjectDescriptions = [
   'A swipe-based discovery experiment for Disney+ and Hulu that turns recommendation training and watchlist building into a game—built in vanilla JS over a weekend.',
 ];
 
+const projectIndexAccentRows = [
+  { rowClass: 'grid-row--1', accentClasses: ['accent-red', 'accent-blue'] },
+  { rowClass: 'grid-row--2', accentClasses: ['accent-black'] },
+  { rowClass: 'grid-row--3', accentClasses: ['accent-white'] },
+  { rowClass: 'grid-row--4', accentClasses: ['accent-yellow', 'accent-paper'] },
+  { rowClass: 'grid-row--overflow-a', accentClasses: ['accent-lightblue'] },
+  { rowClass: 'grid-row--overflow-b', accentClasses: ['accent-red'] },
+];
+
 // Projects without a deployed live URL — the "View Live Product" CTA
 // is suppressed on the detail page, the project card, and the homepage
 // Builds section. The SoftwareApplication JSON-LD entity is also
@@ -114,7 +123,7 @@ describe('Project Pages — routes', () => {
     expect(panel.querySelector('.content-inner > .eyebrow')).toBeNull();
     expect(panel.querySelector('h2')?.textContent).toBe('Built with Agents');
     expect(panel.querySelector('.content-inner > p')?.textContent).toBe(
-      'Every project started as a real problem and shipped end-to-end—Claude Code, Codex, and Cursor, working inside a multi-agent review system I designed to catch the failure modes agents miss.',
+      'Every project started as a real problem and shipped end-to-end—Claude Code, Codex, and Cursor—within a multi-agent review system I designed to catch the failure modes agents miss.',
     );
     expect(projectItems.map((item) => item.querySelector('.p-name')?.textContent.replace('→', '').trim())).toEqual(
       canonicalProjectCards.map((card) => card.title),
@@ -137,6 +146,24 @@ describe('Project Pages — routes', () => {
     expect(links.map((link) => link.getAttribute('href'))).toEqual(canonicalProjectCards.map((card) => card.href));
     expect(matchlineDescription).toContain('generates applications grounded in demonstrated work');
     expect(matchlineDescription).not.toContain('what the user has actually done');
+  });
+
+  it('the projects index keeps its Mondrian accent color sequence by row position', () => {
+    setupDOM(readDistHtml('projects/index.html'));
+
+    const rows = [...document.querySelectorAll('.blog-grid > div')];
+    const titleByRow = rows.map((row) => row.querySelector('.post-title a')?.textContent);
+    const accentClassesByRow = rows.map((row) =>
+      [...row.querySelectorAll('[aria-hidden="true"]')].map((accent) =>
+        [...accent.classList].find((className) => className.startsWith('accent-')),
+      ),
+    );
+
+    expect(titleByRow).toEqual(canonicalProjectCards.map((card) => card.title));
+    expect(rows.map((row) => [...row.classList].find((className) => className.startsWith('grid-row--')))).toEqual(
+      projectIndexAccentRows.map((row) => row.rowClass),
+    );
+    expect(accentClassesByRow).toEqual(projectIndexAccentRows.map((row) => row.accentClasses));
   });
 
   it('the collection source has the same number of non-draft projects as the index renders', () => {


### PR DESCRIPTION
Authoring-Agent: codex

## Summary
- Replace project-slug accent assignment with a six-row project-index sequence that repeats for additional rows.
- Keep the /projects/ row colors aligned with the provided screenshots after project reordering.
- Update the homepage Projects copy to the requested sentence.
- Add regression coverage for project-index row classes, accent classes, and homepage copy.

## Root Cause
The projects index used slug-specific accents for overflow rows. After the project order changed, colors followed individual projects instead of the row-position sequence shown in the screenshots.

## Self-Review
- Verified the row sequence is position-based and uses modulo cycling for row 7+.
- Checked that only the intended homepage/project index/test files are included.
- Confirmed the existing untracked bugs/ audit files remain unstaged and out of scope.

## Validation
- Browser readback on http://127.0.0.1:4321/: homepage Projects copy includes the final period.
- Browser readback on http://127.0.0.1:4321/projects/: rows render Mergepath red/blue, Matchline black, Override white, Friends & Family Billing yellow/paper, Device Source of Truth lightblue, Swipe Watch red; no console errors.
- npm run test
- npm run test:e2e