### PR TITLE
Update color token doc to the split palette registers

### DIFF
--- a/docs/agents/code-modification-rules.md
+++ b/docs/agents/code-modification-rules.md
@@ -5,7 +5,7 @@
 #### Color
 
 Plane colors are split into two *registers* (#499/#500). `:root` carries the
-1921 register—the interior default every page uses unless it opts out:
+1921 register—the interior default for every page:
 
 ```
 --ink:        #11100d        (near-black text)

--- a/docs/agents/code-modification-rules.md
+++ b/docs/agents/code-modification-rules.md
@@ -3,17 +3,41 @@
 ### Design Tokens
 
 #### Color
+
+Plane colors are split into two *registers* (#499/#500). `:root` carries the
+1921 register—the interior default every page uses unless it opts out:
+
 ```
---ink:       #11100d    (near-black text)
---paper:     #ffffff    (white background)
---red:       #c11d19    (red cell bg)
---yellow:    #d9b111    (yellow cell bg)
---blue:      #223f89    (blue cell bg)
---rule:      rgba(17, 16, 13, 0.18) (divider/border color)
---cream:     #f5f0e4    (light background)
---surface:   rgba(244, 239, 229, 0.96) (semi-transparent)
---grid-border: #1a1814  (separator color)
+--ink:        #11100d        (near-black text)
+--paper:      #ffffff        (white background)
+--red:        #e8784a        (red plane, 1921 register)
+--yellow:     #e3d477        (yellow plane, 1921 register)
+--blue:       #2080ca        (blue plane, 1921 register)
+--lightblue:  var(--blue)    (alias—resolves to the active register's blue)
+--gray-plane: #dde1e5        (gray plane)
+--rule:       var(--ink-18)  (divider/border—18% ink via the --ink-NN ramp, #466/#503)
+--cream:      #f5f0e4        (light background)
+--surface:    rgba(244, 239, 229, 0.96) (semi-transparent)
+--grid-border: #1a1814       (separator color)
 ```
+
+A `[data-palette="1930"]` block overrides the three primary planes with the
+high-chroma 1930 register:
+
+```
+--red:       #da2418
+--yellow:    #f0c800
+--blue:      #0a5c9e
+```
+
+The opt-in is per page: `BaseLayout` accepts a `dataPalette?: '1930'` prop
+and stamps `data-palette` on `<html>` and `<body>`. Only the homepage
+(`src/pages/index.astro`) passes `dataPalette="1930"`; its build-time OG
+card (`og-templates/home.astro`) passes the matching `palette="1930"` prop
+to `OgCard.astro` so `home.png` renders in the same register (#504). All
+other pages and OG cards stay on the 1921 `:root` default. Never hard-code
+register hexes in page styles—reference the tokens so `data-palette`
+controls what the plane tokens resolve to.
 
 All cells transition to a warm parchment tone when opened.
 


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

`docs/agents/code-modification-rules.md` § Design Tokens > Color still documented the pre-June-2026 palette (`--red: #c11d19`, `--yellow: #d9b111`, `--blue: #223f89`) and the alpha-baked `--rule` literal that #503 routed through the `--ink-NN` ramp. This rewrites the section against the current `src/styles/global.css`:

- **1921 register (`:root`, interior default):** `--red: #e8784a`, `--yellow: #e3d477`, `--blue: #2080ca`, `--lightblue: var(--blue)`, `--gray-plane: #dde1e5` (#499/#500)
- **1930 register (`[data-palette="1930"]` override):** `--red: #da2418`, `--yellow: #f0c800`, `--blue: #0a5c9e`
- **Per-page opt-in:** BaseLayout's `dataPalette?: '1930'` prop stamps `data-palette` on `<html>`/`<body>`; only `index.astro` opts in, plus the matching `palette="1930"` on the home OG card (#504)
- `--rule` updated to its current `var(--ink-18)` definition (#466/#503)

All values verified against `global.css` `:root` (lines 33–40) and the `[data-palette="1930"]` block (lines 228–232) at HEAD. The rest of the doc is untouched. Terminology matches `docs/css-architecture.md` § register description.

## Self-Review

- **Correctness:** Every hex, alias, and prop name was read from `global.css`, `BaseLayout.astro`, `OgCard.astro`, and `index.astro` at `origin/main` HEAD (8bebc31) before writing, not recalled from the PR descriptions. The doc now matches the code exactly.
- **Regression risk:** None at runtime—doc-only diff (1 file, +33/−9). No styles, templates, or build files touched.
- **Style:** Keeps the section's existing token-table format and parenthetical descriptions; em dashes unspaced per house style; register terminology ("register", "opt-in", "1921/1930") mirrors `css-architecture.md` so the two docs don't drift apart semantically.
- **Test coverage:** No test changes needed—`check_duplicate_docs` covers root-vs-tool-folder duplication only, and the vitest register lock added in #504 already pins the code behavior this doc describes.
- **Security/dependency hygiene:** No dependencies, secrets, or credentials involved. Hex color values and CSS custom property names only.
