### PR TITLE
[claude] Add PostHog product analytics alongside GA4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ coverage/
 # Misc
 tmp/
 .cache/
+.env.local

--- a/specs/analytics.md
+++ b/specs/analytics.md
@@ -7,12 +7,61 @@ title: Analytics
 
 ## Overview
 
-Google Analytics (gtag) fires a `section_view` event once per panel on first hover on hover-capable (fine-pointer) devices, guarded by a `typeof gtag` check.
+The site runs two analytics systems in parallel during the PostHog transition:
 
-## Requirements
+- **Google Analytics 4 (gtag)** — fires a `section_view` event once per panel on
+  first hover on hover-capable (fine-pointer) devices.
+- **PostHog** — product analytics + autocapture + session replay, loaded
+  site-wide, with twelve custom conversion/engagement events instrumented
+  across the homepage, project pages, blog, and resume.
+
+GA4 is retained for continuity; PostHog is the forward-looking system. Either
+may be removed later without affecting the other.
+
+## Google Analytics 4 (gtag)
 
 1. The `gtag` function is called with `'event', 'section_view'` when a panel is first hovered on a hover-capable device.
 2. Each panel only fires the analytics event once (tracked via a `tracked` boolean closure).
 3. The event includes `section_name` matching the panel's `data-panel` attribute.
 4. The analytics call is guarded with `typeof gtag !== 'function'` to avoid errors when gtag is absent.
 5. The event only fires on hover-capable devices, gated by `canHover()` (`(hover: hover) and (pointer: fine)`). Touch/coarse-pointer devices that synthesize `mouseenter` must not record `section_view`.
+
+## PostHog
+
+### Initialization
+
+6. PostHog is initialized site-wide via the `src/components/posthog.astro`
+   component included in `BaseLayout.astro`, so every page loads it.
+7. The project API key is PostHog's **public** (write-only) `phc_` ingest key,
+   hardcoded in the component — the same class of public identifier as the GA
+   Measurement ID. No personal API key (`phx_…`) is ever used or committed.
+8. Every custom event call is guarded with optional chaining
+   (`window.posthog?.capture(...)`) so a blocked or not-yet-loaded PostHog
+   never throws.
+
+### Events
+
+| Event | Trigger | Properties |
+|---|---|---|
+| `homepage_panel_opened` | A Mondrian panel becomes focused (`data-focus` set) | `panel_name` |
+| `contact_email_clicked` | Click on the `#availability-mailto` "Get in touch" link | — |
+| `resume_link_clicked` | Click on a résumé link in the Connect/About panels | — |
+| `social_link_clicked` | Click on a `.social-row` link | `platform` |
+| `donation_link_clicked` | Click on a Community-panel `.effort-link` | `organization` |
+| `writing_link_clicked` | Click on a `.writing-list` link in the About panel | `href` |
+| `project_page_viewed` | A project detail page loads | `project_slug`, `project_title`, `project_status` |
+| `project_live_link_clicked` | "View Live Product" button click | `project_title`, `url` |
+| `project_github_link_clicked` | "View on GitHub" button click | `project_title`, `url` |
+| `blog_post_viewed` | A blog post page loads | `post_title`, `tags`, `reading_time` |
+| `rss_subscribe_clicked` | Click on the blog index `.rss-link` | — |
+| `resume_viewed` | The resume page loads | — |
+
+### Behavior
+
+9. `homepage_panel_opened` is deduped against the last captured panel. Because
+   `measureContentHeights()` cycles `data-focus` across every panel on load and
+   resize and then restores it, the observer must read the *current* focus and
+   skip unchanged/cleared values — a measurement pass that restores the same
+   focus (or clears it) records no event and emits no per-panel phantom opens.
+10. Clearing `data-focus` (panel close) resets the dedupe latch so re-opening
+    the same panel records a fresh `homepage_panel_opened`.

--- a/specs/analytics.md
+++ b/specs/analytics.md
@@ -65,3 +65,7 @@ may be removed later without affecting the other.
    focus (or clears it) records no event and emits no per-panel phantom opens.
 2. Clearing `data-focus` (panel close) resets the dedupe latch so re-opening
    the same panel records a fresh `homepage_panel_opened`.
+3. The Connect "Elsewhere" social-stack résumé row (`.social-row--resume`) is
+   both a résumé link and a `.social-row`, so clicking it intentionally records
+   **both** `resume_link_clicked` (the location-agnostic résumé aggregate) and
+   `social_link_clicked` with `platform: "resume"` (the social-stack breakdown).

--- a/specs/analytics.md
+++ b/specs/analytics.md
@@ -30,12 +30,12 @@ may be removed later without affecting the other.
 
 ### Initialization
 
-6. PostHog is initialized site-wide via the `src/components/posthog.astro`
+1. PostHog is initialized site-wide via the `src/components/posthog.astro`
    component included in `BaseLayout.astro`, so every page loads it.
-7. The project API key is PostHog's **public** (write-only) `phc_` ingest key,
+2. The project API key is PostHog's **public** (write-only) `phc_` ingest key,
    hardcoded in the component — the same class of public identifier as the GA
    Measurement ID. No personal API key (`phx_…`) is ever used or committed.
-8. Every custom event call is guarded with optional chaining
+3. Every custom event call is guarded with optional chaining
    (`window.posthog?.capture(...)`) so a blocked or not-yet-loaded PostHog
    never throws.
 
@@ -58,10 +58,10 @@ may be removed later without affecting the other.
 
 ### Behavior
 
-9. `homepage_panel_opened` is deduped against the last captured panel. Because
+1. `homepage_panel_opened` is deduped against the last captured panel. Because
    `measureContentHeights()` cycles `data-focus` across every panel on load and
    resize and then restores it, the observer must read the *current* focus and
    skip unchanged/cleared values — a measurement pass that restores the same
    focus (or clears it) records no event and emits no per-panel phantom opens.
-10. Clearing `data-focus` (panel close) resets the dedupe latch so re-opening
-    the same panel records a fresh `homepage_panel_opened`.
+2. Clearing `data-focus` (panel close) resets the dedupe latch so re-opening
+   the same panel records a fresh `homepage_panel_opened`.

--- a/src/components/ProjectHero.astro
+++ b/src/components/ProjectHero.astro
@@ -57,3 +57,28 @@ const { variant, title, deck, breadcrumbLabel, liveUrl, githubUrl } = Astro.prop
   </div>
   <hr class="project-hero__rule" />
 </header>
+
+<script is:inline define:vars={{ heroLiveUrl: liveUrl, heroGithubUrl: githubUrl, heroTitle: title }}>
+  (function () {
+    if (heroLiveUrl) {
+      const liveBtn = document.querySelector('.project-actions a[href="' + heroLiveUrl + '"]');
+      if (liveBtn) {
+        liveBtn.addEventListener('click', function () {
+          window.posthog?.capture('project_live_link_clicked', {
+            project_title: heroTitle,
+            url: heroLiveUrl
+          });
+        });
+      }
+    }
+    const githubBtn = document.querySelector('.project-actions a[href="' + heroGithubUrl + '"]');
+    if (githubBtn) {
+      githubBtn.addEventListener('click', function () {
+        window.posthog?.capture('project_github_link_clicked', {
+          project_title: heroTitle,
+          url: heroGithubUrl
+        });
+      });
+    }
+  })();
+</script>

--- a/src/components/posthog.astro
+++ b/src/components/posthog.astro
@@ -1,0 +1,22 @@
+---
+// PostHog analytics snippet — is:inline prevents Astro TypeScript processing.
+//
+// The project token below is PostHog's *public* (write-only) ingest key. Like
+// the GA Measurement ID hardcoded in BaseLayout.astro, it is a public
+// identifier — safe to commit (see rules/repo_rules.md "GA Measurement IDs are
+// public identifiers; anything write-capable is not"). It is hardcoded rather
+// than read from a PUBLIC_* env var so the value is present in every build
+// path (CI, a fresh checkout, the manual deploy) — this repo has no
+// .env.tpl/op-inject pipeline wired for PUBLIC_* vars (DEPLOYMENT.md: "There
+// are no current PUBLIC_* vars"). A personal API key (phx_…) is never used or
+// committed; client capture only needs the public phc_ key.
+---
+<script is:inline>
+  /* eslint-disable */
+  !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+  /* eslint-enable */
+  posthog.init('phc_s6Xe3o5Q5rLsLASJwWEeKmFLDovSpharkoatQddugu8P', {
+    api_host: 'https://us.i.posthog.com',
+    defaults: '2026-01-30'
+  })
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/global.css';
+import PostHog from '../components/posthog.astro';
 
 interface Props {
   title: string;
@@ -118,6 +119,9 @@ const ogImageUrl = ogImage.includes('?') ? `${ogImage}&v=${buildTime}` : `${ogIm
   {jsonLd && (
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   )}
+
+  <!-- PostHog -->
+  <PostHog />
 
   <!-- Google Analytics 4 -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-7C29SRBXB1"></script>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -275,4 +275,12 @@ const jsonLd = {
       },
     });
   </script>
+
+  <script is:inline define:vars={{ postTitle: title, postTags: tags, postReadingTime: readingTime }}>
+    window.posthog?.capture('blog_post_viewed', {
+      post_title: postTitle,
+      tags: postTags,
+      reading_time: postReadingTime
+    });
+  </script>
 </BaseLayout>

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -166,4 +166,12 @@ const topics = kicker.split(/\s*×\s*/).join(' · ');
 
     </article>
   </main>
+
+  <script is:inline define:vars={{ projectSlug: slug, projectTitle: headline, projectStatus: status }}>
+    window.posthog?.capture('project_page_viewed', {
+      project_slug: projectSlug,
+      project_title: projectTitle,
+      project_status: projectStatus
+    });
+  </script>
 </BaseLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -135,4 +135,13 @@ function readingTime(body: string | undefined): string {
       />
     </div>
   </main>
+
+  <script is:inline>
+    const rssLink = document.querySelector('.rss-link');
+    if (rssLink) {
+      rssLink.addEventListener('click', function () {
+        window.posthog?.capture('rss_subscribe_clicked');
+      });
+    }
+  </script>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -826,4 +826,72 @@ const homepageJsonLd = {
       }
     })();
   </script>
+
+  <script is:inline>
+    (function () {
+      // ── PostHog event tracking ──────────────────────────────────────────
+
+      // Panel opened: observe data-focus changes on the Mondrian grid.
+      // data-focus is also cycled by measureContentHeights() across every
+      // panel on load and on resize, then restored — so a naive observer
+      // emits phantom opens (and duplicates) for panels the visitor never
+      // touched. Dedupe against the last captured panel and read the current
+      // focus rather than per-mutation values: a measurement pass that
+      // restores the same focus (or clears it) then captures nothing.
+      const phGrid = document.getElementById('mondrian');
+      if (phGrid) {
+        let phLastPanel = null;
+        new MutationObserver(function () {
+          const focus = phGrid.dataset.focus;
+          if (!focus) { phLastPanel = null; return; }
+          if (focus === phLastPanel) return;
+          phLastPanel = focus;
+          window.posthog?.capture('homepage_panel_opened', { panel_name: focus });
+        }).observe(phGrid, { attributes: true, attributeFilter: ['data-focus'] });
+      }
+
+      // Contact email clicked
+      const mailto = document.getElementById('availability-mailto');
+      if (mailto) {
+        mailto.addEventListener('click', function () {
+          window.posthog?.capture('contact_email_clicked');
+        });
+      }
+
+      // Resume link clicked (Connect panel and About panel)
+      document.querySelectorAll('.availability-resume, .about-block--resume a').forEach(function (el) {
+        el.addEventListener('click', function () {
+          window.posthog?.capture('resume_link_clicked');
+        });
+      });
+
+      // Social link clicked
+      document.querySelectorAll('.social-row').forEach(function (el) {
+        el.addEventListener('click', function () {
+          const match = el.className.match(/social-row--(\w+)/);
+          window.posthog?.capture('social_link_clicked', {
+            platform: match ? match[1] : 'unknown'
+          });
+        });
+      });
+
+      // Donation link clicked (Community panel)
+      document.querySelectorAll('.effort-link').forEach(function (el) {
+        el.addEventListener('click', function () {
+          window.posthog?.capture('donation_link_clicked', {
+            organization: (el.textContent || '').replace('→', '').trim()
+          });
+        });
+      });
+
+      // Writing link clicked (About panel)
+      document.querySelectorAll('.writing-list a').forEach(function (el) {
+        el.addEventListener('click', function () {
+          window.posthog?.capture('writing_link_clicked', {
+            href: el.getAttribute('href') || ''
+          });
+        });
+      });
+    })();
+  </script>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -858,8 +858,14 @@ const homepageJsonLd = {
         });
       }
 
-      // Resume link clicked (Connect panel and About panel)
-      document.querySelectorAll('.availability-resume, .about-block--resume a').forEach(function (el) {
+      // Resume link clicked — all résumé links in the Connect and About
+      // panels: the About-panel block, the Connect availability link, and the
+      // Connect "Elsewhere" social-stack row. The social row also matches
+      // .social-row below, so it intentionally fires both resume_link_clicked
+      // (location-agnostic résumé aggregate) and social_link_clicked
+      // {platform:"resume"} (social-stack row breakdown) — they answer
+      // different questions.
+      document.querySelectorAll('.availability-resume, .about-block--resume a, .social-row--resume').forEach(function (el) {
         el.addEventListener('click', function () {
           window.posthog?.capture('resume_link_clicked');
         });

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -243,4 +243,8 @@ const jsonLd = {
 
     </article>
   </main>
+
+  <script is:inline>
+    window.posthog?.capture('resume_viewed');
+  </script>
 </BaseLayout>

--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -8,6 +8,12 @@ const rawHtml = readFileSync(resolve(__dirname, '../dist/index.html'), 'utf-8');
 // Script 0 = GA config, Script 1 = panel interaction IIFE.
 const inlineScripts = [...rawHtml.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
 const panelScript = inlineScripts.find((s) => s.includes('section_view')) || '';
+// PostHog: the init snippet (posthog.init) and the homepage event script.
+const posthogInitScript = inlineScripts.find((s) => s.includes('posthog.init')) || '';
+const posthogHomepageScript = inlineScripts.find((s) => s.includes('homepage_panel_opened')) || '';
+
+// Flush a macrotask so queued MutationObserver callbacks have run.
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 // Strip all inline <script> blocks so they don't auto-execute during document.write.
 const html = rawHtml.replace(/<script>[\s\S]*?<\/script>/g, '');
@@ -113,5 +119,112 @@ describe('Analytics', () => {
 
   it('guards analytics with typeof check', () => {
     expect(panelScript).toContain("typeof gtag !== 'function'");
+  });
+});
+
+describe('PostHog', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    setupDOM();
+  });
+
+  it('initializes with the public phc_ project key and US host', () => {
+    expect(posthogInitScript).toContain("posthog.init('phc_");
+    expect(posthogInitScript).toContain('us.i.posthog.com');
+  });
+
+  it('never ships a personal API key or an unresolved env token', () => {
+    expect(posthogInitScript).not.toContain('phx_');
+    expect(posthogInitScript).not.toContain('import.meta.env');
+  });
+
+  it('guards every homepage capture with optional chaining', () => {
+    expect(posthogHomepageScript).toContain('window.posthog?.capture');
+    expect(posthogHomepageScript).not.toContain('window.posthog.capture');
+  });
+
+  it('wires the homepage conversion events', () => {
+    for (const evt of [
+      'homepage_panel_opened',
+      'contact_email_clicked',
+      'resume_link_clicked',
+      'social_link_clicked',
+      'donation_link_clicked',
+      'writing_link_clicked',
+    ]) {
+      expect(posthogHomepageScript).toContain(evt);
+    }
+  });
+
+  it('captures homepage_panel_opened when a panel gains focus', async () => {
+    const capture = vi.fn();
+    window.posthog = { capture };
+    new Function(posthogHomepageScript)();
+
+    document.getElementById('mondrian').dataset.focus = 'about';
+    await tick();
+
+    expect(capture).toHaveBeenCalledWith('homepage_panel_opened', { panel_name: 'about' });
+  });
+
+  it('does not emit phantom opens during a measurement-style data-focus cycle', async () => {
+    const capture = vi.fn();
+    window.posthog = { capture };
+    new Function(posthogHomepageScript)();
+
+    const grid = document.getElementById('mondrian');
+    grid.dataset.focus = 'about';
+    await tick();
+
+    // measureContentHeights() cycles focus across every panel, then restores it.
+    grid.dataset.focus = 'projects';
+    grid.dataset.focus = 'connect';
+    grid.dataset.focus = 'community';
+    grid.dataset.focus = 'about';
+    await tick();
+
+    const opens = capture.mock.calls.filter((c) => c[0] === 'homepage_panel_opened');
+    expect(opens).toHaveLength(1);
+  });
+
+  it('re-captures the same panel only after focus clears', async () => {
+    const capture = vi.fn();
+    window.posthog = { capture };
+    new Function(posthogHomepageScript)();
+
+    const grid = document.getElementById('mondrian');
+    grid.dataset.focus = 'about';
+    await tick();
+    delete grid.dataset.focus; // panel closed
+    await tick();
+    grid.dataset.focus = 'about'; // re-opened
+    await tick();
+
+    const opens = capture.mock.calls.filter((c) => c[0] === 'homepage_panel_opened');
+    expect(opens).toHaveLength(2);
+  });
+
+  it('captures social_link_clicked with the platform from the row class', () => {
+    const capture = vi.fn();
+    window.posthog = { capture };
+    new Function(posthogHomepageScript)();
+
+    document
+      .querySelector('.social-row--linkedin')
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(capture).toHaveBeenCalledWith('social_link_clicked', { platform: 'linkedin' });
+  });
+
+  it('captures contact_email_clicked on the availability mailto', () => {
+    const capture = vi.fn();
+    window.posthog = { capture };
+    new Function(posthogHomepageScript)();
+
+    document
+      .getElementById('availability-mailto')
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(capture).toHaveBeenCalledWith('contact_email_clicked');
   });
 });

--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -227,4 +227,31 @@ describe('PostHog', () => {
 
     expect(capture).toHaveBeenCalledWith('contact_email_clicked');
   });
+
+  it('captures resume_link_clicked from the Connect social-stack résumé row (and still social_link_clicked)', () => {
+    const capture = vi.fn();
+    window.posthog = { capture };
+    new Function(posthogHomepageScript)();
+
+    document
+      .querySelector('.social-row--resume')
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    // Connect "Elsewhere" résumé row is both a résumé link and a .social-row,
+    // so it fires both events (see specs/analytics.md Behavior #3).
+    expect(capture).toHaveBeenCalledWith('resume_link_clicked');
+    expect(capture).toHaveBeenCalledWith('social_link_clicked', { platform: 'resume' });
+  });
+
+  it('captures resume_link_clicked from the About-panel résumé link', () => {
+    const capture = vi.fn();
+    window.posthog = { capture };
+    new Function(posthogHomepageScript)();
+
+    document
+      .querySelector('.about-block--resume a')
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(capture).toHaveBeenCalledWith('resume_link_clicked');
+  });
 });


### PR DESCRIPTION
## Summary
Integrate **PostHog** product analytics (autocapture + session replay + 12 custom conversion events) alongside the existing GA4 section_view. PostHog loads site-wide via a new src/components/posthog.astro snippet included in BaseLayout.astro. Generated by npx @posthog/wizard, then hardened to this repo's conventions.

> The vendored PostHog reference-skill docs that the wizard left behind are split into **#513** to keep this PR focused on code.

## What changed vs. the raw wizard output
- Token wiring → hardcoded. The wizard read the token from a gitignored .env.local, which would build empty on CI / fresh checkouts (this repo has no .env.tpl/op-inject pipeline for PUBLIC_*). Hardcoded the public phc_ project token + US host in posthog.astro, exactly like the GA Measurement ID is already hardcoded. It's a public, write-only ingest key — safe to commit; no personal phx_ key is used.
- Bug fix — homepage_panel_opened phantom events. It observed data-focus, but measureContentHeights() cycles data-focus across every panel on load/resize then restores it — so the raw observer emitted phantom per-panel opens (and duplicates) for panels the visitor never touched. Reworked to dedupe against the last captured panel and read current focus, so a measurement pass records nothing.
- .claude/ rule fix. The wizard dropped an agent-skill folder in .claude/skills/, which violates rules/repo_rules.md (.claude is config-only) and the check_no_tool_folder_instructions CI check. Relocated to docs/posthog-integration-skill/ in its own PR #513.
- Spec + tests. Documented the event taxonomy/behavior in specs/analytics.md and added 9 vitest cases.
- GA4 retained for continuity during the transition; removable later in its own PR.

## Validation
- npm run lint — clean.
- npm run test — astro build + 221 vitest tests pass (23 files), including 9 new PostHog cases (public-key/host, no personal-key/no-env, optional-chaining guard, event wiring, panel-open capture, measurement-dedupe regression, focus-clear re-capture, social-click, contact-click).
- Real-browser smoke check (dev server): PostHog loads, correct token + us.i.posthog.com host, all instrumented elements present, no console errors. No conversion events were fired into the live project during verification.

## Self-Review
- Correctness: posthog.astro hardcodes the public token (browser-verified to load with the right token/host and no errors). All 12 events target real selectors (grep-verified) and real frontmatter variables (headline/slug/status, title/tags/readingTime — build-verified). homepage_panel_opened deduped against measureContentHeights() churn.
- Regression risk: Low. PostHog is additive; GA4 section_view is untouched and still passes its tests. The only existing-script change is the new wizard observer, which I hardened. BaseLayout adds one component include.
- Style: is:inline scripts and a hardcoded public analytics ID both match the existing GA pattern. No hard-coded motion values, no new frameworks.
- Test coverage: 9 new cases incl. a regression test that fails on the pre-fix phantom-event behavior.
- Security / dependency hygiene: No new npm dependencies — PostHog loads via its CDN snippet, same mechanism as GA4. Only the public phc_ ingest key is committed (no phx_ personal key); .env.local is gitignored. No secrets.

## Notes for the reviewer
- Scope: ~315 code lines, over the 300-line external-review threshold. The vendored reference docs were split into #513 to keep this PR focused on code.
- Approval: this PR is Authoring-Agent: claude, so per the cross-agent rule I can't self-approve under nathanpayne-claude — it needs a codex or cursor approving review.

Authoring-Agent: claude
