### PR TITLE
[claude] Adopt Prettier for the CSS/JS/TS surface (excludes .astro)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,32 @@
+# Generated / vendored
+node_modules/
+dist/
+.astro/
+package-lock.json
+coverage/
+test-results/
+playwright-report/
+
+# Static assets and checked-in screenshots
+public/
+screenshots/
+bugs/
+
+# Template-synced from mergepath (owned upstream — reformatting would drift the
+# sync audit) and Do-Not-Touch build config (.ai_context.md).
+.github/
+scripts/
+astro.config.mjs
+firebase.json
+.firebaserc
+
+# Markdown (authored content + synced docs) and YAML are not auto-formatted here.
+*.md
+*.yml
+*.yaml
+
+# .astro templates are NOT auto-formatted: Prettier's markup tag-wrapping leaks
+# insignificant whitespace into the compiled HTML, which changes element
+# textContent and breaks the site's exact-output tests (e.g.
+# tests/project-pages.test.js). Prettier formats the CSS/TS/JS/MJS instead.
+*.astro

--- a/.prettierignore
+++ b/.prettierignore
@@ -17,6 +17,7 @@ bugs/
 .github/
 scripts/
 astro.config.mjs
+eslint.config.js
 firebase.json
 .firebaserc
 

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "printWidth": 100
+}

--- a/README.md
+++ b/README.md
@@ -190,14 +190,15 @@ npm run build
 # Preview the production build locally
 npm run preview
 
-# Run lint, typecheck, and tests
+# Run lint, typecheck, format, and tests
 npm run lint
 npm run typecheck     # astro check
+npm run format        # prettier --write (CSS/JS/TS); format:check to verify only
 npm run test          # astro build && vitest run
 npm run test:e2e      # playwright test
 ```
 
-`package-lock.json` is intentionally gitignored in this repo, so `npm ci` is not available; use `npm install` for local and CI dependency installation. A `typecheck` script (`astro check`) is available; there is no `format` script at present.
+`package-lock.json` is intentionally gitignored in this repo, so `npm ci` is not available; use `npm install` for local and CI dependency installation. A `typecheck` script (`astro check`) and a `format` script (`prettier --write`, with `format:check` to verify) are available.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test:e2e": "playwright test",
     "deploy": "npm run build && op-firebase-deploy && scripts/cf-cache-purge.sh",
     "lint": "eslint .",
-    "typecheck": "astro check"
+    "typecheck": "astro check",
+    "format": "prettier --write \"src/**/*.{ts,js,mjs,css}\" \"tests/**/*.{ts,js}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,js,mjs,css}\" \"tests/**/*.{ts,js}\""
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
@@ -25,6 +27,7 @@
     "globals": "^17.6.0",
     "js-yaml": "^4.1.1",
     "jsdom": "^29.0.2",
+    "prettier": "^3.8.4",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.3",
     "unist-util-visit": "^5.1.0",

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -28,10 +28,15 @@ const projects = defineCollection({
       focus: z.string(),
     }),
     stack: z.string().optional(),
-    related: z.array(z.object({
-      label: z.string(),
-      href: z.string(),
-    })).optional().default([]),
+    related: z
+      .array(
+        z.object({
+          label: z.string(),
+          href: z.string(),
+        }),
+      )
+      .optional()
+      .default([]),
     draft: z.boolean().default(false),
 
     // Opt-in: refresh `screenshotSrc` on each build from the GitHub
@@ -60,16 +65,26 @@ const blog = defineCollection({
 
     // Sidebar content — optional, defaults to empty arrays.
     // Posts without these fields render the standard layout.
-    pullquotes: z.array(z.object({
-      text: z.string(),
-      label: z.string().optional(),
-      accent: z.enum(['red', 'yellow', 'blue']),
-    })).optional().default([]),
-    sidebar: z.array(z.object({
-      type: z.enum(['mermaid', 'image', 'text']),
-      content: z.string(),
-      caption: z.string().optional(),
-    })).optional().default([]),
+    pullquotes: z
+      .array(
+        z.object({
+          text: z.string(),
+          label: z.string().optional(),
+          accent: z.enum(['red', 'yellow', 'blue']),
+        }),
+      )
+      .optional()
+      .default([]),
+    sidebar: z
+      .array(
+        z.object({
+          type: z.enum(['mermaid', 'image', 'text']),
+          content: z.string(),
+          caption: z.string().optional(),
+        }),
+      )
+      .optional()
+      .default([]),
   }),
 });
 
@@ -87,10 +102,12 @@ const bio = defineCollection({
     // whole point of the section is freshness, so an explicit value
     // beats anything auto-derived. Format: "Month YYYY" in title case
     // (e.g., "April 2026"); the template uppercases it for display.
-    lastUpdated: z.string().regex(
-      /^(January|February|March|April|May|June|July|August|September|October|November|December) \d{4}$/,
-      'lastUpdated must be "Month YYYY" (e.g., "April 2026")'
-    ),
+    lastUpdated: z
+      .string()
+      .regex(
+        /^(January|February|March|April|May|June|July|August|September|October|November|December) \d{4}$/,
+        'lastUpdated must be "Month YYYY" (e.g., "April 2026")',
+      ),
   }),
 });
 
@@ -140,7 +157,7 @@ const experience = defineCollection({
     order: z.number(),
     badges: z.array(z.string()).optional(),
     website: z.string().optional(), // drives Logo.dev domain lookup
-    logo: z.string().optional(),    // explicit override (path or data-URI)
+    logo: z.string().optional(), // explicit override (path or data-URI)
   }),
 });
 

--- a/src/integrations/og-images.mjs
+++ b/src/integrations/og-images.mjs
@@ -134,9 +134,7 @@ export default function ogImages() {
 
             // Derive output path: og-templates/blog/slug → og/blog/slug.png
             // Special case: og-templates root pages (home, blog, projects)
-            const outputName = templatePath === '.'
-              ? 'home.png'
-              : `${templatePath}.png`;
+            const outputName = templatePath === '.' ? 'home.png' : `${templatePath}.png`;
 
             const outputPath = join(ogOutputDir, outputName);
 

--- a/src/integrations/robots-sitemap.mjs
+++ b/src/integrations/robots-sitemap.mjs
@@ -72,7 +72,7 @@ async function findSitemapFile(distDir) {
   throw new Error(
     'robots-sitemap: no sitemap file found in dist/. ' +
       'Expected sitemap-index.xml, sitemap.xml, or similar. ' +
-      'Is @astrojs/sitemap configured and running?'
+      'Is @astrojs/sitemap configured and running?',
   );
 }
 
@@ -81,7 +81,10 @@ async function findSitemapFile(distDir) {
  */
 function rewriteRobotsTxt(existing, sitemapUrl) {
   // Remove all Sitemap: lines (there should be one or zero, but be defensive)
-  let body = existing.replace(SITEMAP_LINE_RE, '').replace(/\n{3,}/g, '\n\n').trimEnd();
+  let body = existing
+    .replace(SITEMAP_LINE_RE, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd();
 
   // Ensure a single blank line separates the rules from the Sitemap directive
   if (body.length > 0) body += '\n\n';
@@ -104,7 +107,7 @@ export default function robotsSitemap() {
         if (!config.site) {
           throw new Error(
             'robots-sitemap: astro.config.mjs must declare a `site` URL. ' +
-              '@astrojs/sitemap depends on this, and so do we.'
+              '@astrojs/sitemap depends on this, and so do we.',
           );
         }
         resolvedSite = String(config.site).replace(/\/$/, '');
@@ -127,7 +130,7 @@ export default function robotsSitemap() {
             `robots-sitemap: dist/robots.txt not found. ` +
               `Expected a public/robots.txt source file to copy through. ` +
               `(${err.code || err.message})`,
-            { cause: err }
+            { cause: err },
           );
         }
 

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -3,8 +3,9 @@ import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
 
 export async function GET(context: APIContext) {
-  const posts = (await getCollection('blog', ({ data }) => !data.draft))
-    .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+  const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
+    (a, b) => b.data.date.getTime() - a.data.date.getTime(),
+  );
 
   return rss({
     title: 'The AI-Augmented PM',

--- a/src/plugins/rehype-color-chips.mjs
+++ b/src/plugins/rehype-color-chips.mjs
@@ -32,9 +32,7 @@ export default function rehypeColorChips() {
       if (!HEX_COLOR.test(value)) return;
 
       node.properties = node.properties || {};
-      const existing = Array.isArray(node.properties.className)
-        ? node.properties.className
-        : [];
+      const existing = Array.isArray(node.properties.className) ? node.properties.className : [];
       node.properties.className = [...existing, 'color-chip'];
 
       node.children.unshift({

--- a/src/plugins/rehype-figure-captions.mjs
+++ b/src/plugins/rehype-figure-captions.mjs
@@ -14,14 +14,32 @@ import { visit } from 'unist-util-visit';
  */
 // Static dimension map for CLS prevention (measured via sips)
 const imageDimensions = {
-  '/blog/six-prs-one-bug-agent-failure-modes/img/invoice-bug-01-editor-view.png': { width: 1915, height: 1716 },
-  '/blog/six-prs-one-bug-agent-failure-modes/img/invoice-bug-02-preview-view.png': { width: 1937, height: 2071 },
-  '/blog/six-prs-one-bug-agent-failure-modes/img/invoice-bug-03-broken-sent-email.png': { width: 1250, height: 1181 },
-  '/blog/six-prs-one-bug-agent-failure-modes/img/invoice-bug-04-correct-sent-email.png': { width: 1250, height: 1222 },
+  '/blog/six-prs-one-bug-agent-failure-modes/img/invoice-bug-01-editor-view.png': {
+    width: 1915,
+    height: 1716,
+  },
+  '/blog/six-prs-one-bug-agent-failure-modes/img/invoice-bug-02-preview-view.png': {
+    width: 1937,
+    height: 2071,
+  },
+  '/blog/six-prs-one-bug-agent-failure-modes/img/invoice-bug-03-broken-sent-email.png': {
+    width: 1250,
+    height: 1181,
+  },
+  '/blog/six-prs-one-bug-agent-failure-modes/img/invoice-bug-04-correct-sent-email.png': {
+    width: 1250,
+    height: 1222,
+  },
   '/blog/html-mockups-as-spec/img/mondrian-inspiration.jpg': { width: 3543, height: 3532 },
   '/blog/html-mockups-as-spec/img/ffb-editor-mockup.png': { width: 1942, height: 1412 },
-  '/blog/two-blues-one-composition/img/composition-large-blue-plane-1921.jpg': { width: 996, height: 1200 },
-  '/blog/two-blues-one-composition/img/composition-ii-red-blue-yellow-1930.jpg': { width: 1183, height: 1200 },
+  '/blog/two-blues-one-composition/img/composition-large-blue-plane-1921.jpg': {
+    width: 996,
+    height: 1200,
+  },
+  '/blog/two-blues-one-composition/img/composition-ii-red-blue-yellow-1930.jpg': {
+    width: 1183,
+    height: 1200,
+  },
 };
 
 export default function rehypeFigureCaptions() {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -43,18 +43,18 @@
   --accent-paper: #5b5f64;
   --accent-gray: #d4d4d4;
   --linkedin-blue-6: #006699;
-  --linkedin-blue-4: #00A0DC;
+  --linkedin-blue-4: #00a0dc;
   --linkedin-gray-6: #313335;
-  --linkedin-gray-3: #86888A;
-  --linkedin-gray-1: #CACCCE;
-  --bluesky-blue-7: #0E57FF;
-  --bluesky-blue-5: #1F6FFF;
-  --bluesky-blue-3: #73B6FF;
-  --bluesky-blue-1: #CFE5FF;
+  --linkedin-gray-3: #86888a;
+  --linkedin-gray-1: #caccce;
+  --bluesky-blue-7: #0e57ff;
+  --bluesky-blue-5: #1f6fff;
+  --bluesky-blue-3: #73b6ff;
+  --bluesky-blue-1: #cfe5ff;
   --github-gray-6: #101411;
   --github-gray-5: #232925;
-  --github-green-4: #0FBF3E;
-  --github-green-2: #8CF2A6;
+  --github-green-4: #0fbf3e;
+  --github-green-2: #8cf2a6;
   --line: 9px;
   /* Spacing (#472). --su (0.42rem) is the base spacing unit. The audit
      pegged it at ~4% adoption, but the real count is 27 declarations —
@@ -75,11 +75,11 @@
        sub-pixel (<=0.67px at 16px root). New tuned multiples are
        still valid where a step genuinely doesn't fit. */
   --su: 0.42rem;
-  --sp-2xs: calc(var(--su) * 0.5);   /* 0.21rem — hairline gaps */
-  --sp-xs: calc(var(--su) * 0.75);   /* 0.315rem — tight list/label gaps */
-  --sp-sm: var(--su);                /* 0.42rem — base step */
-  --sp-md: calc(var(--su) * 1.5);    /* 0.63rem — block separation */
-  --sp-lg: calc(var(--su) * 2);      /* 0.84rem — section-level gaps */
+  --sp-2xs: calc(var(--su) * 0.5); /* 0.21rem — hairline gaps */
+  --sp-xs: calc(var(--su) * 0.75); /* 0.315rem — tight list/label gaps */
+  --sp-sm: var(--su); /* 0.42rem — base step */
+  --sp-md: calc(var(--su) * 1.5); /* 0.63rem — block separation */
+  --sp-lg: calc(var(--su) * 2); /* 0.84rem — section-level gaps */
   --grid-border: #1a1814;
   --cream: #f5f0e4;
   /* Per-plane tuned mobile-panel veils; intentionally distinct from --cream. */
@@ -96,11 +96,15 @@
      lighter voice than body-muted text. The --breadcrumb-* ramp below is
      deliberately separate (#452/#454 AA calibration), and --canvas-shadow
      (0.12) keeps its own role token. */
-  --ink-06: color-mix(in srgb, var(--ink) 6%, transparent);  /* tint surfaces, offset shadows */
-  --ink-18: color-mix(in srgb, var(--ink) 18%, transparent);  /* rules/dividers, hover tints */
-  --ink-32: color-mix(in srgb, var(--ink) 32%, transparent);  /* emphasis borders, underline tint */
-  --ink-50: color-mix(in srgb, var(--ink) 50%, transparent);  /* panel eyebrow/ribbon labels */
-  --ink-62: color-mix(in srgb, var(--ink) 62%, transparent);  /* muted/secondary text (AA-safe on
+  --ink-06: color-mix(in srgb, var(--ink) 6%, transparent); /* tint surfaces, offset shadows */
+  --ink-18: color-mix(in srgb, var(--ink) 18%, transparent); /* rules/dividers, hover tints */
+  --ink-32: color-mix(in srgb, var(--ink) 32%, transparent); /* emphasis borders, underline tint */
+  --ink-50: color-mix(in srgb, var(--ink) 50%, transparent); /* panel eyebrow/ribbon labels */
+  --ink-62: color-mix(
+    in srgb,
+    var(--ink) 62%,
+    transparent
+  ); /* muted/secondary text (AA-safe on
                                         the light surfaces it appears on;
                                         see the #454 note below) */
   /* Semantic alias kept for the many existing var(--rule) border sites;
@@ -108,8 +112,8 @@
   --rule: var(--ink-18);
 
   /* Repeated page/panel surface colors, tokenized in #469. */
-  --panel-open-bg: #e4ded0;  /* warm parchment every homepage panel opens to */
-  --blue-contrast: #f0f4ff;  /* light text/chrome on the --blue panel */
+  --panel-open-bg: #e4ded0; /* warm parchment every homepage panel opens to */
+  --blue-contrast: #f0f4ff; /* light text/chrome on the --blue panel */
   /* Warm near-ink text on warm surfaces (yellow panel, open parchment).
      Collapsed from three audit-time near-duplicates (#171208 / #17130f /
      #191611) that sat on the same parchment background — drift, not
@@ -117,8 +121,8 @@
      yellow --accent-contrast) and the darkest, so contrast on the light
      surfaces can only improve (#469). */
   --ink-warm: #171208;
-  --stage-bg: #c4c3bc;       /* stage/OG backdrop + blog --project-bg */
-  --chrome-bg: #bdbeb8;      /* html/body backdrop behind the stage */
+  --stage-bg: #c4c3bc; /* stage/OG backdrop + blog --project-bg */
+  --chrome-bg: #bdbeb8; /* html/body backdrop behind the stage */
 
   /* Breadcrumb chrome (#452, raised to WCAG AA in #454): one ink ramp on
      every page. Parent links sit a visible step darker than the current
@@ -134,11 +138,11 @@
   /* Heading scale (#455): display/page/article/section tiers mirror the motion
      token pattern so page families do not hand-roll near-identical h1/h2
      values. */
-  --font-heading: "Cormorant Garamond", garamond, serif;
+  --font-heading: 'Cormorant Garamond', garamond, serif;
   /* Body/UI sans stack (#464). Counterpart to --font-heading so neither
      typeface is hand-rolled at use sites. OgCard.astro keeps its inline
      @font-face stack — required for the static OG image render context. */
-  --font-body: "Inter", system-ui, sans-serif;
+  --font-body: 'Inter', system-ui, sans-serif;
   --heading-weight: 600;
   --heading-letter-spacing: 0;
   --heading-display-size: clamp(2.8rem, 6vw, 5.4rem);
@@ -178,21 +182,21 @@
      and the Community label cross-fade (#304). Defined as tokens so
      timing stays controllable from one place; the inline script in
      src/pages/index.astro reads --pulse-* via getComputedStyle. */
-  --pulse-initial-delay: 300ms;   /* breath after panel labels finish fading
+  --pulse-initial-delay: 300ms; /* breath after panel labels finish fading
                                      in before the sequence fires; the fade-in
                                      itself runs at --motion-hover (~170ms),
                                      so this leaves the page visibly settled
                                      before any motion starts */
-  --pulse-interval: 370ms;        /* time between successive pulse starts */
-  --pulse-duration: 250ms;        /* per-panel pulse length */
-  --label-fade: 100ms;            /* per-orientation cross-fade duration */
-  --label-fade-delay-in: 150ms;   /* hold before the new orientation fades in
+  --pulse-interval: 370ms; /* time between successive pulse starts */
+  --pulse-duration: 250ms; /* per-panel pulse length */
+  --label-fade: 100ms; /* per-orientation cross-fade duration */
+  --label-fade-delay-in: 150ms; /* hold before the new orientation fades in
                                      so the container reshape leads the swap */
-  --label-fade-delay-out: 250ms;  /* hold before the original orientation
+  --label-fade-delay-out: 250ms; /* hold before the original orientation
                                      returns on collapse so the container
                                      reshapes back first */
 
-  --ease-standard: cubic-bezier(0.4, 0.0, 0.2, 1);
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
   --ease-sharp: cubic-bezier(0.2, 0.8, 0.2, 1);
   --ease-out: cubic-bezier(0, 0, 0.2, 1);
   --ease-linear: linear;
@@ -225,15 +229,20 @@
   --mondrian-max-width: 1280px;
 }
 
-[data-palette="1930"] {
+[data-palette='1930'] {
   --red: #da2418;
   --yellow: #f0c800;
   --blue: #0a5c9e;
 }
 
-* { box-sizing: border-box; margin: 0; padding: 0; }
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
 
-html, body {
+html,
+body {
   min-height: 100%;
   background: var(--chrome-bg);
   color: var(--ink);
@@ -265,7 +274,7 @@ html, body {
   grid-template-rows:
     var(--line) minmax(10rem, 3.05fr) var(--line)
     minmax(3rem, 1fr) var(--line)
-    minmax(2rem, 0.60fr) var(--line)
+    minmax(2rem, 0.6fr) var(--line)
     minmax(3.75rem, 1.12fr) var(--line);
   background: var(--black);
   border: 1px solid var(--grid-border);
@@ -302,7 +311,7 @@ html, body {
    The measureContentHeights pass in src/pages/index.astro sets the
    --cell-h-* vars on .mondrian after fonts.ready and on resize. */
 
-.mondrian[data-focus="about"] {
+.mondrian[data-focus='about'] {
   grid-template-columns:
     var(--line) minmax(10rem, 3.65fr) var(--line)
     minmax(4.4rem, 1.45fr) var(--line)
@@ -311,16 +320,16 @@ html, body {
   grid-template-rows:
     var(--line)
     var(--cell-h-about, 547px) /* track 2 — bio content height (JS-measured) */
-    0                          /* track 3 — line absorbed inside bio */
-    0                          /* track 4 — second content row absorbed */
-    var(--line)                /* track 5 — boundary line below bio */
+    0 /* track 3 — line absorbed inside bio */
+    0 /* track 4 — second content row absorbed */
+    var(--line) /* track 5 — boundary line below bio */
     minmax(2rem, 0.6fr)
     var(--line)
     minmax(3.4rem, 0.95fr)
     var(--line);
 }
 
-.mondrian[data-focus="projects"] {
+.mondrian[data-focus='projects'] {
   grid-template-columns:
     var(--line) minmax(5.2rem, 0.92fr) var(--line)
     minmax(4.2rem, 0.88fr) var(--line)
@@ -329,8 +338,8 @@ html, body {
   grid-template-rows:
     var(--line)
     var(--cell-h-projects, 676px) /* track 2 — Builds content height */
-    0                             /* track 3 — line absorbed */
-    0                             /* track 4 — absorbed */
+    0 /* track 3 — line absorbed */
+    0 /* track 4 — absorbed */
     var(--line)
     minmax(1.6rem, 0.52fr)
     var(--line)
@@ -338,11 +347,11 @@ html, body {
     var(--line);
 }
 
-.mondrian[data-focus="projects"] .panel--yellow {
+.mondrian[data-focus='projects'] .panel--yellow {
   grid-row: 2 / 5;
 }
 
-.mondrian[data-focus="community"] {
+.mondrian[data-focus='community'] {
   grid-template-columns:
     var(--line) minmax(11rem, 4.1fr) var(--line)
     minmax(4.1rem, 0.82fr) var(--line)
@@ -358,7 +367,7 @@ html, body {
 /* Connect-focus content-sizes the Connect panel by sizing track 8 to the
    measured connect content height. Community in col 2 still spans rows
    6/7/8 by default, just at the smaller resulting total height. */
-.mondrian[data-focus="connect"] {
+.mondrian[data-focus='connect'] {
   grid-template-columns:
     var(--line) minmax(7.8rem, 1.6fr) var(--line)
     minmax(5.2rem, 1.3fr) var(--line)
@@ -572,7 +581,9 @@ html[data-fonts-pending] .panel-label {
   line-height: 1.58;
 }
 
-.content-inner p { margin-bottom: 0.5rem; }
+.content-inner p {
+  margin-bottom: 0.5rem;
+}
 
 .lead {
   font-family: var(--font-heading);
@@ -648,7 +659,7 @@ html[data-fonts-pending] .panel-label {
   display: block;
   /* Warm-tinted 50% ink (not --ink-50): matches the open parchment
      surface; deliberate, kept as an override on the shared .eyebrow. */
-  color: rgba(23, 19, 15, 0.50);
+  color: rgba(23, 19, 15, 0.5);
   margin-bottom: var(--sp-2xs);
 }
 
@@ -717,7 +728,7 @@ html[data-fonts-pending] .panel-label {
   margin-top: var(--sp-sm);
   margin-bottom: var(--sp-sm);
   /* Warm-tinted 50% ink (not --ink-50): see .about-label note (#467). */
-  color: rgba(25, 22, 17, 0.50);
+  color: rgba(25, 22, 17, 0.5);
 }
 
 .availability-signal {
@@ -758,7 +769,7 @@ html[data-fonts-pending] .panel-label {
 }
 
 .social-row::after {
-  content: "";
+  content: '';
   position: absolute;
   left: 0;
   bottom: -3px;
@@ -792,22 +803,12 @@ html[data-fonts-pending] .panel-label {
   );
 }
 .social-row--blog::after {
-  background: linear-gradient(
-    90deg,
-    var(--red) 0%,
-    var(--yellow) 54%,
-    var(--blue) 100%
-  );
+  background: linear-gradient(90deg, var(--red) 0%, var(--yellow) 54%, var(--blue) 100%);
 }
 .social-row--resume::after {
   /* Reversed Mondrian (blue→yellow→red) — an internal site destination
      like Blog, distinguished from Blog's red→yellow→blue bar. */
-  background: linear-gradient(
-    90deg,
-    var(--blue) 0%,
-    var(--yellow) 54%,
-    var(--red) 100%
-  );
+  background: linear-gradient(90deg, var(--blue) 0%, var(--yellow) 54%, var(--red) 100%);
 }
 .social-row--bluesky::after {
   background: linear-gradient(
@@ -818,24 +819,14 @@ html[data-fonts-pending] .panel-label {
     var(--bluesky-blue-1) 100%
   );
 }
-.social-row--instagram::after { background: linear-gradient(90deg, #FFC273, #E56969, #C1558B, #8A49A1); }
+.social-row--instagram::after {
+  background: linear-gradient(90deg, #ffc273, #e56969, #c1558b, #8a49a1);
+}
 .social-row--threads::after {
-  background: linear-gradient(
-    90deg,
-    #000000 0%,
-    #242424 38%,
-    #6A6A6A 74%,
-    #F2F2F2 100%
-  );
+  background: linear-gradient(90deg, #000000 0%, #242424 38%, #6a6a6a 74%, #f2f2f2 100%);
 }
 .social-row--x::after {
-  background: linear-gradient(
-    90deg,
-    #000000 0%,
-    #0B0B0B 55%,
-    #7C7C7C 82%,
-    #FFFFFF 100%
-  );
+  background: linear-gradient(90deg, #000000 0%, #0b0b0b 55%, #7c7c7c 82%, #ffffff 100%);
 }
 
 .s-icon {
@@ -1074,7 +1065,7 @@ a:focus-visible .link-arrow,
 .blog-callout-link {
   font-size: 0.68rem;
   line-height: 1.45;
-  letter-spacing: 0.10em;
+  letter-spacing: 0.1em;
   word-spacing: 0.05em;
   color: var(--ink-50);
 }
@@ -1159,7 +1150,7 @@ a:focus-visible .link-arrow,
 }
 
 .effort-desc {
-  margin-top: 0.10rem;
+  margin-top: 0.1rem;
   font-size: 0.85rem;
   line-height: 1.48;
 }
@@ -1202,7 +1193,9 @@ a:focus-visible .link-arrow,
   color: var(--ink-warm);
 }
 
-.panel--red .panel-label { color: var(--cream); }
+.panel--red .panel-label {
+  color: var(--cream);
+}
 
 @container (max-width: 380px) {
   .panel--red .panel-label--name {
@@ -1216,7 +1209,11 @@ a:focus-visible .link-arrow,
   }
 }
 
-.block--white-a { grid-column: 6; grid-row: 4; background: var(--paper); }
+.block--white-a {
+  grid-column: 6;
+  grid-row: 4;
+  background: var(--paper);
+}
 
 .panel--yellow {
   grid-column: 6 / 9;
@@ -1238,7 +1235,11 @@ a:focus-visible .link-arrow,
   padding-right: 16%;
 }
 
-.block--white-b { grid-column: 8; grid-row: 4; background: var(--paper); }
+.block--white-b {
+  grid-column: 8;
+  grid-row: 4;
+  background: var(--paper);
+}
 
 .panel--black {
   grid-column: 2;
@@ -1307,11 +1308,11 @@ a:focus-visible .link-arrow,
    expansions (Connect, About) reshape elsewhere and leave Community wide
    enough for the horizontal label, so the vertical variant stays out of
    the way unless it's actually solving the truncation problem. */
-.mondrian[data-focus="projects"] .panel--black .panel-label__h {
+.mondrian[data-focus='projects'] .panel--black .panel-label__h {
   opacity: 0;
   transition-delay: 0ms;
 }
-.mondrian[data-focus="projects"] .panel--black .panel-label__v {
+.mondrian[data-focus='projects'] .panel--black .panel-label__v {
   opacity: 1;
   transition-delay: var(--label-fade-delay-in);
 }
@@ -1323,9 +1324,21 @@ a:focus-visible .link-arrow,
   }
 }
 
-.block--white-c { grid-column: 4 / 7; grid-row: 6; background: var(--paper); }
-.block--gray-e { grid-column: 8; grid-row: 6; background: var(--accent-gray); }
-.block--gray-d { grid-column: 4 / 5; grid-row: 8; background: var(--accent-gray); }
+.block--white-c {
+  grid-column: 4 / 7;
+  grid-row: 6;
+  background: var(--paper);
+}
+.block--gray-e {
+  grid-column: 8;
+  grid-row: 6;
+  background: var(--accent-gray);
+}
+.block--gray-d {
+  grid-column: 4 / 5;
+  grid-row: 8;
+  background: var(--accent-gray);
+}
 
 .panel--blue {
   grid-column: 6 / 9;
@@ -1380,37 +1393,37 @@ body.blog-page {
   --project-gradient-to: var(--cream);
 }
 
-[data-accent="red"] {
+[data-accent='red'] {
   --accent: var(--red);
   --accent-contrast: var(--cream);
   --accent-soft: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
-[data-accent="yellow"] {
+[data-accent='yellow'] {
   --accent: var(--yellow);
   --accent-contrast: var(--ink-warm);
   --accent-soft: color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
-[data-accent="black"] {
+[data-accent='black'] {
   --accent: var(--accent-black);
   --accent-contrast: var(--cream);
   --accent-soft: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
-[data-accent="blue"] {
+[data-accent='blue'] {
   --accent: var(--blue);
   --accent-contrast: var(--cream);
   --accent-soft: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
-[data-accent="lightblue"] {
+[data-accent='lightblue'] {
   --accent: var(--lightblue);
   --accent-contrast: var(--cream);
   --accent-soft: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
-[data-accent="paper"] {
+[data-accent='paper'] {
   --accent: var(--accent-paper);
   --accent-contrast: var(--cream);
   --accent-soft: color-mix(in srgb, var(--accent) 12%, transparent);
@@ -1448,7 +1461,7 @@ body.blog-page {
 }
 
 .project-hero::before {
-  content: "";
+  content: '';
   position: absolute;
   inset: 0 auto 0 0;
   width: clamp(0.5rem, 1vw, 0.8rem);
@@ -1654,26 +1667,26 @@ body.blog-page {
    the wordmark breathes rather than stretching to the full content
    column. The border on the inner img is suppressed because there's no
    raster screenshot edge to soften here. */
-[data-accent="black"] .project-screenshot {
+[data-accent='black'] .project-screenshot {
   background: var(--ink);
   border-top-color: var(--ink);
 }
-[data-accent="black"] .project-screenshot__inner {
+[data-accent='black'] .project-screenshot__inner {
   max-width: 56rem;
   margin: 0 auto;
   padding: clamp(2rem, 6vw, 4rem) clamp(1rem, 4vw, 2.5rem);
 }
-[data-accent="black"] .project-screenshot--wide img,
-[data-accent="black"] .project-screenshot--wide .project-screenshot__inner > svg {
+[data-accent='black'] .project-screenshot--wide img,
+[data-accent='black'] .project-screenshot--wide .project-screenshot__inner > svg {
   border: none;
 }
-[data-accent="black"] .project-stack {
+[data-accent='black'] .project-stack {
   color: color-mix(in srgb, var(--cream) 78%, transparent);
 }
-[data-accent="black"] .project-stack__label {
+[data-accent='black'] .project-stack__label {
   color: color-mix(in srgb, var(--cream) 62%, transparent);
 }
-[data-accent="black"] .project-stack__value {
+[data-accent='black'] .project-stack__value {
   color: color-mix(in srgb, var(--cream) 92%, transparent);
 }
 
@@ -1729,11 +1742,12 @@ body.blog-page {
   transition: opacity var(--motion-fast) var(--ease-linear);
 }
 
-.project-screenshot__mux-shell[data-playback-state="fallback"] .project-screenshot__mux {
+.project-screenshot__mux-shell[data-playback-state='fallback'] .project-screenshot__mux {
   opacity: 0;
 }
 
-.project-screenshot__mux-shell[data-playback-state="fallback"] .project-screenshot__mux-gif-fallback {
+.project-screenshot__mux-shell[data-playback-state='fallback']
+  .project-screenshot__mux-gif-fallback {
   opacity: 1;
 }
 
@@ -1759,7 +1773,7 @@ body.blog-page {
 }
 
 .project-screenshot__mux-play::before {
-  content: "";
+  content: '';
   display: block;
   width: 0;
   height: 0;
@@ -1884,7 +1898,7 @@ body.blog-page {
 }
 
 .project-copy ul li::before {
-  content: "";
+  content: '';
   position: absolute;
   top: 0.5em;
   left: 0;
@@ -1908,7 +1922,11 @@ body.blog-page {
   text-decoration: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 0.22em;
-  text-decoration-color: color-mix(in srgb, var(--project-link-color, var(--accent-text)) 55%, transparent);
+  text-decoration-color: color-mix(
+    in srgb,
+    var(--project-link-color, var(--accent-text)) 55%,
+    transparent
+  );
   transition:
     text-decoration-color var(--motion-hover) var(--ease-standard),
     text-decoration-thickness var(--motion-hover) var(--ease-standard),
@@ -1960,7 +1978,7 @@ body.blog-page {
 }
 
 .project-related__list li::before {
-  content: "";
+  content: '';
   position: absolute;
   top: 0.5em;
   left: 0;
@@ -1990,7 +2008,7 @@ body.blog-page {
   .metadata-strip--grid-4 {
     grid-template-columns: 1fr 1fr;
   }
-  .metadata-strip--grid-4 .metadata-strip__item:nth-child(n+3) {
+  .metadata-strip--grid-4 .metadata-strip__item:nth-child(n + 3) {
     border-top: 1px dotted var(--rule);
   }
   .metadata-strip--grid-4 .metadata-strip__item:nth-child(odd) {
@@ -2136,9 +2154,9 @@ body.blog-page {
      column is shrunk by half a line per adjacent gap so the black grid
      line sits centered on the target percentage. Used by the desktop
      row templates below; the mobile stack overrides to a single column. */
-  --col-post: calc(50% - var(--line) / 2);       /* column ending at the 50% line */
-  --col-mid: calc(22% - var(--line));            /* column spanning 50% → 72% */
-  --col-post-wide: calc(72% - var(--line) / 2);  /* column ending at the 72% line */
+  --col-post: calc(50% - var(--line) / 2); /* column ending at the 50% line */
+  --col-mid: calc(22% - var(--line)); /* column spanning 50% → 72% */
+  --col-post-wide: calc(72% - var(--line) / 2); /* column ending at the 72% line */
 }
 
 /* Rows place their cells on the shared 50% / 72% gridlines (see the
@@ -2457,10 +2475,10 @@ a.tag:hover {
      .error-shell's gutter without depending on flex-shrink. */
   --canvas-width: 64rem;
   display: grid;
-  grid-template-columns:
-    var(--line) 2.4fr var(--line) 1fr var(--line) 1.2fr var(--line) 0.5fr var(--line);
-  grid-template-rows:
-    var(--line) auto var(--line) 5rem var(--line) 3.5rem var(--line);
+  grid-template-columns: var(--line) 2.4fr var(--line) 1fr var(--line) 1.2fr var(--line) 0.5fr var(
+      --line
+    );
+  grid-template-rows: var(--line) auto var(--line) 5rem var(--line) 3.5rem var(--line);
   background: var(--black);
   border: 1px solid var(--grid-border);
 }
@@ -2497,19 +2515,53 @@ a.tag:hover {
   padding-left: 0;
 }
 
-.e-block { min-height: 0; }
+.e-block {
+  min-height: 0;
+}
 
 /* Grid placement for decorative blocks — each cell sits in a content track only;
    var(--line) gap tracks between every cell create consistent black separators.
    Content tracks: cols 2,4,6,8 · rows 2,4,6 */
-.e-red       { grid-column: 8; grid-row: 2;   background: var(--red); }
-.e-yellow-a  { grid-column: 2; grid-row: 4;   background: var(--yellow); }
-.e-blue      { grid-column: 4; grid-row: 4/7; background: var(--blue); }
-.e-black     { grid-column: 6; grid-row: 4;   background: var(--accent-black); }
-.e-white-a   { grid-column: 8; grid-row: 4;   background: var(--accent-gray); }
-.e-white-b   { grid-column: 2; grid-row: 6;   background: var(--accent-gray); }
-.e-yellow-b  { grid-column: 6; grid-row: 6;   background: var(--yellow); }
-.e-white-c   { grid-column: 8; grid-row: 6;   background: var(--paper); }
+.e-red {
+  grid-column: 8;
+  grid-row: 2;
+  background: var(--red);
+}
+.e-yellow-a {
+  grid-column: 2;
+  grid-row: 4;
+  background: var(--yellow);
+}
+.e-blue {
+  grid-column: 4;
+  grid-row: 4/7;
+  background: var(--blue);
+}
+.e-black {
+  grid-column: 6;
+  grid-row: 4;
+  background: var(--accent-black);
+}
+.e-white-a {
+  grid-column: 8;
+  grid-row: 4;
+  background: var(--accent-gray);
+}
+.e-white-b {
+  grid-column: 2;
+  grid-row: 6;
+  background: var(--accent-gray);
+}
+.e-yellow-b {
+  grid-column: 6;
+  grid-row: 6;
+  background: var(--yellow);
+}
+.e-white-c {
+  grid-column: 8;
+  grid-row: 6;
+  background: var(--paper);
+}
 
 /* 768px matches --bp-tablet on :root. (#332) */
 @media (max-width: 768px) {
@@ -2525,7 +2577,9 @@ a.tag:hover {
     grid-column: 2;
     grid-row: 2;
   }
-  .e-block { display: none; }
+  .e-block {
+    display: none;
+  }
 }
 
 /* ── OG Image Card ──────────────────────────────────────────────
@@ -2556,10 +2610,10 @@ a.tag:hover {
   width: 100%;
   height: 100%;
   display: grid;
-  grid-template-columns:
-    var(--line) 2.4fr var(--line) 1fr var(--line) 1.2fr var(--line) 0.5fr var(--line);
-  grid-template-rows:
-    var(--line) 1fr var(--line) 5rem var(--line) 3.5rem var(--line);
+  grid-template-columns: var(--line) 2.4fr var(--line) 1fr var(--line) 1.2fr var(--line) 0.5fr var(
+      --line
+    );
+  grid-template-rows: var(--line) 1fr var(--line) 5rem var(--line) 3.5rem var(--line);
   background: var(--black);
   border: 1px solid var(--grid-border);
   box-shadow: var(--canvas-shadow);
@@ -2632,16 +2686,50 @@ a.tag:hover {
   letter-spacing: 0.04em;
 }
 
-.og-block { min-height: 0; }
+.og-block {
+  min-height: 0;
+}
 
-.og-red       { grid-column: 8; grid-row: 2;   background: var(--red); }
-.og-yellow-a  { grid-column: 2; grid-row: 4;   background: var(--yellow); }
-.og-blue      { grid-column: 4; grid-row: 4/7; background: var(--blue); }
-.og-black     { grid-column: 6; grid-row: 4;   background: var(--accent-black); }
-.og-white-a   { grid-column: 8; grid-row: 4;   background: var(--accent-gray); }
-.og-white-b   { grid-column: 2; grid-row: 6;   background: var(--accent-gray); }
-.og-yellow-b  { grid-column: 6; grid-row: 6;   background: var(--yellow); }
-.og-white-c   { grid-column: 8; grid-row: 6;   background: var(--paper); }
+.og-red {
+  grid-column: 8;
+  grid-row: 2;
+  background: var(--red);
+}
+.og-yellow-a {
+  grid-column: 2;
+  grid-row: 4;
+  background: var(--yellow);
+}
+.og-blue {
+  grid-column: 4;
+  grid-row: 4/7;
+  background: var(--blue);
+}
+.og-black {
+  grid-column: 6;
+  grid-row: 4;
+  background: var(--accent-black);
+}
+.og-white-a {
+  grid-column: 8;
+  grid-row: 4;
+  background: var(--accent-gray);
+}
+.og-white-b {
+  grid-column: 2;
+  grid-row: 6;
+  background: var(--accent-gray);
+}
+.og-yellow-b {
+  grid-column: 6;
+  grid-row: 6;
+  background: var(--yellow);
+}
+.og-white-c {
+  grid-column: 8;
+  grid-row: 6;
+  background: var(--paper);
+}
 
 /* ── Blog Post: Mondrian "Composition with Margins" Canvas ────
    Three-column grid: accent margin | content | sticky sidebar.
@@ -2664,16 +2752,16 @@ a.tag:hover {
   display: grid;
   grid-template-columns:
     var(--line)
-    minmax(2.5rem, 0.4fr)    /* left margin — accent blocks */
+    minmax(2.5rem, 0.4fr) /* left margin — accent blocks */
     var(--line)
-    minmax(20rem, 3fr)        /* main content */
+    minmax(20rem, 3fr) /* main content */
     var(--line)
-    minmax(10rem, 1.3fr)      /* right sidebar */
+    minmax(10rem, 1.3fr) /* right sidebar */
     var(--line);
   grid-template-rows:
-    var(--line) auto           /* header row */
-    var(--line) 1fr            /* body row (content + sidebar) */
-    var(--line) auto           /* footer row */
+    var(--line) auto /* header row */
+    var(--line) 1fr /* body row (content + sidebar) */
+    var(--line) auto /* footer row */
     var(--line);
   background: var(--ink);
   /* Use clip instead of hidden — hidden creates a scroll container
@@ -2897,9 +2985,15 @@ a.tag:hover {
   background: rgba(255, 255, 255, 0.52);
 }
 
-.blog-sidebar-pullquote--red    { border-left-color: var(--red); }
-.blog-sidebar-pullquote--yellow { border-left-color: var(--yellow); }
-.blog-sidebar-pullquote--blue   { border-left-color: var(--blue); }
+.blog-sidebar-pullquote--red {
+  border-left-color: var(--red);
+}
+.blog-sidebar-pullquote--yellow {
+  border-left-color: var(--yellow);
+}
+.blog-sidebar-pullquote--blue {
+  border-left-color: var(--blue);
+}
 
 .blog-sidebar-pullquote p {
   font-family: var(--font-heading);
@@ -3073,7 +3167,7 @@ a.tag:hover {
 }
 
 .blog-prose code {
-  font-family: "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+  font-family: 'SFMono-Regular', 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace;
   font-size: 0.88em;
   background: color-mix(in srgb, var(--ink) 7%, transparent);
   padding: 0.15em 0.35em;
@@ -3126,7 +3220,7 @@ a.tag:hover {
 }
 
 .blog-prose blockquote li::before {
-  content: "";
+  content: '';
   position: absolute;
   left: 0;
   top: 0.72em;
@@ -3160,7 +3254,7 @@ a.tag:hover {
 }
 
 .blog-list li::before {
-  content: "";
+  content: '';
   position: absolute;
   left: 0;
   top: 0.72em;
@@ -3266,7 +3360,6 @@ a.tag:hover {
   --astro-code-token-punctuation: var(--ink);
   --astro-code-token-link: #4a7a3a;
 }
-
 
 /* (blog footer content styles moved to the shared .site-footer system, #434) */
 
@@ -3381,13 +3474,23 @@ a.tag:hover {
    has near-zero effect on a neutral fill.
    Supersedes #271 (inactivity nudges + on-load settle). */
 @keyframes panel-pulse {
-  0%, 100% { filter: none; }
-  50%      { filter: brightness(1.08) saturate(1.05); }
+  0%,
+  100% {
+    filter: none;
+  }
+  50% {
+    filter: brightness(1.08) saturate(1.05);
+  }
 }
 
 @keyframes panel-pulse-neutral {
-  0%, 100% { filter: none; }
-  50%      { filter: brightness(1.16); }
+  0%,
+  100% {
+    filter: none;
+  }
+  50% {
+    filter: brightness(1.16);
+  }
 }
 
 /* Blue Connect panel needs a stronger pulse than the default keyframe.
@@ -3397,8 +3500,13 @@ a.tag:hover {
    the same range as the red and yellow panels' pulses, restoring the
    "navigation hint" cue across all four primaries. (#330) */
 @keyframes panel-pulse-blue {
-  0%, 100% { filter: none; }
-  50%      { filter: brightness(1.22) saturate(1.10); }
+  0%,
+  100% {
+    filter: none;
+  }
+  50% {
+    filter: brightness(1.22) saturate(1.1);
+  }
 }
 
 .panel--pulsing {
@@ -3461,13 +3569,14 @@ a:focus-visible {
     font-size: 0.75rem;
     padding: 0.75rem 0.85rem;
   }
-
 }
 
 /* 1023px is one below --bp-stack (1024px) on :root — the homepage
    stack-mode boundary. (#332) */
 @media (max-width: 1023px) {
-  :root { --line: 6px; }
+  :root {
+    --line: 6px;
+  }
 
   /* Vertical stack fills the viewport edge-to-edge below --bp-stack (#313).
      Phone-landscape (e.g. iPhone Pro Max landscape, 956×440) and
@@ -3496,16 +3605,30 @@ a:focus-visible {
   }
 
   .panel,
-  .block { grid-column: 2; }
+  .block {
+    grid-column: 2;
+  }
 
-  .panel--red { grid-row: 2; }
-  .panel--yellow { grid-row: 4; }
-  .panel--black { grid-row: 6; }
-  .panel--blue { grid-row: 8; }
+  .panel--red {
+    grid-row: 2;
+  }
+  .panel--yellow {
+    grid-row: 4;
+  }
+  .panel--black {
+    grid-row: 6;
+  }
+  .panel--blue {
+    grid-row: 8;
+  }
 
-  .block { display: none; }
+  .block {
+    display: none;
+  }
 
-  .panel-label { display: none; }
+  .panel-label {
+    display: none;
+  }
 
   /* Stack mode renders all panel content statically — interactions are
      disabled below --bp-stack so the is-content-visible state machine
@@ -3680,14 +3803,16 @@ a:focus-visible {
   .blog-canvas {
     grid-template-columns: var(--line) 1fr var(--line);
     grid-template-rows:
-      var(--line) auto       /* sidebar-meta (moves to top) */
-      var(--line) auto       /* header */
-      var(--line) auto       /* content */
-      var(--line) auto       /* footer */
+      var(--line) auto /* sidebar-meta (moves to top) */
+      var(--line) auto /* header */
+      var(--line) auto /* content */
+      var(--line) auto /* footer */
       var(--line);
   }
 
-  .blog-margin { display: none; }
+  .blog-margin {
+    display: none;
+  }
 
   .blog-sidebar-meta {
     grid-column: 2;
@@ -3706,8 +3831,12 @@ a:focus-visible {
     gap: 0.4rem 1.5rem;
   }
 
-  .blog-sidebar-meta dt { color: rgba(255, 255, 255, 0.55); }
-  .blog-sidebar-meta dd { color: rgba(255, 255, 255, 0.95); }
+  .blog-sidebar-meta dt {
+    color: rgba(255, 255, 255, 0.55);
+  }
+  .blog-sidebar-meta dd {
+    color: rgba(255, 255, 255, 0.95);
+  }
 
   .blog-canvas-header {
     grid-column: 2;
@@ -3721,7 +3850,9 @@ a:focus-visible {
     min-width: 0;
   }
 
-  .blog-sidebar { display: none; }
+  .blog-sidebar {
+    display: none;
+  }
 
   /* blog footer reposition handled by the shared .site-footer--canvas @1023 rule (#434) */
 }
@@ -3763,16 +3894,16 @@ body.resume-page {
   display: grid;
   grid-template-columns:
     var(--line)
-    minmax(2.5rem, 0.4fr)    /* left margin — accent blocks */
+    minmax(2.5rem, 0.4fr) /* left margin — accent blocks */
     var(--line)
-    minmax(18rem, 3fr)        /* main content */
+    minmax(18rem, 3fr) /* main content */
     var(--line)
-    minmax(10rem, 1.3fr)      /* right sidebar */
+    minmax(10rem, 1.3fr) /* right sidebar */
     var(--line);
   grid-template-rows:
-    var(--line) auto           /* header row */
-    var(--line) 1fr            /* body row (content + sidebar) */
-    var(--line) auto           /* footer row */
+    var(--line) auto /* header row */
+    var(--line) 1fr /* body row (content + sidebar) */
+    var(--line) auto /* footer row */
     var(--line);
   background: var(--ink);
   /* clip (not hidden) so position:sticky on the sidebar still works. */
@@ -3963,9 +4094,15 @@ body.resume-page {
 .resume-highlight:first-of-type {
   margin-top: 0;
 }
-.resume-highlight--red    { border-left-color: var(--red); }
-.resume-highlight--yellow { border-left-color: var(--yellow); }
-.resume-highlight--blue   { border-left-color: var(--blue); }
+.resume-highlight--red {
+  border-left-color: var(--red);
+}
+.resume-highlight--yellow {
+  border-left-color: var(--yellow);
+}
+.resume-highlight--blue {
+  border-left-color: var(--blue);
+}
 .resume-highlight p {
   margin: 0;
   font-family: var(--font-heading);
@@ -4089,7 +4226,7 @@ body.resume-page {
 }
 
 .resume-prose ul li::before {
-  content: "";
+  content: '';
   position: absolute;
   top: 0.55em;
   left: 0;
@@ -4379,7 +4516,7 @@ body.resume-page {
 }
 
 .resume-writing__essays li::before {
-  content: "";
+  content: '';
   position: absolute;
   top: 0.55em;
   left: 0;
@@ -4440,14 +4577,16 @@ body.resume-page {
   .resume-canvas {
     grid-template-columns: var(--line) 1fr var(--line);
     grid-template-rows:
-      var(--line) auto    /* header (name + breadcrumbs) — top */
-      var(--line) auto    /* metadata panel */
-      var(--line) auto    /* content */
-      var(--line) auto    /* footer */
+      var(--line) auto /* header (name + breadcrumbs) — top */
+      var(--line) auto /* metadata panel */
+      var(--line) auto /* content */
+      var(--line) auto /* footer */
       var(--line);
   }
 
-  .resume-canvas-margin { display: none; }
+  .resume-canvas-margin {
+    display: none;
+  }
 
   .resume-canvas-meta {
     grid-column: 2;
@@ -4463,9 +4602,17 @@ body.resume-page {
     gap: 0.5rem 1.5rem;
   }
 
-  .resume-canvas-header { grid-column: 2; grid-row: 2; }
-  .resume-canvas-content { grid-column: 2; grid-row: 6; }
-  .resume-canvas-sidebar { display: none; }
+  .resume-canvas-header {
+    grid-column: 2;
+    grid-row: 2;
+  }
+  .resume-canvas-content {
+    grid-column: 2;
+    grid-row: 6;
+  }
+  .resume-canvas-sidebar {
+    display: none;
+  }
   /* Match the blog footer's narrow-screen flow: stack + center. */
   /* Resume footer reposition + column-stack now come from the shared
      .site-footer / .site-footer--canvas @1023 rules (#434); --resume is the
@@ -4589,17 +4736,17 @@ body.resume-page {
      project links, and the Writing/Projects leads (nathanpayne.com/blog,
      nathanpayne.com/projects) — suppress this to avoid duplication. (The
      essay list is hidden in print; see the Writing-collapse rule below.) */
-  .resume-canvas a[href^="http"]::after {
-    content: " (" attr(href) ")";
+  .resume-canvas a[href^='http']::after {
+    content: ' (' attr(href) ')';
     font-size: 0.85em;
     word-break: break-all;
   }
 
-  .resume-contact a[href^="http"]::after,
-  .resume-entry__link a[href^="http"]::after,
-  .resume-projects__lead a[href^="http"]::after,
-  .resume-writing__lead a[href^="http"]::after {
-    content: "";
+  .resume-contact a[href^='http']::after,
+  .resume-entry__link a[href^='http']::after,
+  .resume-projects__lead a[href^='http']::after,
+  .resume-writing__lead a[href^='http']::after {
+    content: '';
   }
 
   /* Writing collapses to just its lead line in print. The section is
@@ -4618,7 +4765,9 @@ body.resume-page {
 
   /* With the intro hidden, the Projects lead carries the gap to the first
      entry (.resume-entry:first-of-type zeroes its own top margin). */
-  .resume-projects__lead { margin-bottom: 0.52rem; }
+  .resume-projects__lead {
+    margin-bottom: 0.52rem;
+  }
 
   /* Print density — restore the screen rhythm to fill three balanced
      US-Letter pages. The earlier tuning crushed these gaps to their floor to
@@ -4629,20 +4778,44 @@ body.resume-page {
      packs into three pages instead of spilling the Writing tail onto a fourth
      in renderers (Safari, Chromium) that fit slightly less per page. This is
      the fine-tune dial: nudge up if page 3 lands thin, down if it spills. */
-  .resume-contact { margin-top: 0.32rem; gap: 0.12rem 0.4rem; line-height: 1.3; }
-  .resume-contact--profiles { margin-top: 0.1rem; }
+  .resume-contact {
+    margin-top: 0.32rem;
+    gap: 0.12rem 0.4rem;
+    line-height: 1.3;
+  }
+  .resume-contact--profiles {
+    margin-top: 0.1rem;
+  }
   /* Drop the inter-section divider rules in print and reclaim the padding
      they reserved — the bold section titles carry the separation, and this
      buys vertical space toward the three-page fit (Safari fits ~11% less per
      page than Chromium). */
-  .resume-section { margin-top: 0.55rem; padding-top: 0; border-top: none; }
-  .resume-summary { margin-top: 0.32rem; }
-  .resume-section__title { margin-bottom: 0.28rem; }
-  .resume-entry { margin-top: 0.52rem; }
-  .resume-entry__meta { margin-top: 0.1rem; }
-  .resume-entry__head { gap: 0.5rem; }
-  .resume-entry--logo .resume-prose { margin-top: 0.14rem; }
-  .resume-prose p + p { margin-top: 0.24rem; }
+  .resume-section {
+    margin-top: 0.55rem;
+    padding-top: 0;
+    border-top: none;
+  }
+  .resume-summary {
+    margin-top: 0.32rem;
+  }
+  .resume-section__title {
+    margin-bottom: 0.28rem;
+  }
+  .resume-entry {
+    margin-top: 0.52rem;
+  }
+  .resume-entry__meta {
+    margin-top: 0.1rem;
+  }
+  .resume-entry__head {
+    gap: 0.5rem;
+  }
+  .resume-entry--logo .resume-prose {
+    margin-top: 0.14rem;
+  }
+  .resume-prose p + p {
+    margin-top: 0.24rem;
+  }
   /* Render the bullet list as normal block flow in print instead of the
      screen's CSS grid. Grid containers don't fragment reliably across page
      breaks — Safari slices grid items at the page edge (the clipped-bullet
@@ -4650,23 +4823,48 @@ body.resume-page {
      being ignored on the items. Block flow paginates cleanly and lets those
      per-item rules actually keep each bullet whole. The grid `gap` is
      restored as a top margin on each item. */
-  .resume-prose ul { display: block; margin-top: 0.2rem; }
-  .resume-prose li { padding-left: 0.8rem; margin-top: 0.14rem; }
-  .resume-prose li:first-child { margin-top: 0; }
-  .resume-prose ul li::before { top: 0.5em; }
-  .resume-skills__list { gap: 0.24rem; }
-  .resume-skills__row { gap: 0.12rem 0.72rem; }
+  .resume-prose ul {
+    display: block;
+    margin-top: 0.2rem;
+  }
+  .resume-prose li {
+    padding-left: 0.8rem;
+    margin-top: 0.14rem;
+  }
+  .resume-prose li:first-child {
+    margin-top: 0;
+  }
+  .resume-prose ul li::before {
+    top: 0.5em;
+  }
+  .resume-skills__list {
+    gap: 0.24rem;
+  }
+  .resume-skills__row {
+    gap: 0.12rem 0.72rem;
+  }
   /* Same grid->block fix as the prose bullets: the certifications list is a
      CSS grid on screen, which Safari slices at a page edge (the clipped cert
      at the page 2->3 break). Render the list AND each cert as block flow in
      print — the logo is hidden here, so the cert's flex row isn't needed —
      so each cert's break-inside:avoid keeps it whole. Grid `gap` -> margin. */
-  .resume-certs { display: block; }
-  .resume-cert { display: block; margin-top: 0.28rem; }
-  .resume-cert:first-child { margin-top: 0; }
+  .resume-certs {
+    display: block;
+  }
+  .resume-cert {
+    display: block;
+    margin-top: 0.28rem;
+  }
+  .resume-cert:first-child {
+    margin-top: 0;
+  }
   .resume-projects .resume-entry__tech,
-  .resume-entry__link { margin-top: 0.1rem; }
-  .resume-entry__link + .resume-prose { margin-top: 0.2rem; }
+  .resume-entry__link {
+    margin-top: 0.1rem;
+  }
+  .resume-entry__link + .resume-prose {
+    margin-top: 0.2rem;
+  }
 
   /* Print type scale — decompressed to a readable body size so three pages
      fill with the content already present (issue #420 R-02 Tier 1). Body is
@@ -4676,40 +4874,76 @@ body.resume-page {
      roomier layout clipped the Writing essay links off the bottom of page 3.
      Both values stay well above the pre-issue floor (8.5pt / 1.22).
      Section/entry titles keep their Tier-1 sizes. */
-  .resume-name { font-size: 18pt; line-height: 1; }
-  .resume-title { font-size: 11.5pt; line-height: 1.25; }
-  .resume-contact { font-size: 9.5pt; }
-  .resume-section__title { font-size: 14pt; }
-  .resume-entry__title { font-size: 12pt; line-height: 1.15; }
-  .resume-entry__meta { font-size: 9pt; }
+  .resume-name {
+    font-size: 18pt;
+    line-height: 1;
+  }
+  .resume-title {
+    font-size: 11.5pt;
+    line-height: 1.25;
+  }
+  .resume-contact {
+    font-size: 9.5pt;
+  }
+  .resume-section__title {
+    font-size: 14pt;
+  }
+  .resume-entry__title {
+    font-size: 12pt;
+    line-height: 1.15;
+  }
+  .resume-entry__meta {
+    font-size: 9pt;
+  }
   .resume-prose p,
   .resume-prose li,
-  .resume-skills__values { font-size: 9.5pt; line-height: 1.3; }
+  .resume-skills__values {
+    font-size: 9.5pt;
+    line-height: 1.3;
+  }
   .resume-skills__label,
-  .resume-cert__name { font-size: 9.5pt; }
+  .resume-cert__name {
+    font-size: 9.5pt;
+  }
   .resume-cert__meta,
-  .resume-entry__tech { font-size: 9pt; }
+  .resume-entry__tech {
+    font-size: 9pt;
+  }
   .resume-projects__lead,
-  .resume-writing__lead { font-size: 9.5pt; line-height: 1.35; }
+  .resume-writing__lead {
+    font-size: 9.5pt;
+    line-height: 1.35;
+  }
 
   /* Project link matches the new body size (issue #420 R-05). At the old
      8.5pt body the screen-sized link dwarfed the title; it should simply equal
      the body (now 9.5pt per Contingency B). (The underline treatment lives
      with the black-on-white link rule above.) */
   .resume-entry__link,
-  .resume-entry__link a { font-size: 9.5pt; line-height: 1.35; }
+  .resume-entry__link a {
+    font-size: 9.5pt;
+    line-height: 1.35;
+  }
 
   /* Page-break polish (issue #420 R-06). break-inside:avoid on entries/certs/
      skills-rows/essays already lives above; keep a section title with the
      first entry under it, and prevent single-line orphans/widows in prose. */
-  .resume-section__title { break-after: avoid; }
-  .resume-prose p { orphans: 3; widows: 3; }
+  .resume-section__title {
+    break-after: avoid;
+  }
+  .resume-prose p {
+    orphans: 3;
+    widows: 3;
+  }
   /* Bullets are <li>, and Safari ignores break-inside:avoid on list items —
      but it DOES honor orphans/widows. Requiring >=2 lines on each side of a
      break means a 2-3 line bullet that would straddle a page edge is pushed
      whole to the next page instead of being sliced mid-line (the clipped-line
      artifact this fixes). */
-  .resume-prose li { orphans: 2; widows: 2; }
+  .resume-prose li {
+    orphans: 2;
+    widows: 2;
+  }
 
   /* The two tall Experience entries — the first (Disney NCP: intro paragraph
      + 7 bullets) and the last (CNN: the Magic Wall paragraph) — are

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3167,7 +3167,7 @@ a.tag:hover {
 }
 
 .blog-prose code {
-  font-family: 'SFMono-Regular', 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-family: SFMono-Regular, 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace;
   font-size: 0.88em;
   background: color-mix(in srgb, var(--ink) 7%, transparent);
   padding: 0.15em 0.35em;
@@ -3832,10 +3832,10 @@ a:focus-visible {
   }
 
   .blog-sidebar-meta dt {
-    color: rgba(255, 255, 255, 0.55);
+    color: color-mix(in srgb, var(--accent-contrast) 62%, transparent);
   }
   .blog-sidebar-meta dd {
-    color: rgba(255, 255, 255, 0.95);
+    color: var(--accent-contrast);
   }
 
   .blog-canvas-header {

--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -13,7 +13,10 @@ const panelScript = inlineScripts.find((s) => s.includes('section_view')) || '';
 // token, so it may be absent from a token-less build (e.g. CI). Assert the
 // init contract against the component SOURCE (build-env-independent); assert
 // event behavior against the homepage script, which always renders.
-const posthogComponentSrc = readFileSync(resolve(__dirname, '../src/components/posthog.astro'), 'utf-8');
+const posthogComponentSrc = readFileSync(
+  resolve(__dirname, '../src/components/posthog.astro'),
+  'utf-8',
+);
 const posthogHomepageScript = inlineScripts.find((s) => s.includes('homepage_panel_opened')) || '';
 // GA4 is loaded by BaseLayout from the env Measurement ID and gated on it, so
 // assert the load contract against the layout SOURCE (build-env-independent).
@@ -33,7 +36,10 @@ function setupDOM() {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
     value: vi.fn((query) => ({
-      matches: query === '(hover: hover) and (pointer: fine)' ? true : !query.includes('max-width: 1023px'),
+      matches:
+        query === '(hover: hover) and (pointer: fine)'
+          ? true
+          : !query.includes('max-width: 1023px'),
       media: query,
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
@@ -83,7 +89,8 @@ describe('Analytics', () => {
     panel.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
 
     const sectionViewCalls = gtagMock.mock.calls.filter(
-      (call) => call[0] === 'event' && call[1] === 'section_view' && call[2].section_name === 'projects'
+      (call) =>
+        call[0] === 'event' && call[1] === 'section_view' && call[2].section_name === 'projects',
     );
     expect(sectionViewCalls).toHaveLength(1);
   });

--- a/tests/blog-pages.test.js
+++ b/tests/blog-pages.test.js
@@ -4,7 +4,10 @@ import { resolve } from 'path';
 
 const homepageHtml = readFileSync(resolve(__dirname, '../dist/index.html'), 'utf-8');
 const blogIndexHtml = readFileSync(resolve(__dirname, '../dist/blog/index.html'), 'utf-8');
-const blogPostHtml = readFileSync(resolve(__dirname, '../dist/blog/six-prs-one-bug-agent-failure-modes/index.html'), 'utf-8');
+const blogPostHtml = readFileSync(
+  resolve(__dirname, '../dist/blog/six-prs-one-bug-agent-failure-modes/index.html'),
+  'utf-8',
+);
 const firebaseConfig = JSON.parse(readFileSync(resolve(__dirname, '../firebase.json'), 'utf-8'));
 
 function setupDOM(html) {
@@ -57,7 +60,9 @@ describe('Blog Pages', () => {
     const screenshots = [...document.querySelectorAll('.blog-figure img')];
     const localMdLink = document.querySelector('a[href$=".md"]:not([href^="https://"])');
 
-    expect(canonical?.getAttribute('href')).toBe('https://nathanpayne.com/blog/six-prs-one-bug-agent-failure-modes/');
+    expect(canonical?.getAttribute('href')).toBe(
+      'https://nathanpayne.com/blog/six-prs-one-bug-agent-failure-modes/',
+    );
     expect(ogType?.getAttribute('content')).toBe('article');
     expect(screenshots).toHaveLength(4);
     expect(screenshots[0].getAttribute('src')).toContain('invoice-bug-01-editor-view.png');
@@ -73,7 +78,9 @@ describe('Blog Pages', () => {
 
     expect(posting).toBeDefined();
     expect(posting.headline).toBe('Six PRs, One Bug: What AI Agents Actually Get Wrong');
-    expect(posting.image).toBe('https://nathanpayne.com/og/blog/six-prs-one-bug-agent-failure-modes.png');
+    expect(posting.image).toBe(
+      'https://nathanpayne.com/og/blog/six-prs-one-bug-agent-failure-modes.png',
+    );
   });
 
   it('hosting deploys from dist/ so markdown source is excluded', () => {

--- a/tests/blog-responsive.test.js
+++ b/tests/blog-responsive.test.js
@@ -15,7 +15,10 @@ const blogPostPaths = readdirSync(blogRoot)
     const dir = resolve(blogRoot, name);
     return statSync(dir).isDirectory() && existsSync(resolve(dir, 'index.html'));
   })
-  .map((name) => ({ slug: name, html: readFileSync(resolve(blogRoot, name, 'index.html'), 'utf-8') }));
+  .map((name) => ({
+    slug: name,
+    html: readFileSync(resolve(blogRoot, name, 'index.html'), 'utf-8'),
+  }));
 
 function setupDOM(html) {
   document.documentElement.innerHTML = '';
@@ -104,7 +107,10 @@ describe('Blog Responsive Layout', () => {
         setupDOM(post.html);
         const allImages = document.querySelectorAll('main img');
         for (const img of allImages) {
-          expect(img.closest('.blog-figure'), `${post.slug}: image not in .blog-figure`).not.toBeNull();
+          expect(
+            img.closest('.blog-figure'),
+            `${post.slug}: image not in .blog-figure`,
+          ).not.toBeNull();
         }
       }
     });

--- a/tests/contain-path.test.js
+++ b/tests/contain-path.test.js
@@ -27,8 +27,6 @@ describe('containedJoin', () => {
   });
 
   it('accepts .. segments that stay inside the base after normalization', () => {
-    expect(containedJoin(base, '/images/../fonts/a.woff2')).toBe(
-      `${base}${sep}fonts${sep}a.woff2`,
-    );
+    expect(containedJoin(base, '/images/../fonts/a.woff2')).toBe(`${base}${sep}fonts${sep}a.woff2`);
   });
 });

--- a/tests/integration-contracts.test.js
+++ b/tests/integration-contracts.test.js
@@ -70,7 +70,7 @@ function listIntegrationFiles() {
 function stripComments(source) {
   return source
     .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
-    .replace(/\/\/.*$/gm, '');         // line comments
+    .replace(/\/\/.*$/gm, ''); // line comments
 }
 
 const integrationFiles = listIntegrationFiles();
@@ -99,7 +99,7 @@ describe('Astro integration contracts (Windows portability)', () => {
         `${file} still references dir.pathname in runtime code. ` +
           `Use fileURLToPath(dir) from node:url instead — dir.pathname ` +
           `yields /C:/path/... on Windows and breaks path.join. ` +
-          `See #171 / #173 for the documented pattern.`
+          `See #171 / #173 for the documented pattern.`,
       ).not.toMatch(/\bdir\.pathname\b/);
     });
 
@@ -114,9 +114,9 @@ describe('Astro integration contracts (Windows portability)', () => {
           `${file} uses the astro:build:done hook but does not import ` +
             `fileURLToPath. Every integration that consumes the 'dir' ` +
             `parameter must convert it via fileURLToPath(dir) — see ` +
-            `specs/seo-metadata.md requirement 16.`
+            `specs/seo-metadata.md requirement 16.`,
         ).toMatch(/import\s*\{[^}]*\bfileURLToPath\b[^}]*\}\s*from\s*['"]node:url['"]/);
-      }
+      },
     );
   });
 });

--- a/tests/keyboard-navigation.test.js
+++ b/tests/keyboard-navigation.test.js
@@ -16,7 +16,10 @@ function setupDOM() {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
     value: vi.fn((query) => ({
-      matches: query === '(hover: hover) and (pointer: fine)' ? true : !query.includes('max-width: 1023px'),
+      matches:
+        query === '(hover: hover) and (pointer: fine)'
+          ? true
+          : !query.includes('max-width: 1023px'),
       media: query,
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
@@ -108,7 +111,9 @@ describe('Keyboard Navigation', () => {
     // Focus leaves to an element outside the panel. The state machine
     // (#313) fades content first (--motion-fast ≈ 130ms) before
     // removing is-open.
-    panel.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: document.body }));
+    panel.dispatchEvent(
+      new FocusEvent('focusout', { bubbles: true, relatedTarget: document.body }),
+    );
     await new Promise((resolve) => setTimeout(resolve, 700));
     expect(panel.classList.contains('is-open')).toBe(false);
   });

--- a/tests/mermaid-diagrams.test.js
+++ b/tests/mermaid-diagrams.test.js
@@ -6,9 +6,7 @@ describe('remark-mermaid plugin', () => {
 
     const tree = {
       type: 'root',
-      children: [
-        { type: 'code', lang: 'mermaid', value: 'graph TD\nA --> B' },
-      ],
+      children: [{ type: 'code', lang: 'mermaid', value: 'graph TD\nA --> B' }],
     };
 
     remarkMermaid()(tree);
@@ -24,9 +22,7 @@ describe('remark-mermaid plugin', () => {
 
     const tree = {
       type: 'root',
-      children: [
-        { type: 'code', lang: 'javascript', value: 'const x = 1;' },
-      ],
+      children: [{ type: 'code', lang: 'javascript', value: 'const x = 1;' }],
     };
 
     remarkMermaid()(tree);

--- a/tests/no-external-images.test.js
+++ b/tests/no-external-images.test.js
@@ -25,7 +25,7 @@ describe('No External Images', () => {
       const content = readFileSync(file, 'utf-8');
       expect(
         content.includes('raw.githubusercontent.com'),
-        `${file} contains a raw.githubusercontent.com reference`
+        `${file} contains a raw.githubusercontent.com reference`,
       ).toBe(false);
     }
   });

--- a/tests/og-image-targets.test.js
+++ b/tests/og-image-targets.test.js
@@ -64,7 +64,7 @@ function extractImageMetas(htmlPath) {
 
   const out = [];
   for (const meta of doc.querySelectorAll(
-    'meta[property="og:image"], meta[property="og:image:secure_url"], meta[name="twitter:image"]'
+    'meta[property="og:image"], meta[property="og:image:secure_url"], meta[name="twitter:image"]',
   )) {
     const content = meta.getAttribute('content');
     if (content) {
@@ -119,11 +119,11 @@ describe('OG image targets (post-build)', () => {
       existsSync(distDir),
       `Build output not found at ${distDir}. ` +
         `Run \`npm run build\` (or \`npm test\`, which runs it for you) ` +
-        `before invoking vitest directly.`
+        `before invoking vitest directly.`,
     ).toBe(true);
     htmlFiles = findIndexHtmlFiles(distDir);
     ogImageFindings = htmlFiles.flatMap((htmlPath) =>
-      extractImageMetas(htmlPath).map((meta) => ({ htmlPath, ...meta }))
+      extractImageMetas(htmlPath).map((meta) => ({ htmlPath, ...meta })),
     );
   });
 
@@ -143,21 +143,19 @@ describe('OG image targets (post-build)', () => {
     });
     expect(
       pagesWithoutOgImage.map((p) => relative(distDir, p)),
-      'These pages have no og:image meta tag. Add one to the page layout.'
+      'These pages have no og:image meta tag. Add one to the page layout.',
     ).toEqual([]);
   });
 
   it('every og:image / og:image:secure_url / twitter:image URL is absolute https on nathanpayne.com', () => {
-    const invalid = ogImageFindings.filter(
-      (f) => !f.content.startsWith(`${SITE}/`)
-    );
+    const invalid = ogImageFindings.filter((f) => !f.content.startsWith(`${SITE}/`));
     expect(
       invalid.map((f) => ({
         page: relative(distDir, f.htmlPath),
         tag: f.tag,
         content: f.content,
       })),
-      'These image tags are not absolute URLs under https://nathanpayne.com/.'
+      'These image tags are not absolute URLs under https://nathanpayne.com/.',
     ).toEqual([]);
   });
 
@@ -182,7 +180,7 @@ describe('OG image targets (post-build)', () => {
       'These pages reference OG images that do not exist in dist/ ' +
         '(or resolve to a directory). This is the class of bug #163 ' +
         'diagnosed — verify the integration that generates OG images ' +
-        'ran and wrote the expected filename.'
+        'ran and wrote the expected filename.',
     ).toEqual([]);
   });
 
@@ -200,10 +198,7 @@ describe('OG image targets (post-build)', () => {
         });
       }
     }
-    expect(
-      mismatches,
-      'og:image and twitter:image should point at the same asset.'
-    ).toEqual([]);
+    expect(mismatches, 'og:image and twitter:image should point at the same asset.').toEqual([]);
   });
 
   it('og:image:secure_url matches og:image when both are present', () => {

--- a/tests/panel-interaction.test.js
+++ b/tests/panel-interaction.test.js
@@ -17,7 +17,10 @@ function setupDOM() {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
     value: vi.fn((query) => ({
-      matches: query === '(hover: hover) and (pointer: fine)' ? true : !query.includes('max-width: 1023px'),
+      matches:
+        query === '(hover: hover) and (pointer: fine)'
+          ? true
+          : !query.includes('max-width: 1023px'),
       media: query,
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),

--- a/tests/parse-frontmatter.test.js
+++ b/tests/parse-frontmatter.test.js
@@ -96,17 +96,17 @@ describe('parseFrontmatter (scripts/lib/parse-frontmatter.mjs)', () => {
   it('preserves array + object structure but strings inside them too', () => {
     const md = [
       '---',
-      'tags: [1, 2, 3]',            // inline array of bare scalars
+      'tags: [1, 2, 3]', // inline array of bare scalars
       'metadata:',
-      '  count: 5',                  // nested bare scalar
+      '  count: 5', // nested bare scalar
       '  flag: true',
       '---',
     ].join('\n');
     const data = parseFrontmatter(md);
     expect(Array.isArray(data.tags)).toBe(true);
-    expect(data.tags).toEqual(['1', '2', '3']);   // strings under FAILSAFE
+    expect(data.tags).toEqual(['1', '2', '3']); // strings under FAILSAFE
     expect(typeof data.metadata).toBe('object');
-    expect(data.metadata.count).toBe('5');         // strings under FAILSAFE
+    expect(data.metadata.count).toBe('5'); // strings under FAILSAFE
     expect(data.metadata.flag).toBe('true');
   });
 

--- a/tests/path-conversion.test.js
+++ b/tests/path-conversion.test.js
@@ -38,10 +38,7 @@ import { resolve } from 'node:path';
 
 const REPO_ROOT = resolve(fileURLToPath(import.meta.url), '..', '..');
 
-const BUILD_SCRIPTS = [
-  'scripts/refresh-hero-images.mjs',
-  'scripts/refresh-mux-gifs.mjs',
-];
+const BUILD_SCRIPTS = ['scripts/refresh-hero-images.mjs', 'scripts/refresh-mux-gifs.mjs'];
 
 // The buggy pattern. Match the call form, not the literal substring —
 // `import.meta.url.replace(...)` with any args is suspicious in the

--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -127,13 +127,17 @@ describe('Project Pages — routes', () => {
     expect(panel.querySelector('.content-inner > p')?.textContent).toBe(
       'Every project started as a real problem and shipped end-to-end—Claude Code, Codex, and Cursor—within a multi-agent review system I designed to catch the failure modes agents miss.',
     );
-    expect(projectItems.map((item) => item.querySelector('.p-name')?.textContent.replace('→', '').trim())).toEqual(
-      canonicalProjectCards.map((card) => card.title),
-    );
+    expect(
+      projectItems.map((item) =>
+        item.querySelector('.p-name')?.textContent.replace('→', '').trim(),
+      ),
+    ).toEqual(canonicalProjectCards.map((card) => card.title));
     expect(projectItems.map((item) => item.querySelector('.p-name')?.getAttribute('href'))).toEqual(
       canonicalProjectCards.map((card) => card.href),
     );
-    expect(projectItems.map((item) => item.querySelector('p')?.textContent)).toEqual(homepageProjectDescriptions);
+    expect(projectItems.map((item) => item.querySelector('p')?.textContent)).toEqual(
+      homepageProjectDescriptions,
+    );
     expect(homepageProjectDescriptions.join(' ')).not.toMatch(/\b(?:you|your)\b/i);
   });
 
@@ -141,11 +145,17 @@ describe('Project Pages — routes', () => {
     setupDOM(readDistHtml('projects/index.html'));
 
     const links = [...document.querySelectorAll('.blog-grid .post-title a')];
-    const matchlineCard = links.find((link) => link.textContent === 'Matchline')?.closest('.post-card');
+    const matchlineCard = links
+      .find((link) => link.textContent === 'Matchline')
+      ?.closest('.post-card');
     const matchlineDescription = matchlineCard?.querySelector('.post-desc')?.textContent;
 
-    expect(links.map((link) => link.textContent)).toEqual(canonicalProjectCards.map((card) => card.title));
-    expect(links.map((link) => link.getAttribute('href'))).toEqual(canonicalProjectCards.map((card) => card.href));
+    expect(links.map((link) => link.textContent)).toEqual(
+      canonicalProjectCards.map((card) => card.title),
+    );
+    expect(links.map((link) => link.getAttribute('href'))).toEqual(
+      canonicalProjectCards.map((card) => card.href),
+    );
     expect(matchlineDescription).toContain('generates applications grounded in demonstrated work');
     expect(matchlineDescription).not.toContain('what the user has actually done');
   });
@@ -162,9 +172,9 @@ describe('Project Pages — routes', () => {
     );
 
     expect(titleByRow).toEqual(canonicalProjectCards.map((card) => card.title));
-    expect(rows.map((row) => [...row.classList].find((className) => className.startsWith('grid-row--')))).toEqual(
-      projectIndexAccentRows.map((row) => row.rowClass),
-    );
+    expect(
+      rows.map((row) => [...row.classList].find((className) => className.startsWith('grid-row--'))),
+    ).toEqual(projectIndexAccentRows.map((row) => row.rowClass));
     expect(accentClassesByRow).toEqual(projectIndexAccentRows.map((row) => row.accentClasses));
   });
 
@@ -230,8 +240,8 @@ describe('Project Pages — render', () => {
       });
 
       it('renders all four metadata labels (Topics, Format, Focus, Status)', () => {
-        const labels = Array.from(document.querySelectorAll('.metadata-strip dt')).map(
-          (dt) => dt.textContent.trim(),
+        const labels = Array.from(document.querySelectorAll('.metadata-strip dt')).map((dt) =>
+          dt.textContent.trim(),
         );
         expect(labels).toEqual(['Topics', 'Format', 'Focus', 'Status']);
       });
@@ -272,15 +282,13 @@ describe('Project Pages — render', () => {
       it('has a .project-copy container with an <h2>Overview</h2> heading', () => {
         const copy = document.querySelector('.project-copy');
         expect(copy, '.project-copy not found').not.toBeNull();
-        const headings = Array.from(copy.querySelectorAll('h2')).map((h) =>
-          h.textContent.trim(),
-        );
+        const headings = Array.from(copy.querySelectorAll('h2')).map((h) => h.textContent.trim());
         expect(headings).toContain('Overview');
       });
 
       it('renders the appropriate CTA actions for the project', () => {
-        const actions = Array.from(document.querySelectorAll('.nav-button')).map(
-          (a) => a.textContent.trim(),
+        const actions = Array.from(document.querySelectorAll('.nav-button')).map((a) =>
+          a.textContent.trim(),
         );
         // The "Back to Projects" / "Back to Homepage" footer actions also
         // share the .nav-button class, so filter to the hero CTAs by
@@ -311,7 +319,9 @@ describe('Project Pages — render', () => {
           }
         }
         if (noLiveUrlSlugs.includes(slug)) {
-          expect(foundSoftwareApp, 'pre-launch project should NOT emit SoftwareApplication').toBe(false);
+          expect(foundSoftwareApp, 'pre-launch project should NOT emit SoftwareApplication').toBe(
+            false,
+          );
         } else {
           expect(foundSoftwareApp, 'no SoftwareApplication entity in JSON-LD graph').toBe(true);
         }
@@ -335,7 +345,9 @@ describe('Project Pages — screenshot aspect variants', () => {
     const player = document.querySelector('mux-background-video.project-screenshot__mux');
     expect(player, 'Swipe Watch mux-background-video not found').not.toBeNull();
     expect(document.querySelector('mux-player')).toBeNull();
-    expect(player.getAttribute('src')).toBe('https://stream.mux.com/wNCRY97981o2uDAJrJ3ExPeK379yldRRFJgUIgSYz00k.m3u8');
+    expect(player.getAttribute('src')).toBe(
+      'https://stream.mux.com/wNCRY97981o2uDAJrJ3ExPeK379yldRRFJgUIgSYz00k.m3u8',
+    );
     expect(player.getAttribute('preload')).toBe('auto');
     expect(player.hasAttribute('max-resolution')).toBe(false);
 
@@ -361,7 +373,9 @@ describe('Project Pages — screenshot aspect variants', () => {
 
     const poster = player.querySelector('.project-screenshot__mux-poster');
     expect(poster, 'Swipe Watch poster img not found').not.toBeNull();
-    expect(poster.getAttribute('src')).toBe('https://image.mux.com/wNCRY97981o2uDAJrJ3ExPeK379yldRRFJgUIgSYz00k/thumbnail.jpg?width=1280&time=0');
+    expect(poster.getAttribute('src')).toBe(
+      'https://image.mux.com/wNCRY97981o2uDAJrJ3ExPeK379yldRRFJgUIgSYz00k/thumbnail.jpg?width=1280&time=0',
+    );
     expect(poster.getAttribute('aria-hidden')).toBe('true');
 
     const moduleSrcs = Array.from(
@@ -397,7 +411,10 @@ describe('Project Pages — screenshot aspect variants', () => {
         document.querySelector('mux-background-video'),
         `${slug} should not render a Mux background video`,
       ).toBeNull();
-      expect(document.querySelector('mux-player'), `${slug} should not render mux-player`).toBeNull();
+      expect(
+        document.querySelector('mux-player'),
+        `${slug} should not render mux-player`,
+      ).toBeNull();
     }
   });
 
@@ -412,14 +429,10 @@ describe('Project Pages — screenshot aspect variants', () => {
     for (const slug of wideSlugs) {
       setupDOM(readDistHtml(`projects/${slug}/index.html`));
       const figure = document.querySelector('figure.project-screenshot');
-      expect(
-        figure,
-        `${slug}: figure.project-screenshot not found`,
-      ).not.toBeNull();
-      expect(
-        figure.className,
-        `${slug} should use project-screenshot--wide`,
-      ).toContain('project-screenshot--wide');
+      expect(figure, `${slug}: figure.project-screenshot not found`).not.toBeNull();
+      expect(figure.className, `${slug} should use project-screenshot--wide`).toContain(
+        'project-screenshot--wide',
+      );
     }
   });
 });

--- a/tests/responsive-layout.test.js
+++ b/tests/responsive-layout.test.js
@@ -26,7 +26,10 @@ function setupDOM() {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
     value: vi.fn((query) => ({
-      matches: query === '(hover: hover) and (pointer: fine)' ? true : !query.includes('max-width: 1023px'),
+      matches:
+        query === '(hover: hover) and (pointer: fine)'
+          ? true
+          : !query.includes('max-width: 1023px'),
       media: query,
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),

--- a/tests/responsive/mondrian-rebalance-animation.spec.ts
+++ b/tests/responsive/mondrian-rebalance-animation.spec.ts
@@ -46,13 +46,10 @@ test.beforeEach(async ({ page }, testInfo) => {
  */
 async function openByClick(page: Page, panel: PanelName) {
   await page.click(`[data-panel="${panel}"]`);
-  await page.waitForFunction(
-    (p) => {
-      const el = document.querySelector(`[data-panel="${p}"]`)!;
-      return el.classList.contains('is-open') && el.classList.contains('is-content-visible');
-    },
-    panel,
-  );
+  await page.waitForFunction((p) => {
+    const el = document.querySelector(`[data-panel="${p}"]`)!;
+    return el.classList.contains('is-open') && el.classList.contains('is-content-visible');
+  }, panel);
 }
 
 /**
@@ -60,22 +57,27 @@ async function openByClick(page: Page, panel: PanelName) {
  * { panel: { width, height } } so assertions can target a single panel.
  */
 async function readPanelDims(page: Page) {
-  return page.evaluate((panels) => {
-    const out: Record<string, { width: number; height: number }> = {};
-    for (const p of panels) {
-      const el = document.querySelector(`[data-panel="${p}"]`)!;
-      const r = el.getBoundingClientRect();
-      out[p] = { width: Math.round(r.width), height: Math.round(r.height) };
-    }
-    return out;
-  }, PANELS as readonly string[]);
+  return page.evaluate(
+    (panels) => {
+      const out: Record<string, { width: number; height: number }> = {};
+      for (const p of panels) {
+        const el = document.querySelector(`[data-panel="${p}"]`)!;
+        const r = el.getBoundingClientRect();
+        out[p] = { width: Math.round(r.width), height: Math.round(r.height) };
+      }
+      return out;
+    },
+    PANELS as readonly string[],
+  );
 }
 
 // ─────────────────────────────────────────────────────────────────────────
 // Regression assertions — concrete bug shapes from this week
 // ─────────────────────────────────────────────────────────────────────────
 
-test('all four panels render at non-zero dimensions in every focus state (#315 regression: Connect-hidden in community-focus)', async ({ page }) => {
+test('all four panels render at non-zero dimensions in every focus state (#315 regression: Connect-hidden in community-focus)', async ({
+  page,
+}) => {
   // Default state — panels at their rest dimensions.
   let dims = await readPanelDims(page);
   for (const p of PANELS) {
@@ -93,7 +95,9 @@ test('all four panels render at non-zero dimensions in every focus state (#315 r
     }
     // Close before next iteration.
     await page.click('main', { position: { x: 5, y: 5 }, force: true }).catch((err) => {
-      console.warn(`close-click failed (continuing to assert close via waitForFunction): ${err?.message ?? err}`);
+      console.warn(
+        `close-click failed (continuing to assert close via waitForFunction): ${err?.message ?? err}`,
+      );
     });
     await page.waitForFunction(
       (f) => !document.querySelector(`[data-panel="${f}"]`)!.classList.contains('is-open'),
@@ -102,7 +106,9 @@ test('all four panels render at non-zero dimensions in every focus state (#315 r
   }
 });
 
-test('about/projects/connect panels are exactly content-sized in their focus states (#330 regression: ~400px cream void)', async ({ page }) => {
+test('about/projects/connect panels are exactly content-sized in their focus states (#330 regression: ~400px cream void)', async ({
+  page,
+}) => {
   // Tolerance for sub-pixel rounding + measurement variance.
   const TOLERANCE = 4;
 
@@ -119,7 +125,9 @@ test('about/projects/connect panels are exactly content-sized in their focus sta
 
     // Close before next iteration.
     await page.click('main', { position: { x: 5, y: 5 }, force: true }).catch((err) => {
-      console.warn(`close-click failed (continuing to assert close via waitForFunction): ${err?.message ?? err}`);
+      console.warn(
+        `close-click failed (continuing to assert close via waitForFunction): ${err?.message ?? err}`,
+      );
     });
     await page.waitForFunction(
       (f) => !document.querySelector(`[data-panel="${f}"]`)!.classList.contains('is-open'),
@@ -162,13 +170,17 @@ async function installEventRecorder(page: Page) {
     // transitionend for background-color / opacity which we filter out by
     // propertyName (and by target, since those events target the panel
     // article and don't bubble through the grid in capture phase from above).
-    grid.addEventListener('transitionend', (ev) => {
-      const e = ev as TransitionEvent;
-      if (e.target !== grid) return;
-      if (e.propertyName === 'grid-template-rows' || e.propertyName === 'grid-template-columns') {
-        push('geometry-settled', e.propertyName);
-      }
-    }, true);
+    grid.addEventListener(
+      'transitionend',
+      (ev) => {
+        const e = ev as TransitionEvent;
+        if (e.target !== grid) return;
+        if (e.propertyName === 'grid-template-rows' || e.propertyName === 'grid-template-columns') {
+          push('geometry-settled', e.propertyName);
+        }
+      },
+      true,
+    );
     for (const p of ['about', 'projects', 'community', 'connect']) {
       const el = document.querySelector(`[data-panel="${p}"]`)!;
       new MutationObserver((muts) => {
@@ -183,7 +195,9 @@ async function installEventRecorder(page: Page) {
   });
 }
 
-test('open sequence: data-focus precedes is-content-visible; grid-template transition fires', async ({ page }) => {
+test('open sequence: data-focus precedes is-content-visible; grid-template transition fires', async ({
+  page,
+}) => {
   await installEventRecorder(page);
 
   await page.click(`[data-panel="about"]`);
@@ -196,7 +210,9 @@ test('open sequence: data-focus precedes is-content-visible; grid-template trans
   await page.waitForFunction(() => {
     const events = window.__events;
     const hasSettled = events.some((e) => e.kind === 'geometry-settled');
-    const hasContent = events.some((e) => e.kind === 'is-content-visible:about' && e.value === 'on');
+    const hasContent = events.some(
+      (e) => e.kind === 'is-content-visible:about' && e.value === 'on',
+    );
     return hasSettled && hasContent;
   });
 
@@ -240,7 +256,9 @@ test('close sequence: is-content-visible is removed before data-focus clears', a
   expect(focusCleared, 'data-focus cleared event captured').toBeTruthy();
   // Strict ordering by monotonic counter (CodeRabbit: rounded timestamps could
   // mask same-tick reversals).
-  expect(contentOff!.order, 'content fades out BEFORE data-focus clears').toBeLessThan(focusCleared!.order);
+  expect(contentOff!.order, 'content fades out BEFORE data-focus clears').toBeLessThan(
+    focusCleared!.order,
+  );
 });
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -249,21 +267,25 @@ test('close sequence: is-content-visible is removed before data-focus clears', a
 
 test('only one panel is open at a time across click switches', async ({ page }) => {
   await openByClick(page, 'about');
-  expect(await page.locator('[data-panel="about"]').evaluate((el) => el.classList.contains('is-open'))).toBe(true);
+  expect(
+    await page.locator('[data-panel="about"]').evaluate((el) => el.classList.contains('is-open')),
+  ).toBe(true);
 
   // Click projects → about should close, projects should open.
   await page.click(`[data-panel="projects"]`);
   await page.waitForFunction(() =>
     document.querySelector('[data-panel="projects"]')!.classList.contains('is-open'),
   );
-  await page.waitForFunction(() =>
-    !document.querySelector('[data-panel="about"]')!.classList.contains('is-open'),
+  await page.waitForFunction(
+    () => !document.querySelector('[data-panel="about"]')!.classList.contains('is-open'),
   );
 
   // After settle: only one panel has is-open.
-  const openCount = await page.evaluate(() =>
-    Array.from(document.querySelectorAll('[data-panel]'))
-      .filter((el) => el.classList.contains('is-open')).length,
+  const openCount = await page.evaluate(
+    () =>
+      Array.from(document.querySelectorAll('[data-panel]')).filter((el) =>
+        el.classList.contains('is-open'),
+      ).length,
   );
   expect(openCount).toBe(1);
 });
@@ -275,20 +297,22 @@ test('keyboard (Enter) bypasses the hover guard and opens a panel', async ({ pag
   await page.waitForFunction(() =>
     document.querySelector('[data-panel="about"]')!.classList.contains('is-open'),
   );
-  expect(
-    await page.evaluate(() => document.getElementById('mondrian')!.dataset.focus),
-  ).toBe('about');
+  expect(await page.evaluate(() => document.getElementById('mondrian')!.dataset.focus)).toBe(
+    'about',
+  );
 });
 
 test('keyboard (Escape) closes the open panel', async ({ page }) => {
   await openByClick(page, 'about');
   await page.keyboard.press('Escape');
-  await page.waitForFunction(() =>
-    !document.querySelector('[data-panel="about"]')!.classList.contains('is-open'),
+  await page.waitForFunction(
+    () => !document.querySelector('[data-panel="about"]')!.classList.contains('is-open'),
   );
 });
 
-test('prefers-reduced-motion: reduce short-circuits the state machine to instant transitions', async ({ page }) => {
+test('prefers-reduced-motion: reduce short-circuits the state machine to instant transitions', async ({
+  page,
+}) => {
   await page.emulateMedia({ reducedMotion: 'reduce' });
   await page.reload();
   await page.waitForLoadState('domcontentloaded');
@@ -308,7 +332,9 @@ test('prefers-reduced-motion: reduce short-circuits the state machine to instant
     return new Promise<number>((resolve) => {
       const start = performance.now();
       const tick = () => {
-        if (document.querySelector('[data-panel="about"]')?.classList.contains('is-content-visible')) {
+        if (
+          document.querySelector('[data-panel="about"]')?.classList.contains('is-content-visible')
+        ) {
           resolve(performance.now() - start);
         } else {
           requestAnimationFrame(tick);
@@ -328,7 +354,9 @@ test('prefers-reduced-motion: reduce short-circuits the state machine to instant
 // Pulse animation — the brightness keyframe used at peak per panel
 // ─────────────────────────────────────────────────────────────────────────
 
-test('panel-pulse-blue keyframe applies a stronger filter on Connect than the default panel-pulse keyframe (#330 regression)', async ({ page }) => {
+test('panel-pulse-blue keyframe applies a stronger filter on Connect than the default panel-pulse keyframe (#330 regression)', async ({
+  page,
+}) => {
   // Manually trigger the pulse on Connect by adding the class. Read the
   // computed filter mid-keyframe (50% via animation-delay trick).
   const connectFilter = await page.evaluate(() => {

--- a/tests/responsive/shared-chrome.spec.ts
+++ b/tests/responsive/shared-chrome.spec.ts
@@ -56,7 +56,9 @@ type ParsedColor = {
 };
 
 function parseComputedColor(value: string): ParsedColor | null {
-  const commaRgb = value.match(/^rgba?\(\s*([\d.]+),\s*([\d.]+),\s*([\d.]+)(?:,\s*([\d.]+))?\s*\)$/);
+  const commaRgb = value.match(
+    /^rgba?\(\s*([\d.]+),\s*([\d.]+),\s*([\d.]+)(?:,\s*([\d.]+))?\s*\)$/,
+  );
   if (commaRgb) {
     return {
       r: Math.round(Number(commaRgb[1])),
@@ -66,7 +68,9 @@ function parseComputedColor(value: string): ParsedColor | null {
     };
   }
 
-  const spaceRgb = value.match(/^rgb\(\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)(?:\s*\/\s*([\d.]+))?\s*\)$/);
+  const spaceRgb = value.match(
+    /^rgb\(\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)(?:\s*\/\s*([\d.]+))?\s*\)$/,
+  );
   if (spaceRgb) {
     return {
       r: Math.round(Number(spaceRgb[1])),
@@ -76,7 +80,9 @@ function parseComputedColor(value: string): ParsedColor | null {
     };
   }
 
-  const srgb = value.match(/^color\(srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)(?:\s*\/\s*([\d.]+))?\s*\)$/);
+  const srgb = value.match(
+    /^color\(srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)(?:\s*\/\s*([\d.]+))?\s*\)$/,
+  );
   if (srgb) {
     return {
       r: Math.round(Number(srgb[1]) * 255),
@@ -163,7 +169,9 @@ for (const width of BREAKPOINTS) {
 
     test.describe('shared breadcrumbs — one impl, current item flagged (#436), one color ramp (#452)', () => {
       for (const path of CANVAS_PAGES) {
-        test(`${path} has one .breadcrumbs with an aria-current current item and the shared ramp`, async ({ page }) => {
+        test(`${path} has one .breadcrumbs with an aria-current current item and the shared ramp`, async ({
+          page,
+        }) => {
           await page.goto(path);
           await page.waitForLoadState('domcontentloaded');
           const result = await page.evaluate(() => {
@@ -192,7 +200,9 @@ for (const width of BREAKPOINTS) {
         });
       }
 
-      test('parent links carry the hover affordance (underline + darker step)', async ({ page }) => {
+      test('parent links carry the hover affordance (underline + darker step)', async ({
+        page,
+      }) => {
         await page.goto('/blog/');
         await page.waitForLoadState('domcontentloaded');
         await page.addStyleTag({

--- a/tests/responsive/swipe-watch-mux-fallback.spec.ts
+++ b/tests/responsive/swipe-watch-mux-fallback.spec.ts
@@ -1,7 +1,12 @@
 import { expect, test } from '@playwright/test';
 
-test('Swipe Watch swaps to the Mux GIF fallback when the stream cannot autoplay', async ({ page }, testInfo) => {
-  test.skip(testInfo.project.name !== 'Desktop 1440', 'One viewport covers this media failure contract.');
+test('Swipe Watch swaps to the Mux GIF fallback when the stream cannot autoplay', async ({
+  page,
+}, testInfo) => {
+  test.skip(
+    testInfo.project.name !== 'Desktop 1440',
+    'One viewport covers this media failure contract.',
+  );
 
   await page.route('https://stream.mux.com/**', (route) => route.abort());
   await page.goto('/projects/swipe-watch/');
@@ -28,7 +33,9 @@ test('Swipe Watch swaps to the Mux GIF fallback when the stream cannot autoplay'
   await expect(playButton).toBeVisible();
 });
 
-test('Swipe Watch hero honors prefers-reduced-motion: no autoplay, poster + play button, GIF only after explicit play (#468)', async ({ page }, testInfo) => {
+test('Swipe Watch hero honors prefers-reduced-motion: no autoplay, poster + play button, GIF only after explicit play (#468)', async ({
+  page,
+}, testInfo) => {
   test.skip(testInfo.project.name !== 'Desktop 1440', 'One viewport covers this media contract.');
 
   // Abort the stream like the fallback test so the run is deterministic and
@@ -49,11 +56,9 @@ test('Swipe Watch hero honors prefers-reduced-motion: no autoplay, poster + play
   expect(await fallback.getAttribute('src')).toBeNull();
   expect(
     await page.evaluate(() => {
-      const v = document
-        .querySelector('mux-background-video')
-        ?.shadowRoot?.querySelector('video');
+      const v = document.querySelector('mux-background-video')?.shadowRoot?.querySelector('video');
       return v ? v.paused : null;
-    })
+    }),
   ).toBe(true);
 
   // Explicit play is an opt-in to motion: with the stream aborted, the

--- a/tests/resume.test.js
+++ b/tests/resume.test.js
@@ -74,8 +74,14 @@ describe('Resume — page structure', () => {
     expect(document.querySelectorAll('.resume-canvas').length).toBe(1);
     // The old project-style centered card is gone.
     expect(document.querySelector('.resume-document')).toBeNull();
-    expect(document.querySelector('.resume-canvas-margin--header'), 'accent margin missing').not.toBeNull();
-    expect(document.querySelector('.resume-canvas-content'), 'content column missing').not.toBeNull();
+    expect(
+      document.querySelector('.resume-canvas-margin--header'),
+      'accent margin missing',
+    ).not.toBeNull();
+    expect(
+      document.querySelector('.resume-canvas-content'),
+      'content column missing',
+    ).not.toBeNull();
     expect(document.querySelector('.resume-canvas-sidebar'), 'sidebar missing').not.toBeNull();
     expect(document.querySelector('.site-footer--resume'), 'footer missing').not.toBeNull();
   });
@@ -106,10 +112,9 @@ describe('Resume — page structure', () => {
     const cycle = ['red', 'yellow', 'blue'];
     cards.forEach((c, i) => {
       const expected = cycle[i % cycle.length];
-      expect(
-        c.className,
-        `highlight ${i} should use the ${expected} accent`,
-      ).toContain(`resume-highlight--${expected}`);
+      expect(c.className, `highlight ${i} should use the ${expected} accent`).toContain(
+        `resume-highlight--${expected}`,
+      );
     });
   });
 
@@ -117,14 +122,28 @@ describe('Resume — page structure', () => {
     const toc = document.querySelector('.resume-canvas-toc-list');
     expect(toc, 'sidebar ToC missing').not.toBeNull();
     const links = Array.from(toc.querySelectorAll('a')).map((a) => a.getAttribute('href'));
-    for (const id of ['summary', 'skills', 'experience', 'education', 'certifications', 'projects', 'writing']) {
+    for (const id of [
+      'summary',
+      'skills',
+      'experience',
+      'education',
+      'certifications',
+      'projects',
+      'writing',
+    ]) {
       expect(links, `ToC missing link #${id}`).toContain(`#${id}`);
-      expect(document.getElementById(id), `no <section id="${id}"> for the ToC link`).not.toBeNull();
+      expect(
+        document.getElementById(id),
+        `no <section id="${id}"> for the ToC link`,
+      ).not.toBeNull();
     }
     // Awards is empty → AwardsSection renders nothing, so the ToC must NOT
     // list a (broken) #awards anchor and there is no <section id="awards">.
     expect(links, 'ToC should omit #awards while the collection is empty').not.toContain('#awards');
-    expect(document.getElementById('awards'), 'awards section should not render while empty').toBeNull();
+    expect(
+      document.getElementById('awards'),
+      'awards section should not render while empty',
+    ).toBeNull();
   });
 
   it('renders the section <h2> titles in order; no References; Awards absent while empty', () => {
@@ -145,7 +164,9 @@ describe('Resume — page structure', () => {
       expect(h.tagName).toBe('H2');
     }
     // No References section anywhere.
-    const allH2 = Array.from(document.querySelectorAll('h2')).map((h) => h.textContent.toLowerCase());
+    const allH2 = Array.from(document.querySelectorAll('h2')).map((h) =>
+      h.textContent.toLowerCase(),
+    );
     expect(allH2.some((t) => t.includes('reference'))).toBe(false);
     // Awards collection is empty → no awards section rendered.
     expect(document.querySelector('.resume-awards')).toBeNull();
@@ -236,7 +257,10 @@ describe('Resume — page structure', () => {
     const logos = document.querySelectorAll('.company-logo');
     expect(logos.length).toBe(10); // 6 experience + 1 education + 3 certifications
     for (const logo of logos) {
-      expect(logo.querySelector('.company-logo__initials'), 'logo missing initials fallback').not.toBeNull();
+      expect(
+        logo.querySelector('.company-logo__initials'),
+        'logo missing initials fallback',
+      ).not.toBeNull();
     }
   });
 

--- a/tests/robots-sitemap-integration.test.js
+++ b/tests/robots-sitemap-integration.test.js
@@ -149,7 +149,7 @@ describe('robots-sitemap integration', () => {
           'robots.txt': 'User-agent: *\nAllow: /\n',
           'sitemap-index.xml': '<?xml version="1.0"?><sitemapindex/>',
         },
-        { site: 'https://nathanpayne.com/' }
+        { site: 'https://nathanpayne.com/' },
       );
       expect(result.error).toBeUndefined();
       expect(result.robotsTxt).toContain('Sitemap: https://nathanpayne.com/sitemap-index.xml');
@@ -159,7 +159,7 @@ describe('robots-sitemap integration', () => {
     it('throws if astro.config.mjs has no `site` declared', async () => {
       const integration = robotsSitemap();
       expect(() => integration.hooks['astro:config:done']({ config: {} })).toThrow(
-        /must declare a `site` URL/i
+        /must declare a `site` URL/i,
       );
     });
   });
@@ -191,7 +191,7 @@ describe('robots-sitemap integration', () => {
       });
       expect(result.error).toBeUndefined();
       expect(result.robotsTxt).toMatch(
-        /User-agent: \*\nAllow: \/\n\nSitemap: https:\/\/nathanpayne\.com\/sitemap-index\.xml\n$/
+        /User-agent: \*\nAllow: \/\n\nSitemap: https:\/\/nathanpayne\.com\/sitemap-index\.xml\n$/,
       );
     });
 

--- a/tests/robots-sitemap.test.js
+++ b/tests/robots-sitemap.test.js
@@ -43,7 +43,7 @@ describe('dist/robots.txt (post-build)', () => {
       existsSync(robotsPath),
       `Build output not found at ${robotsPath}. ` +
         `Run \`npm run build\` (or \`npm test\`, which runs it for you) ` +
-        `before invoking vitest directly.`
+        `before invoking vitest directly.`,
     ).toBe(true);
     robotsTxt = readFileSync(robotsPath, 'utf-8');
   });
@@ -66,7 +66,7 @@ describe('dist/robots.txt (post-build)', () => {
     expect(
       existsSync(onDisk),
       `robots.txt declares ${url} but ${onDisk} does not exist. ` +
-        `This is exactly the class of bug #163 diagnosed.`
+        `This is exactly the class of bug #163 diagnosed.`,
     ).toBe(true);
   });
 

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -15,6 +15,8 @@ describe('Sitemap', () => {
   });
 
   it('includes the generated blog post route', () => {
-    expect(sitemap0).toContain('<loc>https://nathanpayne.com/blog/six-prs-one-bug-agent-failure-modes/</loc>');
+    expect(sitemap0).toContain(
+      '<loc>https://nathanpayne.com/blog/six-prs-one-bug-agent-failure-modes/</loc>',
+    );
   });
 });


### PR DESCRIPTION
Follow-up standards work from #525 (formatter).

Authoring-Agent: claude

## Summary

Adopts Prettier and formats the repo-original code surface. Adds the prettier devDep, .prettierrc.json (singleQuote, printWidth 100), .prettierignore, and format / format:check scripts.

Scope is bounded to behavior-preserving, repo-owned code:
- Formats src/**/*.{ts,js,mjs,css} and tests/**/*.{ts,js}. global.css is the bulk of the diff.
- Excludes .astro templates: Prettier markup tag-wrapping leaks insignificant whitespace into the compiled HTML, which changes element textContent and breaks the exact-output tests (tests/project-pages.test.js) even with htmlWhitespaceSensitivity strict. Excluded rather than loosen those assertions.
- Excludes template-synced files (.github/, scripts/, AGENTS.md, docs/agents/, REVIEW_POLICY.md, *.yml) so the mergepath sync audit does not drift.
- Excludes Do-Not-Touch config (astro.config.mjs, firebase.json) and authored content/docs markdown.

## Self-Review

- Correctness: pure whitespace and quote normalization; no runtime effect. format:check is clean (idempotent).
- Regression risk: minimal. No .astro markup changed, so rendered HTML and textContent stay byte-identical. The CSS/JS/TS reformat is semantically neutral.
- Style: establishes one shared style (singleQuote matches existing code, printWidth 100). No eslint-config-prettier needed because lint passes against the formatted output.
- Test coverage: no behavior change, so no new tests. Full suite re-run below.
- Security / dependency hygiene: one devDep added (prettier). No runtime deps. package-lock.json stays gitignored.

## Validation

- npm run lint -> clean
- npm run typecheck -> 0 errors
- npm run format:check -> clean
- npm run build -> 31 pages, Complete
- npm run test -> 234 passed
- npm run test:e2e -> 299 passed, 33 skipped

## Notes

This is over the 300-line external-review threshold, so it is a Phase 4 PR.