### PR TITLE
[claude] Wire PostHog token through env/op (supersedes #515)

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -9,3 +9,12 @@
 # If unset at build time, the component renders styled initials only — no
 # broken images. Same publishable token as friends-and-family-billing.
 PUBLIC_LOGODEV_KEY={{ op://Private/rtvfyomcqjigt6ezaycht3vy6i/publishable API key }}
+
+# PostHog project (client) token — public, write-only ingest key (phc_), the
+# same class of public client identifier as PUBLIC_LOGODEV_KEY and the GA
+# Measurement ID. Safe to ship in the static HTML output, but must come from
+# env, never committed (rules/repo_rules.md § No committed secrets). Drives
+# product analytics + session replay via src/components/posthog.astro. If unset
+# at build time, PostHog does not initialize — no analytics, no errors. The
+# personal API key (phx_…) is a true secret and is NOT stored here.
+PUBLIC_POSTHOG_PROJECT_TOKEN={{ op://Private/hghd53g7z4fldgqf4d7kgr22ue/project token }}

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -399,10 +399,15 @@ Any `PUBLIC_*` env var read via `import.meta.env` during the build is baked into
 3. Anyone on the team runs `./scripts/bootstrap.sh --force` to refresh their `.env.local`.
 4. `npm run build` picks up the new value automatically.
 
-There are no current `PUBLIC_*` vars. Mux Data for project hero videos does
-not use a build-time env var in this site: pages with a Mux hero load
-`mux-embed`, and `@mux/mux-background-video` infers the Mux Data env key from
-the public `stream.mux.com` URL at runtime.
+The current `PUBLIC_*` vars are `PUBLIC_LOGODEV_KEY` (Logo.dev publishable
+token — drives the `/resume` company logos via `CompanyLogo.astro`) and
+`PUBLIC_POSTHOG_PROJECT_TOKEN` (PostHog public project ingest token — drives
+analytics via `posthog.astro`). Both are public client identifiers resolved
+from 1Password via `op inject`, and both degrade gracefully when unset at build
+time (initials-only logos; PostHog simply does not initialize). Mux Data for
+project hero videos does not use a build-time env var in this site: pages with
+a Mux hero load `mux-embed`, and `@mux/mux-background-video` infers the Mux Data
+env key from the public `stream.mux.com` URL at runtime.
 
 ## Deployment Steps
 

--- a/specs/analytics.md
+++ b/specs/analytics.md
@@ -33,9 +33,15 @@ may be removed later without affecting the other.
 1. PostHog is initialized site-wide via the `src/components/posthog.astro`
    component included in `BaseLayout.astro`, so every page loads it.
 2. The project API key is PostHog's **public** (write-only) `phc_` ingest key,
-   hardcoded in the component — the same class of public identifier as the GA
-   Measurement ID. No personal API key (`phx_…`) is ever used or committed.
-3. Every custom event call is guarded with optional chaining
+   injected at build from the `PUBLIC_POSTHOG_PROJECT_TOKEN` env var (resolved
+   from 1Password via `op inject` — the same `.env.tpl`/`bootstrap.sh` pipeline
+   as `PUBLIC_LOGODEV_KEY`), never committed to source. No personal API key
+   (`phx_…`) is ever used or committed.
+3. If `PUBLIC_POSTHOG_PROJECT_TOKEN` is unset at build time (e.g. CI, or a
+   checkout that has not run `scripts/bootstrap.sh`), `posthog.astro` renders
+   nothing and PostHog never initializes — no events, no errors — mirroring
+   `CompanyLogo`'s graceful degradation.
+4. Every custom event call is guarded with optional chaining
    (`window.posthog?.capture(...)`) so a blocked or not-yet-loaded PostHog
    never throws.
 

--- a/src/components/posthog.astro
+++ b/src/components/posthog.astro
@@ -1,22 +1,26 @@
 ---
 // PostHog analytics snippet — is:inline prevents Astro TypeScript processing.
 //
-// The project token below is PostHog's *public* (write-only) ingest key. Like
-// the GA Measurement ID hardcoded in BaseLayout.astro, it is a public
-// identifier — safe to commit (see rules/repo_rules.md "GA Measurement IDs are
-// public identifiers; anything write-capable is not"). It is hardcoded rather
-// than read from a PUBLIC_* env var so the value is present in every build
-// path (CI, a fresh checkout, the manual deploy) — this repo has no
-// .env.tpl/op-inject pipeline wired for PUBLIC_* vars (DEPLOYMENT.md: "There
-// are no current PUBLIC_* vars"). A personal API key (phx_…) is never used or
-// committed; client capture only needs the public phc_ key.
+// The phc_ project token is PostHog's public, write-only client ingest key.
+// Per the repo's credential-hygiene policy (rules/repo_rules.md § No committed
+// secrets) public client tokens come from env via `op inject`, never committed
+// — the same pattern as PUBLIC_LOGODEV_KEY (.env.tpl / CompanyLogo.astro). When
+// the token is unset at build time (CI, or a checkout that has not run
+// scripts/bootstrap.sh), this component renders nothing and PostHog never
+// initializes: no events, no errors, no array.js request — mirroring
+// CompanyLogo's graceful degradation. api_host is a non-secret region constant.
+// The personal API key (phx_…), which can read/manage the project, is never
+// used here.
+const token = import.meta.env.PUBLIC_POSTHOG_PROJECT_TOKEN || '';
 ---
-<script is:inline>
-  /* eslint-disable */
-  !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-  /* eslint-enable */
-  posthog.init('phc_s6Xe3o5Q5rLsLASJwWEeKmFLDovSpharkoatQddugu8P', {
-    api_host: 'https://us.i.posthog.com',
-    defaults: '2026-01-30'
-  })
-</script>
+{token && (
+  <script is:inline define:vars={{ token }}>
+    /* eslint-disable */
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    /* eslint-enable */
+    posthog.init(token, {
+      api_host: 'https://us.i.posthog.com',
+      defaults: '2026-01-30'
+    })
+  </script>
+)}

--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -8,8 +8,11 @@ const rawHtml = readFileSync(resolve(__dirname, '../dist/index.html'), 'utf-8');
 // Script 0 = GA config, Script 1 = panel interaction IIFE.
 const inlineScripts = [...rawHtml.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
 const panelScript = inlineScripts.find((s) => s.includes('section_view')) || '';
-// PostHog: the init snippet (posthog.init) and the homepage event script.
-const posthogInitScript = inlineScripts.find((s) => s.includes('posthog.init')) || '';
+// PostHog init lives in src/components/posthog.astro and is gated on the env
+// token, so it may be absent from a token-less build (e.g. CI). Assert the
+// init contract against the component SOURCE (build-env-independent); assert
+// event behavior against the homepage script, which always renders.
+const posthogComponentSrc = readFileSync(resolve(__dirname, '../src/components/posthog.astro'), 'utf-8');
 const posthogHomepageScript = inlineScripts.find((s) => s.includes('homepage_panel_opened')) || '';
 
 // Flush a macrotask so queued MutationObserver callbacks have run.
@@ -128,14 +131,18 @@ describe('PostHog', () => {
     setupDOM();
   });
 
-  it('initializes with the public phc_ project key and US host', () => {
-    expect(posthogInitScript).toContain("posthog.init('phc_");
-    expect(posthogInitScript).toContain('us.i.posthog.com');
+  it('reads the PostHog token from env and never commits a key in source', () => {
+    expect(posthogComponentSrc).toContain('import.meta.env.PUBLIC_POSTHOG_PROJECT_TOKEN');
+    // No committed project token (phc_) or personal key (phx_) material in
+    // source — match key bodies, not bare mentions in comments.
+    expect(posthogComponentSrc).not.toMatch(/phc_[A-Za-z0-9]{6}/);
+    expect(posthogComponentSrc).not.toMatch(/phx_[A-Za-z0-9]{6}/);
   });
 
-  it('never ships a personal API key or an unresolved env token', () => {
-    expect(posthogInitScript).not.toContain('phx_');
-    expect(posthogInitScript).not.toContain('import.meta.env');
+  it('only initializes PostHog when a token is present (graceful degradation)', () => {
+    expect(posthogComponentSrc).toMatch(/\{token &&/); // conditional render guard
+    expect(posthogComponentSrc).toContain('posthog.init(token');
+    expect(posthogComponentSrc).toContain('us.i.posthog.com');
   });
 
   it('guards every homepage capture with optional chaining', () => {


### PR DESCRIPTION
## Summary
Wire the PostHog `phc_` token through the repo's existing `.env.tpl`/`op inject` pipeline (mirroring `PUBLIC_LOGODEV_KEY`), with graceful degradation when unset — instead of hardcoding it. **Supersedes #515** (which documented a hardcode exception).

## Why (codex's #515 catch)
Codex's CHANGES_REQUESTED on #515 surfaced that the repo already has exactly the pipeline I'd claimed didn't exist: `.env.tpl` defines `PUBLIC_LOGODEV_KEY` via `op inject`, with an explicit policy in its own comment — a public client token "like the GA Measurement ID ... must come from env, never committed" — and `CompanyLogo.astro` degrades gracefully when it is unset. So the hardcoded `phc_` token contradicted the repo's actual policy. Matching LOGODEV makes the credential-hygiene exception unnecessary.

## Changes
- **`posthog.astro`**: reads `import.meta.env.PUBLIC_POSTHOG_PROJECT_TOKEN`; renders nothing and never initializes when the token is unset (graceful degradation, mirroring `CompanyLogo`). The committed token is removed.
- **`.env.tpl`**: adds `PUBLIC_POSTHOG_PROJECT_TOKEN` via `op://Private/<item>/project token`.
- **`specs/analytics.md`**: Initialization now specifies env-injection + graceful degradation (no hardcoded key).
- **`DEPLOYMENT.md`**: corrects the stale "There are no current `PUBLIC_*` vars" claim.
- **`tests/analytics.test.js`**: init-contract tests now read `posthog.astro` source (build-env-independent) — assert env-read, no committed `phc_`/`phx_` key material, token-gated init — so a token-less CI build stays green. Event-behavior tests unchanged.

## 1Password
Created a Private-vault item "PostHog API Key" holding the public `phc_` token (`op://Private/hghd53g7z4fldgqf4d7kgr22ue/project token`). Verified end-to-end: `op item → .env.tpl → bootstrap.sh --force → .env.local → build`.

## Validation
- `npm run test` → **223 pass** (build with token present locally; source-based init tests pass regardless of build env).
- eslint on the changed files: clean.

## Self-Review
- **Correctness**: env-read mirrors `CompanyLogo` (`import.meta.env.PUBLIC_… || ''`); the `{token && <script>}` guard means no init / no `array.js` request / no events when unset. Host is a non-secret region constant. No `phc_`/`phx_` key material in source (regex-asserted).
- **Regression risk**: Low. Event handlers (in `index.astro`) are unchanged, still optional-chaining-guarded, and no-op when PostHog is not initialized. GA4 untouched.
- **Style**: Matches the LOGODEV/`.env.tpl` pattern; comments mirror the LOGODEV comment.
- **Test coverage**: Init contract moved to CI-robust source assertions; behavioral event tests retained; 223 pass.
- **Security / dependency hygiene**: Token is no longer committed — it lives in 1Password, op-injected at build, per the repo's "never committed" policy. No new npm deps. `phx_` personal key never used.

## Notes
- **Supersedes #515** — closing it; the credential-hygiene *exception* is no longer needed because the token is not committed.
- Unrelated pre-existing finding (flagged separately, NOT in this PR): the eslint-10 bump makes `npm run lint` flag `robots-sitemap.mjs:126` (`preserve-caught-error`), and eslint is not part of CI (`repo_lint.yml` runs only structure checks).
- Under-threshold (~97 lines) but Authoring-Agent: claude → needs a codex/cursor approval.

Authoring-Agent: claude