### PR TITLE
[claude] Route PostHog ingest through the d.nathanpayne.com reverse proxy

### DIFF
--- a/specs/analytics.md
+++ b/specs/analytics.md
@@ -46,6 +46,13 @@ may be removed later without affecting the other.
 4. Every custom event call is guarded with optional chaining
    (`window.posthog?.capture(...)`) so a blocked or not-yet-loaded PostHog
    never throws.
+5. Ingest is routed through the first-party managed reverse proxy at
+   `https://d.nathanpayne.com` (`api_host`), so `array.js` and all event /
+   session-replay traffic load from our own subdomain rather than
+   `us.i.posthog.com` — reducing loss to tracking blockers. `ui_host` is set to
+   `https://us.posthog.com` (the real PostHog US app) so the toolbar and
+   "open in PostHog" deep links continue to resolve. Both hosts are non-secret
+   constants, not env-injected.
 
 ### Events
 

--- a/src/components/posthog.astro
+++ b/src/components/posthog.astro
@@ -8,9 +8,13 @@
 // the token is unset at build time (CI, or a checkout that has not run
 // scripts/bootstrap.sh), this component renders nothing and PostHog never
 // initializes: no events, no errors, no array.js request — mirroring
-// CompanyLogo's graceful degradation. api_host is a non-secret region constant.
-// The personal API key (phx_…), which can read/manage the project, is never
-// used here.
+// CompanyLogo's graceful degradation. api_host is the first-party managed
+// reverse proxy (d.nathanpayne.com) so array.js and all event/session traffic
+// load from our own subdomain and are less likely to be dropped by tracking
+// blockers; ui_host points at the real PostHog US app (us.posthog.com) so the
+// toolbar and "open in PostHog" deep links still resolve. Both are non-secret
+// constants. The personal API key (phx_…), which can read/manage the project,
+// is never used here.
 const token = import.meta.env.PUBLIC_POSTHOG_PROJECT_TOKEN || '';
 ---
 {token && (
@@ -19,7 +23,8 @@ const token = import.meta.env.PUBLIC_POSTHOG_PROJECT_TOKEN || '';
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
     /* eslint-enable */
     posthog.init(token, {
-      api_host: 'https://us.i.posthog.com',
+      api_host: 'https://d.nathanpayne.com',
+      ui_host: 'https://us.posthog.com',
       defaults: '2026-01-30'
     })
   </script>

--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -198,7 +198,15 @@ describe('PostHog', () => {
   it('only initializes PostHog when a token is present (graceful degradation)', () => {
     expect(posthogComponentSrc).toMatch(/\{token &&/); // conditional render guard
     expect(posthogComponentSrc).toContain('posthog.init(token');
-    expect(posthogComponentSrc).toContain('us.i.posthog.com');
+    expect(posthogComponentSrc).toContain("api_host: 'https://d.nathanpayne.com'");
+  });
+
+  it('sets ui_host and fully migrates off the direct ingest host (reverse proxy, #540)', () => {
+    // ui_host must point at the real PostHog US app so the toolbar and
+    // "open in PostHog" deep links resolve once api_host is a first-party proxy.
+    expect(posthogComponentSrc).toContain("ui_host: 'https://us.posthog.com'");
+    // Regression guard: api_host must not revert to the cloud ingest host.
+    expect(posthogComponentSrc).not.toContain('us.i.posthog.com');
   });
 
   it('guards every homepage capture with optional chaining', () => {


### PR DESCRIPTION
Authoring-Agent: claude

Closes #540.

## Summary

The PostHog managed reverse proxy at d.nathanpayne.com is live. This routes PostHog ingest through that first-party subdomain instead of the cloud endpoint.

- src/components/posthog.astro: api_host -> https://d.nathanpayne.com and add ui_host -> https://us.posthog.com, so array.js and event/session traffic load from our own subdomain (fewer requests dropped by tracking blockers) while the toolbar and "open in PostHog" deep links still resolve. Header comment refreshed.
- tests/analytics.test.js: assert the proxy api_host, add a ui_host test plus a regression guard that api_host never reverts to us.i.posthog.com.
- specs/analytics.md: document the proxy under PostHog > Initialization.

## Self-Review

- Correctness: Built the site with the real project token; dist/index.html emits api_host: https://d.nathanpayne.com and ui_host: https://us.posthog.com, and us.i.posthog.com no longer appears anywhere in dist/. The defaults value is unchanged.
- Regression risk: Low. Transport/host-only change; the phc_ token and US region are unchanged. Graceful degradation (no token means no init) is untouched and still covered. A new test guards against reverting api_host to the direct ingest host.
- Style: Matches the existing inline-snippet pattern and comment conventions; no new dependencies and no repo invariants touched.
- Test coverage: npm run lint, npm run typecheck, and npm run test (astro build + 248 vitest tests) all pass locally. Added one focused test for ui_host plus the regression guard.
- Security / dependency hygiene: No secrets added. Both hosts are non-secret constants (matching the prior api_host pattern); nothing env-injected changed. No dependency changes.

## Test plan

- [x] npm run lint
- [x] npm run typecheck
- [x] npm run test (248 passed)
- [x] Verified built dist/ carries both hosts and no longer references us.i.posthog.com
- [ ] Post-deploy: confirm requests hit https://d.nathanpayne.com (array.js, /e/), events arrive, toolbar launches