### PR TITLE
Opt the home OG card into the 1930 register

### DIFF
--- a/docs/css-architecture.md
+++ b/docs/css-architecture.md
@@ -93,6 +93,11 @@ plane values (the interior default), and the homepage—which uses no
 (`index.astro` only). `data-palette` selects what the plane tokens resolve
 to; `data-accent` selects which token a page accents with.
 
+Build-time OG cards follow the same per-page register boundary where the card
+represents a page: `og-templates/home.astro` passes `palette="1930"` to
+`OgCard.astro`, so `home.png` matches the homepage register. Other OG cards do
+not pass a palette and stay on the 1921 `:root` default.
+
 | Page | Accent source |
 |---|---|
 | Blog post | `dataAccent="red"` (`BlogPost.astro`) |

--- a/src/layouts/OgCard.astro
+++ b/src/layouts/OgCard.astro
@@ -17,9 +17,10 @@ interface Props {
   heading: string;
   description?: string;
   meta?: string;
+  palette?: '1930';
 }
 
-const { label, heading, description, meta } = Astro.props;
+const { label, heading, description, meta, palette } = Astro.props;
 const headingClass = [
   'og-heading',
   !description ? 'og-heading--title-only' : '',
@@ -57,7 +58,7 @@ const headingClass = [
     }
   </style>
 </head>
-<body class="og-body">
+<body class="og-body" data-palette={palette}>
   <div class="og-shell">
     <div class="og-card">
       <div class="og-content">

--- a/src/pages/og-templates/home.astro
+++ b/src/pages/og-templates/home.astro
@@ -6,4 +6,5 @@ import OgCard from '../../layouts/OgCard.astro';
   label="nathanpayne.com"
   heading="Nathan Payne"
   description="Product manager working at the intersection of AI coding agents and shipped software. Based in San Francisco. Open to new roles and collaborations."
+  palette="1930"
 />

--- a/tests/og-palette.test.js
+++ b/tests/og-palette.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative, resolve } from 'path';
+
+const ROOT = resolve(__dirname, '..');
+const OG_TEMPLATES = resolve(ROOT, 'src/pages/og-templates');
+const OG_CARD = resolve(ROOT, 'src/layouts/OgCard.astro');
+
+function findAstroFiles(dir) {
+  const files = [];
+
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    if (statSync(fullPath).isDirectory()) {
+      files.push(...findAstroFiles(fullPath));
+    } else if (entry.endsWith('.astro')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+describe('OG palette register boundary', () => {
+  it('lets OgCard accept a 1930 register opt-in on the body element', () => {
+    const source = readFileSync(OG_CARD, 'utf-8');
+
+    expect(source).toMatch(/palette\?:\s*'1930';/);
+    expect(source).toMatch(/data-palette=\{palette\}/);
+  });
+
+  it('opts only the homepage OG template into the 1930 register', () => {
+    const templateSources = findAstroFiles(OG_TEMPLATES).map((file) => ({
+      path: relative(OG_TEMPLATES, file),
+      source: readFileSync(file, 'utf-8'),
+    }));
+    const paletteUsers = templateSources
+      .filter(({ source }) => /palette="1930"/.test(source))
+      .map(({ path }) => path)
+      .sort();
+
+    expect(paletteUsers).toEqual(['home.astro']);
+  });
+});


### PR DESCRIPTION
Authoring-Agent: codex

Closes #502

Resolves the OG register decision as **Option B**: each OG card follows its page's register. `OgCard.astro` gains an optional `palette?: '1930'` prop rendered as `data-palette` on its body (mirroring BaseLayout's pattern — attribute omitted when unset); only `og-templates/home.astro` passes it, so `home.png` renders the 1930 register while the other 13 cards stay on the 1921 `:root` default.

## What changed

- `OgCard.astro`: optional `palette` prop → `data-palette` on `.og-body` (4 lines)
- `og-templates/home.astro`: passes `palette="1930"` (1 line)
- `docs/css-architecture.md`: OG register boundary documented next to the `data-palette` paragraph, per the issue's third task
- `tests/og-palette.test.js` (new): locks the boundary — OgCard accepts the opt-in, and a directory sweep asserts `home.astro` is the *only* template using it, so a future OG template can't silently opt in

## Validation performed

- `npm test`: build clean, 211/211 vitest (2 new). Playwright: 299 passed, 0 failed (CSS untouched; included for the record).
- **Build-and-diff per the issue's verification step:** rebuilt and visually inspected the generated PNGs — `dist/og/home.png` renders cadmium red `#da2418` / bright yellow `#f0c800` / deep blue `#0a5c9e` (1930); `dist/og/blog.png` renders vermilion `#e8784a` / muted yellow `#e3d477` / cerulean `#2080ca` (1921). The register split is plainly visible side by side and each card matches its page.
- OG images are built at deploy (not committed), so production share cards update on merge automatically.

## Self-Review

- **Correctness:** the prop type (`'1930'` literal) and attribute mechanism are identical to BaseLayout's `dataPalette`, so the CSS override block applies unmodified; undefined props render no attribute in Astro, leaving the other 13 cards bit-identical to their current output.
- **Regression risk:** Minimal — 5 lines of template change scoped to OG rendering; no site page is touched. The realistic failure (some other template accidentally opting in later) is exactly what the new directory-sweep test guards.
- **Style:** mirrors the established `data-palette` pattern; docs updated in the same section that documents the page-level boundary.
- **Test coverage:** the decision is encoded as a test, not just prose — same pattern as the #500 frontmatter-hygiene and #503 acceptance-grep tests.
- **Security/dependency hygiene:** no dependencies, scripts, or secrets; template + docs + test only.

Implementation authored by Codex on this branch; validated, committed, and shepherded by Claude. Decision (Option B over uniform-1921) made by the human per #502's recommendation.
