### PR TITLE
Forward caught error as cause in robots-sitemap (eslint preserve-caught-error)

### DIFF
--- a/src/integrations/robots-sitemap.mjs
+++ b/src/integrations/robots-sitemap.mjs
@@ -126,7 +126,8 @@ export default function robotsSitemap() {
           throw new Error(
             `robots-sitemap: dist/robots.txt not found. ` +
               `Expected a public/robots.txt source file to copy through. ` +
-              `(${err.code || err.message})`
+              `(${err.code || err.message})`,
+            { cause: err }
           );
         }
 


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Fixes the lone `npm run lint` (eslint 10) failure on `main`. `src/integrations/robots-sitemap.mjs:126` tripped the `preserve-caught-error` rule: the `readFile` catch block threw a new `Error` describing the missing `dist/robots.txt` without forwarding the caught error. The rule became enforced when the eslint 10 bump pulled `preserve-caught-error` into the recommended config, so it stayed latent until lint was run locally with lockfile-exact deps.

The catch block now forwards the original error via `{ cause: err }`, so the underlying failure is preserved on the error chain. The thrown message and control flow are unchanged, and the happy path (robots.txt present) never enters this branch.

## Self-Review

- Correctness: `{ cause: err }` is the standard Error options-bag form; `err` is the binding caught on the same line. Verified red to green in a clean worktree off `main`—`eslint .` reported 1 error (preserve-caught-error) before and 0 problems after (eslint v10.5.0).
- Regression risk: minimal. Single error-path change; message string and control flow untouched. `astro build` exercises the integration in the happy path and completed cleanly.
- Style: matches the existing multi-line `throw new Error(...)` calls in the file (no trailing comma before the closing paren).
- Test coverage: `npm run test` (astro build plus vitest) passes 223 of 223. No new test added—this is lint-rule compliance on an error path whose observable message is unchanged, and existing sitemap coverage already exercises the modified function. Can add a cause-assertion test on request.
- Security and dependency hygiene: no dependency changes, no new imports, no secrets, no protected paths touched.

## Out of scope (tracked separately)

eslint is not run in CI: `.github/workflows/repo_lint.yml` runs only the `scripts/ci/*` structure checks, which is why this error stayed latent. A follow-up PR will add an `npm run lint` step. That change edits `.github/**` (a protected path that triggers Phase 4 external review), so it ships separately from this fix.