### PR TITLE
[claude] Fix #524: canonical "Projects" nav label on the 404 page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -16,10 +16,17 @@ import Breadcrumbs from '../components/Breadcrumbs.astro';
         <Breadcrumbs items={[{ label: "Nathan Payne", href: "/" }, { label: "404" }]} />
         <h1>Page not found</h1>
         <p class="deck">The page you're looking for doesn't exist or has been moved.</p>
+        {/*
+          Canonical wayfinding labels (see #524): these match the navigation
+          labels used elsewhere — "Projects" (homepage panel + project index
+          breadcrumb) and "Blog" (homepage social row + blog breadcrumb). They
+          intentionally differ from the editorial H1s ("Built with Agents",
+          "The AI-Augmented PM"). Guarded by tests/nav-labels.test.js.
+        */}
         <div class="project-actions">
           <a class="nav-button" href="/">Homepage</a>
           <a class="nav-button" href="/resume/">Résumé</a>
-          <a class="nav-button" href="/projects/">Builds</a>
+          <a class="nav-button" href="/projects/">Projects</a>
           <a class="nav-button" href="/blog/">Blog</a>
         </div>
       </div>

--- a/tests/nav-labels.test.js
+++ b/tests/nav-labels.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// Guards the canonical wayfinding labels on the 404 page against drift (#524).
+// The 404 shortcut buttons must use the same navigation labels as the rest of
+// the site — "Projects" (not the old "Builds") for /projects/ and "Blog" for
+// /blog/ — even though the editorial H1s differ ("Built with Agents", "The
+// AI-Augmented PM"). Reads the built dist/ HTML (`npm test` runs `astro build`
+// first).
+
+const DIST = resolve(__dirname, '../dist');
+
+function setupDOM(rawHtml) {
+  const safe = rawHtml.replace(/<script>[\s\S]*?<\/script>/g, '');
+  document.documentElement.innerHTML = '';
+  document.write(safe);
+  document.close();
+}
+
+describe('404 navigation labels (#524)', () => {
+  beforeEach(() => {
+    setupDOM(readFileSync(resolve(DIST, '404.html'), 'utf-8'));
+  });
+
+  it('uses canonical wayfinding labels for the section shortcuts', () => {
+    const buttons = [...document.querySelectorAll('.project-actions .nav-button')];
+    const byHref = Object.fromEntries(
+      buttons.map((a) => [a.getAttribute('href'), a.textContent.trim()]),
+    );
+    expect(byHref['/']).toBe('Homepage');
+    expect(byHref['/resume/']).toBe('Résumé');
+    expect(byHref['/projects/']).toBe('Projects'); // canonical nav label, not the old "Builds"
+    expect(byHref['/blog/']).toBe('Blog');
+  });
+
+  it('does not reintroduce the stale "Builds" wayfinding label', () => {
+    const labels = [...document.querySelectorAll('.project-actions .nav-button')].map((a) =>
+      a.textContent.trim(),
+    );
+    expect(labels).not.toContain('Builds');
+  });
+});


### PR DESCRIPTION
Fixes #524.

Authoring-Agent: claude

## Summary

The 404 page /projects/ shortcut said "Builds" while the rest of the site wayfinding (homepage panel label, project index breadcrumb/title) uses "Projects". This aligns the 404 shortcut to the canonical "Projects" label and adds a guard test. The /blog/ shortcut already matches its canonical nav label ("Blog"), so it is unchanged. Editorial H1s (Built with Agents, The AI-Augmented PM) intentionally differ and are noted in a source comment.

## Self-Review

- Correctness: only the /projects/ 404 shortcut label changed (Builds to Projects). Canonical labels verified against the homepage panel and project index breadcrumb (Projects) and the homepage social row and blog breadcrumb (Blog).
- Regression risk: minimal. One visible label string on the 404 page; no routes, layout, or other pages touched. The new test reads the built dist/404.html.
- Style: matches surrounding markup; a source comment documents the intentional nav-vs-editorial split.
- Test coverage: adds tests/nav-labels.test.js asserting the four 404 shortcut labels by href and that "Builds" cannot return. 236 vitest tests pass (was 234).
- Security / dependency hygiene: no dependency or config changes.

## Validation

- npm run lint -> clean
- npm run typecheck -> 0 errors
- npm run format:check -> clean
- npm run build -> 31 pages, Complete
- npm run test -> 236 passed
- npm run test:e2e -> 299 passed, 33 skipped