### PR TITLE
[codex] Fix npm deploy entrypoint

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -413,10 +413,10 @@ env key from the public `stream.mux.com` URL at runtime.
 
 ## Deployment Steps
 
-All deploys use `op-firebase-deploy` for keyless, non-interactive service account impersonation. **Never run `firebase deploy` directly.** The package `deploy` script is the full production deploy entry point: it builds first, then calls the PATH-provided `op-firebase-deploy` helper.
+All deploys use `op-firebase-deploy` for keyless, non-interactive service account impersonation. **Never run `firebase deploy` directly.** The package `deploy` script is the full production deploy entry point: it builds first, calls the PATH-provided `op-firebase-deploy` helper, then purges Cloudflare via `scripts/cf-cache-purge.sh`.
 
 ```bash
-# Full deploy (build, then hosting + all configured services)
+# Full deploy (build, deploy, then purge Cloudflare)
 npm run deploy
 
 # Hosting only
@@ -500,7 +500,7 @@ Or use the Firebase Console → Hosting → Release History → Roll back.
 
 ## CI/CD Integration
 
-Deploys are manual via `npm run deploy`, which builds first and then calls `op-firebase-deploy`. CI workflows (repo linting, review policy enforcement) run on push/PR via GitHub Actions—see `.github/workflows/`.
+Deploys are manual via `npm run deploy`, which builds first, calls `op-firebase-deploy`, and purges Cloudflare. CI workflows (repo linting, review policy enforcement) run on push/PR via GitHub Actions—see `.github/workflows/`.
 
 If a CI pipeline is added later, prefer Workload Identity Federation or another `external_account` credential as the source credential, then let `op-firebase-deploy` impersonate the deployer service account. Do **not** store service account keys as CI secrets.
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -413,13 +413,14 @@ env key from the public `stream.mux.com` URL at runtime.
 
 ## Deployment Steps
 
-All deploys use `op-firebase-deploy` for keyless, non-interactive service account impersonation. **Never run `firebase deploy` directly.**
+All deploys use `op-firebase-deploy` for keyless, non-interactive service account impersonation. **Never run `firebase deploy` directly.** The package `deploy` script is the full production deploy entry point: it builds first, then calls the PATH-provided `op-firebase-deploy` helper.
 
 ```bash
-# Full deploy (hosting + all configured services)
-op-firebase-deploy
+# Full deploy (build, then hosting + all configured services)
+npm run deploy
 
 # Hosting only
+npm run build
 op-firebase-deploy --only hosting
 ```
 
@@ -499,7 +500,7 @@ Or use the Firebase Console → Hosting → Release History → Roll back.
 
 ## CI/CD Integration
 
-Deploys are manual via `op-firebase-deploy`. CI workflows (repo linting, review policy enforcement) run on push/PR via GitHub Actions—see `.github/workflows/`.
+Deploys are manual via `npm run deploy`, which builds first and then calls `op-firebase-deploy`. CI workflows (repo linting, review policy enforcement) run on push/PR via GitHub Actions—see `.github/workflows/`.
 
 If a CI pipeline is added later, prefer Workload Identity Federation or another `external_account` credential as the source credential, then let `op-firebase-deploy` impersonate the deployer service account. Do **not** store service account keys as CI secrets.
 

--- a/README.md
+++ b/README.md
@@ -190,11 +190,8 @@ npm run test:e2e      # playwright test
 The site is hosted on [Firebase Hosting](https://firebase.google.com/docs/hosting). Firebase project ID: `nathanpaynedotcom`.
 
 ```bash
-# Build first
-npm run build
-
-# Deploy (uses 1Password-backed credentials)
-op-firebase-deploy
+# Full deploy: build first, then deploy with 1Password-backed credentials
+npm run deploy
 ```
 
 `op-firebase-deploy` creates a short-lived impersonated credential for `firebase-deployer@nathanpaynedotcom.iam.gserviceaccount.com` from a 1Password-backed GCP ADC source credential. No routine browser login is needed. See [`DEPLOYMENT.md`](DEPLOYMENT.md) for full setup, credential bootstrap, and rollback procedures.

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ npm run test:e2e      # playwright test
 The site is hosted on [Firebase Hosting](https://firebase.google.com/docs/hosting). Firebase project ID: `nathanpaynedotcom`.
 
 ```bash
-# Full deploy: build first, then deploy with 1Password-backed credentials
+# Full deploy: build, deploy with 1Password-backed credentials, then purge Cloudflare
 npm run deploy
 ```
 

--- a/docs/agents/deployment-process.md
+++ b/docs/agents/deployment-process.md
@@ -1,9 +1,9 @@
 # Deployment Process
 
-All deploys use `op-firebase-deploy` for non-interactive service account impersonation. Never run `firebase deploy` directly. For a full production deploy, use the package alias so the build always runs first.
+All deploys use `op-firebase-deploy` for non-interactive service account impersonation. Never run `firebase deploy` directly. For a full production deploy, use the package alias so the build always runs first and Cloudflare is purged afterward.
 
 ```bash
-npm run deploy                      # full deploy: build, then op-firebase-deploy
+npm run deploy                      # full deploy: build, op-firebase-deploy, purge Cloudflare
 npm run build && op-firebase-deploy --only hosting
 ```
 

--- a/docs/agents/deployment-process.md
+++ b/docs/agents/deployment-process.md
@@ -1,10 +1,10 @@
 # Deployment Process
 
-All deploys use `op-firebase-deploy` for non-interactive service account impersonation. Never run `firebase deploy` directly.
+All deploys use `op-firebase-deploy` for non-interactive service account impersonation. Never run `firebase deploy` directly. For a full production deploy, use the package alias so the build always runs first.
 
 ```bash
-op-firebase-deploy                  # full deploy
-op-firebase-deploy --only hosting   # hosting only
+npm run deploy                      # full deploy: build, then op-firebase-deploy
+npm run build && op-firebase-deploy --only hosting
 ```
 
 See `DEPLOYMENT.md` for the 1Password-backed GCP ADC bootstrap, `gcloud` wrapper install, first-time impersonation setup, cache-bust steps, caching rules, security headers, rollback procedure, and secrets management.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "astro preview",
     "test": "astro build && vitest run",
     "test:e2e": "playwright test",
-    "deploy": "npm run build && op-firebase-deploy",
+    "deploy": "npm run build && op-firebase-deploy && scripts/cf-cache-purge.sh",
     "lint": "eslint ."
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "astro preview",
     "test": "astro build && vitest run",
     "test:e2e": "playwright test",
-    "deploy": "scripts/deploy.sh",
+    "deploy": "npm run build && op-firebase-deploy",
     "lint": "eslint ."
   },
   "devDependencies": {

--- a/scripts/cf-cache-purge.sh
+++ b/scripts/cf-cache-purge.sh
@@ -12,7 +12,7 @@ OP_ITEM_ID="4x6wslp3f6pal5t6h3jhhe63ie"
 
 if [[ -n "${CF_API_TOKEN:-}" ]]; then
   CF_TOKEN="$CF_API_TOKEN"
-elif [[ "${OP_PREFLIGHT_DONE:-}" == "1" ]]; then
+elif [[ "${OP_PREFLIGHT_DONE:-}" == "1" && ( "${OP_PREFLIGHT_MODE:-}" == "deploy" || "${OP_PREFLIGHT_MODE:-}" == "all" ) ]]; then
   echo "  CF_API_TOKEN not exported by preflight; skipping Cloudflare cache purge."
   exit 0
 else

--- a/scripts/cf-cache-purge.sh
+++ b/scripts/cf-cache-purge.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Purge the Cloudflare cache for nathanpayne.com.
-# Reads the API token from 1Password — requires `op` to be unlocked.
+# Uses CF_API_TOKEN from credential preflight when available. When run
+# directly without preflight, falls back to 1Password.
 #
 # Usage:
 #   scripts/cf-cache-purge.sh
@@ -9,9 +10,16 @@ set -euo pipefail
 ZONE_ID="2ea6932e7a6e86434297873a191bb123"
 OP_ITEM_ID="4x6wslp3f6pal5t6h3jhhe63ie"
 
-echo "  Purging Cloudflare cache for nathanpayne.com..."
+if [[ -n "${CF_API_TOKEN:-}" ]]; then
+  CF_TOKEN="$CF_API_TOKEN"
+elif [[ "${OP_PREFLIGHT_DONE:-}" == "1" ]]; then
+  echo "  CF_API_TOKEN not exported by preflight; skipping Cloudflare cache purge."
+  exit 0
+else
+  CF_TOKEN="$(op read "op://Private/${OP_ITEM_ID}/credential")"
+fi
 
-CF_TOKEN="$(op read "op://Private/${OP_ITEM_ID}/credential")"
+echo "  Purging Cloudflare cache for nathanpayne.com..."
 
 RESPONSE="$(curl -s -X POST \
   "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/purge_cache" \

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -762,6 +762,7 @@ emit_from_session_file() (
     printf 'export CF_API_TOKEN=%q\n' "$CF_API_TOKEN"
   printf 'export OP_PREFLIGHT_DONE=1\n'
   printf 'export OP_PREFLIGHT_AGENT=%q\n' "$AGENT"
+  printf 'export OP_PREFLIGHT_MODE=%q\n' "${OP_PREFLIGHT_MODE:-$MODE}"
   exit 0
 )
 
@@ -1181,6 +1182,7 @@ chmod 600 "$SESSION_FILE"
 # ── Output ────────────────────────────────────────────────────────────
 EXPORTS+=("export OP_PREFLIGHT_DONE=1")
 EXPORTS+=("export OP_PREFLIGHT_AGENT=$(printf '%q' "$AGENT")")
+EXPORTS+=("export OP_PREFLIGHT_MODE=$(printf '%q' "$MODE")")
 
 # Print export statements to stdout (caller evals them)
 for exp in "${EXPORTS[@]}"; do

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -176,11 +176,10 @@ FIREBASE_SA_VAULT="${FIREBASE_SA_VAULT:-Firebase}"
 
 # ── Cloudflare Cache Purge token (#167) ───────────────────────────────
 # Shared API token with Purge:Edit permission across all domains. Wired
-# into preflight so scripts/deploy.sh's existing CF purge step
-# (currently no-op when CF_API_TOKEN is unset) actually fires on
-# agent-driven deploys without an extra biometric prompt. CF_ZONE_ID
-# is intentionally NOT sourced here — it's per-repo and lives in each
-# downstream consumer's own bootstrap, not in this shared wiring.
+# into preflight so deploy flows that purge Cloudflare can do so without
+# an extra biometric prompt. CF_ZONE_ID is intentionally NOT sourced here
+# — it's per-repo and lives in each downstream consumer's own bootstrap,
+# not in this shared wiring.
 DEFAULT_CF_TOKEN_OP_URI="${CF_TOKEN_OP_URI:-op://Private/4x6wslp3f6pal5t6h3jhhe63ie/credential}"
 SSH_AUTHOR_HOST="github.com"
 
@@ -1139,8 +1138,8 @@ if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
   fi
 
   # Cloudflare cache-purge token (#167). Optional — if 1Password is
-  # unreachable for this item the deploy still proceeds; deploy.sh's
-  # CF purge step gracefully no-ops on empty CF_API_TOKEN.
+  # unreachable for this item the deploy still proceeds; deploy flows
+  # that purge Cloudflare should gracefully no-op on empty CF_API_TOKEN.
   echo "# Preflight: reading Cloudflare cache-purge token..." >&2
   cf_token=$(op read "$DEFAULT_CF_TOKEN_OP_URI" 2>/dev/null || true)
   if [[ -n "$cf_token" ]]; then
@@ -1148,7 +1147,7 @@ if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
     SESSION_LINES+=("CF_API_TOKEN=$(printf '%q' "$cf_token")")
     SUMMARY+=("Cloudflare cache-purge token: loaded")
   else
-    echo "# Warning: could not read Cloudflare cache-purge token. CF_API_TOKEN not exported; deploy.sh will skip the purge step." >&2
+    echo "# Warning: could not read Cloudflare cache-purge token. CF_API_TOKEN not exported; Cloudflare purge steps should no-op." >&2
     SUMMARY+=("Cloudflare cache-purge token: SKIPPED (not available)")
   fi
 fi

--- a/tests/cf-cache-purge.test.js
+++ b/tests/cf-cache-purge.test.js
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const rootDir = resolve(__dirname, '..');
+const scriptPath = resolve(rootDir, 'scripts/cf-cache-purge.sh');
+
+function makeStubBin({ opScript, curlScript }) {
+  const workDir = mkdtempSync(join(tmpdir(), 'cf-cache-purge-test-'));
+  const binDir = join(workDir, 'bin');
+  execFileSync('mkdir', ['-p', binDir]);
+
+  writeFileSync(join(binDir, 'op'), opScript, 'utf-8');
+  chmodSync(join(binDir, 'op'), 0o755);
+
+  writeFileSync(join(binDir, 'curl'), curlScript, 'utf-8');
+  chmodSync(join(binDir, 'curl'), 0o755);
+
+  return { workDir, binDir };
+}
+
+function runPurge({ env = {}, opScript, curlScript }) {
+  const { workDir, binDir } = makeStubBin({ opScript, curlScript });
+  try {
+    const output = execFileSync('bash', [scriptPath], {
+      cwd: rootDir,
+      env: {
+        ...process.env,
+        ...env,
+        PATH: `${binDir}:${process.env.PATH}`,
+        CURL_LOG: join(workDir, 'curl.log'),
+      },
+      encoding: 'utf-8',
+    });
+
+    let curlLog = '';
+    try {
+      curlLog = readFileSync(join(workDir, 'curl.log'), 'utf-8');
+    } catch {
+      // No curl call is expected for skip paths.
+    }
+
+    return { output, curlLog };
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+const failingOp = `#!/usr/bin/env bash
+echo "op should not have been called" >&2
+exit 99
+`;
+
+const failingCurl = `#!/usr/bin/env bash
+echo "curl should not have been called" >&2
+exit 98
+`;
+
+const loggingCurl = `#!/usr/bin/env bash
+printf '%s\\n' "$*" > "$CURL_LOG"
+printf '{"success":true}\\n'
+`;
+
+describe('Cloudflare cache purge helper', () => {
+  it('uses CF_API_TOKEN from credential preflight without reading 1Password', () => {
+    const { output, curlLog } = runPurge({
+      env: { CF_API_TOKEN: 'preflight-token' },
+      opScript: failingOp,
+      curlScript: loggingCurl,
+    });
+
+    expect(output).toContain('Cloudflare cache purged');
+    expect(curlLog).toContain('Authorization: Bearer preflight-token');
+  });
+
+  it('skips successfully when preflight ran but did not export a Cloudflare token', () => {
+    const { output, curlLog } = runPurge({
+      env: { OP_PREFLIGHT_DONE: '1', CF_API_TOKEN: '' },
+      opScript: failingOp,
+      curlScript: failingCurl,
+    });
+
+    expect(output).toContain('skipping Cloudflare cache purge');
+    expect(curlLog).toBe('');
+  });
+
+  it('falls back to 1Password when run directly without preflight', () => {
+    const { output, curlLog } = runPurge({
+      env: { CF_API_TOKEN: '', OP_PREFLIGHT_DONE: '' },
+      opScript: `#!/usr/bin/env bash
+printf 'op-token\\n'
+`,
+      curlScript: loggingCurl,
+    });
+
+    expect(output).toContain('Cloudflare cache purged');
+    expect(curlLog).toContain('Authorization: Bearer op-token');
+  });
+});

--- a/tests/cf-cache-purge.test.js
+++ b/tests/cf-cache-purge.test.js
@@ -77,13 +77,26 @@ describe('Cloudflare cache purge helper', () => {
 
   it('skips successfully when preflight ran but did not export a Cloudflare token', () => {
     const { output, curlLog } = runPurge({
-      env: { OP_PREFLIGHT_DONE: '1', CF_API_TOKEN: '' },
+      env: { OP_PREFLIGHT_DONE: '1', OP_PREFLIGHT_MODE: 'all', CF_API_TOKEN: '' },
       opScript: failingOp,
       curlScript: failingCurl,
     });
 
     expect(output).toContain('skipping Cloudflare cache purge');
     expect(curlLog).toBe('');
+  });
+
+  it('falls back to 1Password when review preflight did not load deploy credentials', () => {
+    const { output, curlLog } = runPurge({
+      env: { OP_PREFLIGHT_DONE: '1', OP_PREFLIGHT_MODE: 'review', CF_API_TOKEN: '' },
+      opScript: `#!/usr/bin/env bash
+printf 'review-mode-op-token\\n'
+`,
+      curlScript: loggingCurl,
+    });
+
+    expect(output).toContain('Cloudflare cache purged');
+    expect(curlLog).toContain('Authorization: Bearer review-mode-op-token');
   });
 
   it('falls back to 1Password when run directly without preflight', () => {

--- a/tests/deploy-entrypoint.test.js
+++ b/tests/deploy-entrypoint.test.js
@@ -7,10 +7,10 @@ const packageJson = JSON.parse(readFileSync(resolve(rootDir, 'package.json'), 'u
 const deploymentDoc = readFileSync(resolve(rootDir, 'DEPLOYMENT.md'), 'utf-8');
 
 describe('deploy entrypoint contract', () => {
-  it('builds before invoking the PATH-provided Firebase deploy helper', () => {
+  it('builds, deploys with the PATH-provided helper, then purges Cloudflare', () => {
     const deployScript = packageJson.scripts.deploy;
 
-    expect(deployScript).toMatch(/^npm run build && op-firebase-deploy(?:\s|$)/);
+    expect(deployScript).toBe('npm run build && op-firebase-deploy && scripts/cf-cache-purge.sh');
     expect(deployScript).not.toMatch(/\bfirebase\s+deploy\b/);
   });
 
@@ -28,6 +28,7 @@ describe('deploy entrypoint contract', () => {
   it('keeps DEPLOYMENT.md aligned with the package deploy alias', () => {
     expect(deploymentDoc).toContain('npm run deploy');
     expect(deploymentDoc).toContain('npm run build');
+    expect(deploymentDoc).toContain('scripts/cf-cache-purge.sh');
     expect(deploymentDoc).toContain('op-firebase-deploy --only hosting');
   });
 });

--- a/tests/deploy-entrypoint.test.js
+++ b/tests/deploy-entrypoint.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const rootDir = resolve(__dirname, '..');
+const packageJson = JSON.parse(readFileSync(resolve(rootDir, 'package.json'), 'utf-8'));
+const deploymentDoc = readFileSync(resolve(rootDir, 'DEPLOYMENT.md'), 'utf-8');
+
+describe('deploy entrypoint contract', () => {
+  it('builds before invoking the PATH-provided Firebase deploy helper', () => {
+    const deployScript = packageJson.scripts.deploy;
+
+    expect(deployScript).toMatch(/^npm run build && op-firebase-deploy(?:\s|$)/);
+    expect(deployScript).not.toMatch(/\bfirebase\s+deploy\b/);
+  });
+
+  it('does not point at a missing repo-local script', () => {
+    const firstToken = packageJson.scripts.deploy.split(/\s+/)[0];
+
+    if (firstToken.startsWith('scripts/')) {
+      expect(
+        existsSync(resolve(rootDir, firstToken)),
+        `${firstToken} is referenced by package.json scripts.deploy but does not exist`,
+      ).toBe(true);
+    }
+  });
+
+  it('keeps DEPLOYMENT.md aligned with the package deploy alias', () => {
+    expect(deploymentDoc).toContain('npm run deploy');
+    expect(deploymentDoc).toContain('npm run build');
+    expect(deploymentDoc).toContain('op-firebase-deploy --only hosting');
+  });
+});

--- a/tests/test_op_preflight_check.sh
+++ b/tests/test_op_preflight_check.sh
@@ -136,6 +136,10 @@ test_check_fresh_cache() {
     fail "test_check_fresh_cache: stdout missing author PAT export; got $out"
     return
   fi
+  if ! echo "$out" | grep -q "export OP_PREFLIGHT_MODE=review"; then
+    fail "test_check_fresh_cache: stdout missing preflight mode export; got $out"
+    return
+  fi
   if echo "$err" | grep -q FATAL; then
     fail "test_check_fresh_cache: --check invoked op or ssh; stderr=$err"
     return

--- a/tests/test_op_preflight_token_mode.sh
+++ b/tests/test_op_preflight_token_mode.sh
@@ -223,6 +223,10 @@ test_token_mode_agents() {
       fail "test_token_mode_agents($agent): token mode marker missing"
       return
     fi
+    if ! grep -q "export OP_PREFLIGHT_MODE=review" "$out"; then
+      fail "test_token_mode_agents($agent): stdout missing preflight mode export"
+      return
+    fi
     perms="$(mode_for_file "$session")"
     if [[ "$perms" != "600" ]]; then
       fail "test_token_mode_agents($agent): session permissions expected 600, got $perms"
@@ -457,6 +461,10 @@ test_token_mode_cache_and_check() {
   fi
   if ! grep -q "export OP_PREFLIGHT_REVIEWER_PAT=reviewer-pat-codex" "$WORKDIR/check.out"; then
     fail "test_token_mode_cache_and_check: --check missing reviewer PAT export"
+    return
+  fi
+  if ! grep -q "export OP_PREFLIGHT_MODE=review" "$WORKDIR/check.out"; then
+    fail "test_token_mode_cache_and_check: --check missing preflight mode export"
     return
   fi
   if grep -q "OP_PREFLIGHT_AUTHOR_PAT" "$WORKDIR/check.out"; then


### PR DESCRIPTION
Authoring-Agent: codex

## Summary
- Fixes #521 by changing `npm run deploy` to build first, then call the PATH-provided `op-firebase-deploy` helper and purge Cloudflare.
- Reuses the preflighted Cloudflare token when available, skips purge only for deploy/all preflight runs that could not export it, and preserves direct/review-mode fallback to 1Password.
- Exports `OP_PREFLIGHT_MODE` from fresh and cached preflight paths so deploy consumers can distinguish review-only preflight from deploy/all preflight.
- Aligns README, DEPLOYMENT.md, and agent deployment instructions around `npm run deploy` as the full deploy entry point.

## Testing
- [x] Focused deploy tests: `npx vitest run tests/cf-cache-purge.test.js tests/deploy-entrypoint.test.js`
- [x] Preflight shell tests: `bash tests/test_op_preflight_check.sh`; `bash tests/test_op_preflight_token_mode.sh`
- [x] Tests pass: `npm run test`
- [x] Lint passes: `npm run lint`
- [x] E2E passes: `npm run test:e2e` (299 passed, 33 skipped)

## Review Signals
- [x] CodeRabbit clear on current HEAD (`46ae14d`), 0 `Potential issue` / warning markers
- [x] Codex GitHub App cleared current HEAD with a `+1` reaction and no findings

## Self-Review
- [x] Correctness: `npm run deploy` no longer references a missing repo-local script and preserves build + Firebase + Cloudflare purge behavior
- [x] Regression risk: deploy/preflight shell behavior is covered by focused Vitest and shell tests
- [x] Style and conventions: follows repository deploy-helper policy and avoids `firebase deploy` directly
- [x] Test coverage: added deploy-entrypoint and Cloudflare purge tests; extended preflight export tests
- [x] Security and dependency hygiene: no new dependencies or secrets added
