### PR TITLE
[codex] Guard analytics hover tracking

### DIFF
--- a/specs/analytics.md
+++ b/specs/analytics.md
@@ -7,11 +7,12 @@ title: Analytics
 
 ## Overview
 
-Google Analytics (gtag) fires a `section_view` event once per panel on first hover, guarded by a `typeof gtag` check.
+Google Analytics (gtag) fires a `section_view` event once per panel on first hover on hover-capable (fine-pointer) devices, guarded by a `typeof gtag` check.
 
 ## Requirements
 
-1. The `gtag` function is called with `'event', 'section_view'` when a panel is first hovered.
+1. The `gtag` function is called with `'event', 'section_view'` when a panel is first hovered on a hover-capable device.
 2. Each panel only fires the analytics event once (tracked via a `tracked` boolean closure).
 3. The event includes `section_name` matching the panel's `data-panel` attribute.
 4. The analytics call is guarded with `typeof gtag !== 'function'` to avoid errors when gtag is absent.
+5. The event only fires on hover-capable devices, gated by `canHover()` (`(hover: hover) and (pointer: fine)`). Touch/coarse-pointer devices that synthesize `mouseenter` must not record `section_view`.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -711,7 +711,7 @@ const homepageJsonLd = {
       panels.forEach((panel) => {
         let tracked = false;
         panel.addEventListener('mouseenter', () => {
-          if (tracked || typeof gtag !== 'function') return;
+          if (!canHover() || tracked || typeof gtag !== 'function') return;
           tracked = true;
           gtag('event', 'section_view', {
             section_name: panel.dataset.panel,

--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -86,6 +86,31 @@ describe('Analytics', () => {
     }).not.toThrow();
   });
 
+  it('does not fire section_view on non-hover devices', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn((query) => ({
+        matches: query.includes('max-width: 1023px'),
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        onchange: null,
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    const gtagMock = vi.fn();
+    window.gtag = gtagMock;
+
+    loadScript();
+
+    const panel = document.querySelector('[data-panel="about"]');
+    panel.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+
+    expect(gtagMock).not.toHaveBeenCalledWith('event', 'section_view', expect.any(Object));
+  });
+
   it('guards analytics with typeof check', () => {
     expect(panelScript).toContain("typeof gtag !== 'function'");
   });


### PR DESCRIPTION
## Summary
- Gate homepage `section_view` analytics behind hover-capable pointers (`canHover()`).
- Add a regression test so touch/mobile synthetic `mouseenter` events do not record hover analytics.
- Sync `specs/analytics.md` to document the hover-capability gate.

## Root Cause
Touch interactions can synthesize `mouseenter` events in a real browser, so the previous analytics listener could record `section_view` on mobile even though the intended trigger is first panel hover on a fine-pointer device.

## Validation
- `npm run lint` — clean (eslint).
- `npm run test` — `astro build` + **212 vitest tests pass (23 files)**, including the new `does not fire section_view on non-hover devices` regression case. The suite builds `dist/` first, so the analytics test runs against the real built script.
- Chromium runtime probe (codex): desktop hover emits `section_view` once per panel; mobile touch tap emits no `section_view` event.

## Self-Review
- **Correctness:** `canHover()` is defined in the same homepage IIFE (`src/pages/index.astro:370`) and already gates the panel open/morph handlers (lines 435/641/648); the new analytics guard reuses it, so there is no new helper, no scope risk, and no `ReferenceError` exposure. Guard order `!canHover() || tracked || typeof gtag !== 'function'` short-circuits before any `gtag` call.
- **Regression risk:** Low. Only the hover-derived `section_view` event is gated. GA4 page-level config (`gtag('config', …)` in `src/layouts/BaseLayout.astro`) is untouched, so `page_view` still fires on every device. Grep confirms `section_view` is the only custom `gtag('event', …)` call in the codebase, so the fix is complete in scope.
- **Test coverage:** The new vitest case simulates a coarse-pointer device via `matchMedia` (`canHover()` → false) and asserts `section_view` never fires; existing once-per-panel and `typeof`-guard cases still pass.
- **Style:** Single-line guard matches the surrounding `canHover()` call sites. No hard-coded motion values introduced; no new dependencies or frameworks.
- **Security/deps:** No new dependencies, no secrets. The GA Measurement ID is a public identifier.
- **Spec alignment:** `specs/analytics.md` updated (new requirement 5) so the spec↔test↔code triad stays coherent for `check_spec_test_alignment`.

Diff size: 3 files changed — `src/pages/index.astro`, `tests/analytics.test.js`, `specs/analytics.md`.

Authoring-Agent: codex

> Comprehensive analytics validation pass and `specs/analytics.md` sync performed by Claude (this session); core hover-gate logic and its regression test authored by codex.
