### PR TITLE
Add eslint (npm run lint) job to CI

### DIFF
--- a/.github/workflows/repo_lint.yml
+++ b/.github/workflows/repo_lint.yml
@@ -61,3 +61,31 @@ jobs:
             fi
           done
           exit $MISSING
+
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # `npm run lint` (eslint) had never run in CI — the job above only
+      # executes the scripts/ci/* structure checks. eslint errors, such as
+      # the preserve-caught-error break repaired in #519, therefore stayed
+      # latent until someone ran lint locally with lockfile-exact deps.
+      # This job closes that gap.
+      - name: install_dependencies
+        # package-lock.json is gitignored, so `npm ci` is unavailable;
+        # install straight from package.json.
+        #   --no-save        leave package.json untouched
+        #   --ignore-scripts the eslint toolchain needs no lifecycle hooks,
+        #                    and this skips the credentialed prebuild
+        #                    image-refresh scripts
+        # NOTE: unlike the ad-hoc js-yaml installs in agent-review.yml /
+        # pr-audit.yml, this step deliberately omits --legacy-peer-deps.
+        # `typescript` is a PEER dependency of typescript-eslint (and of
+        # astro's tsconfck), not a direct dependency; --legacy-peer-deps
+        # would skip it and `eslint .` would then fail with
+        # "Cannot find module 'typescript'" on the .astro / .ts sources.
+        run: npm install --no-save --ignore-scripts
+
+      - name: eslint
+        run: npm run lint


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Adds an `eslint` job to `.github/workflows/repo_lint.yml` so `npm run lint` runs in CI. Until now repo_lint.yml executed only the `scripts/ci/*` structure checks; eslint never ran in CI, so eslint errors stayed latent until a developer happened to run lint locally. That is exactly how the `preserve-caught-error` break (fixed in #519) reached main unnoticed. This job closes the gap.

## What the job does

- Checks out the repo (pinned `actions/checkout` SHA, matching the existing job).
- Installs dependencies from package.json with `npm install --no-save --ignore-scripts`.
- Runs `npm run lint` (eslint).

## Why this omits --legacy-peer-deps

The ad-hoc js-yaml installs in agent-review.yml and pr-audit.yml use `--no-save --ignore-scripts --legacy-peer-deps`. This job intentionally omits `--legacy-peer-deps`: `typescript` is a PEER dependency of typescript-eslint (and of astro tsconfck), not a direct dependency. With --legacy-peer-deps npm skips the peer install and `eslint .` fails with "Cannot find module typescript" on the .astro and .ts sources. Omitting the flag lets npm resolve all required peers. package-lock.json is gitignored, so `npm ci` is not an option; this installs straight from package.json.

## Validation

- Reproduced the failure mode in a clean room: install WITH --legacy-peer-deps fails on the missing typescript module; WITHOUT it, install and lint both succeed.
- Clean-room `npm install --no-save --ignore-scripts` then eslint on real .astro and .mjs sources: install exit 0, eslint exit 0.
- `npm run lint` on this branch (main plus the #519 fix): 0 problems.
- `check_workflow_parsers` still passes (63 tests); it does not inspect repo_lint.yml, so the new job does not affect it.
- repo_lint.yml parses as valid YAML with jobs `lint` and `eslint`.

## Gating note

This makes eslint RUN on every push and PR and surfaces failures, but it does not BLOCK merges by itself. To gate on it, add the `eslint` check to the `main` branch protection required status checks (a repo-settings change, outside this repository).

## Self-Review

- Correctness: the job mirrors the existing structure-lint job conventions (ubuntu-latest, pinned checkout SHA). The install and lint sequence is verified end to end in a clean room, including the .astro parser path.
- Regression risk: low. Adds a new, independent job; does not modify the existing `lint` job or any other workflow. A new check appears on PRs but does not gate until added to branch protection.
- Style: matches repo_lint.yml indentation and the inline-comment style of the surrounding steps.
- Test coverage: no unit test applies to a workflow YAML; validated by clean-room reproduction and by the workflow running on this PR.
- Security and dependency hygiene: no new dependencies declared, no secrets, no token usage (contents: read is inherited). --ignore-scripts avoids dependency lifecycle scripts and the credentialed prebuild hooks. Touches only .github/workflows/repo_lint.yml.

## Protected path

This edits `.github/**`, which `.github/review-policy.yml` lists under external_review_paths, so it requires Phase 4 external review regardless of size.