### PR TITLE
[claude] Fix #523: stop the homepage Writing block from drifting on count

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -100,7 +100,7 @@ const homepageJsonLd = {
               </div>
               <div class="about-block about-block--writing">
                 <span class="eyebrow about-label">Writing</span>
-                <p>Three pieces on building with AI coding agents: where they fail, what makes them reliable, and how to get real work out of them.</p>
+                <p>Selected writing on building with AI coding agents: where they fail, what makes them reliable, and how to get real work out of them.</p>
                 <ul class="writing-list">
                   <li><a href="/blog/six-prs-one-bug-agent-failure-modes/" class="p-name-link">Six PRs, One Bug: What AI Agents Actually Get <span class="no-break">Wrong<span class="link-arrow" aria-hidden="true">→</span></span></a></li>
                   <li><a href="/blog/agent-approval-workflow-genesis-of-mergepath/" class="p-name-link">Agent Approval Workflow and the Genesis of <span class="no-break">Mergepath<span class="link-arrow" aria-hidden="true">→</span></span></a></li>

--- a/tests/homepage-writing.test.js
+++ b/tests/homepage-writing.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// Guards the homepage Writing block against the drift reported in #523. The
+// block is intentionally a curated selection (not the full published set), so:
+//   1. it must NOT assert a hardcoded post count that can fall behind the blog
+//      collection (the old copy said "Three pieces" while five were published);
+//   2. each curated link must resolve to a real built post, so a renamed or
+//      unpublished post can't leave a dead homepage link.
+// Reads the built dist/ HTML (`npm test` runs `astro build` first).
+
+const DIST = resolve(__dirname, '../dist');
+
+function setupDOM(rawHtml) {
+  const safe = rawHtml.replace(/<script>[\s\S]*?<\/script>/g, '');
+  document.documentElement.innerHTML = '';
+  document.write(safe);
+  document.close();
+}
+
+describe('homepage Writing block (#523)', () => {
+  beforeEach(() => {
+    setupDOM(readFileSync(resolve(DIST, 'index.html'), 'utf-8'));
+  });
+
+  it('does not hardcode a post count that can drift from the blog collection', () => {
+    const list = document.querySelector('.writing-list');
+    expect(list, '.writing-list missing').not.toBeNull();
+    const prose = list.previousElementSibling?.textContent ?? '';
+    // A literal "<N> pieces/posts" claim (e.g. the old "Three pieces") goes
+    // stale as posts are published; the block is framed as a curated selection.
+    expect(prose).not.toMatch(
+      /\b(one|two|three|four|five|six|seven|eight|nine|ten|\d+)\s+(pieces|posts|essays|articles|stories)\b/i,
+    );
+  });
+
+  it('links only to posts that exist in the built blog output', () => {
+    const hrefs = [...document.querySelectorAll('.writing-list a')].map((a) =>
+      a.getAttribute('href'),
+    );
+    expect(hrefs.length).toBeGreaterThan(0);
+    for (const href of hrefs) {
+      const slug = href.replace(/^\/blog\//, '').replace(/\/$/, '');
+      expect(
+        existsSync(resolve(DIST, 'blog', slug, 'index.html')),
+        `homepage Writing link ${href} should resolve to a built post`,
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #523.

Authoring-Agent: claude

## Summary

The homepage Writing block hardcoded "Three pieces" and three links while five posts are published, leaving one post unreachable from the homepage and a count that drifts as posts are added. Per the chosen curated model, the copy is reframed to "Selected writing on building with AI coding agents..." — dropping the stale count and framing the block as a curated selection — while keeping the three hand-picked links and the themed description. A guard test prevents regressions.

## Self-Review

- Correctness: the only copy change is "Three pieces" to "Selected writing"; the themed triplet and the three curated links are unchanged. The separate latest-post callout is untouched.
- Regression risk: minimal. One prose string on the homepage; no routes, layout, or other content changed.
- Style: matches the existing editorial voice; no number word remains, so the count cannot go stale.
- Test coverage: adds tests/homepage-writing.test.js asserting (a) the Writing block prose contains no hardcoded post-count claim, and (b) every curated link resolves to a real built post in dist/. 238 vitest tests pass (was 236).
- Security / dependency hygiene: no dependency or config changes.

## Validation

- npm run lint -> clean
- npm run typecheck -> 0 errors
- npm run format:check -> clean
- npm run build -> 31 pages, Complete
- npm run test -> 238 passed
- npm run test:e2e -> 299 passed, 33 skipped

## Notes

Implements the curated-subset option (your call): the block stays a hand-picked selection framed explicitly as "Selected writing", satisfying #523 without claiming completeness.