### PR TITLE
[claude] docs: add "Validating PostHog ingestion" to DEPLOYMENT.md

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -498,6 +498,26 @@ Or use the Firebase Console → Hosting → Release History → Roll back.
 7. Verify OG images render (check `/og/home.png` or use a social card preview tool)
 8. Check Firebase Console → Analytics → confirm `section_view` events fire on panel hover
 
+### Validating PostHog ingestion
+
+PostHog events are sent through the first-party reverse proxy `d.nathanpayne.com` (`api_host`), with `ui_host` set to `https://us.posthog.com` (see [`src/components/posthog.astro`](src/components/posthog.astro) and [`specs/analytics.md`](specs/analytics.md) § PostHog). To confirm ingestion is healthy after a deploy:
+
+1. Load https://nathanpayne.com with DevTools → Network open.
+2. **SDK loads via the proxy:** `GET https://d.nathanpayne.com/static/array.js` returns `200`. In the console, `posthog.__loaded === true`, `posthog.config.api_host === 'https://d.nathanpayne.com'`, and `posthog.config.ui_host === 'https://us.posthog.com'`.
+3. **Events post via the proxy:** capturing an event issues a `POST https://d.nathanpayne.com/i/v0/e/` that returns `200`; no requests go to `us.i.posthog.com`.
+4. **Ingestion lands in PostHog:** open Activity → Live (project `469428`) and watch a fresh event arrive, or run a recent-events query. A pass shows `$pageview` / `$pageleave` / `$autocapture` with current timestamps.
+
+Headless check via the query API (the personal API key lives in 1Password — item "Claude & Codex MCP for Posthog"; read it at runtime, never commit it):
+
+```bash
+# POSTHOG_PERSONAL_API_KEY sourced from 1Password (e.g. via `op read`)
+curl -s -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" -H "Content-Type: application/json" \
+  https://us.posthog.com/api/projects/469428/query/ \
+  -d '{"query":{"kind":"HogQLQuery","query":"SELECT event, count() AS n, max(timestamp) AS latest FROM events WHERE timestamp > now() - INTERVAL 24 HOUR GROUP BY event ORDER BY latest DESC LIMIT 100"}}' | jq .
+```
+
+A maintained runbook with an embedded live query is kept as the PostHog notebook **Analytics validation — PostHog reverse proxy** ([`/project/469428/notebooks/oK81CjVS`](https://us.posthog.com/project/469428/notebooks/oK81CjVS)).
+
 ## CI/CD Integration
 
 Deploys are manual via `npm run deploy`, which builds first, calls `op-firebase-deploy`, and purges Cloudflare. CI workflows (repo linting, review policy enforcement) run on push/PR via GitHub Actions—see `.github/workflows/`.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -503,15 +503,16 @@ Or use the Firebase Console → Hosting → Release History → Roll back.
 PostHog events are sent through the first-party reverse proxy `d.nathanpayne.com` (`api_host`), with `ui_host` set to `https://us.posthog.com` (see [`src/components/posthog.astro`](src/components/posthog.astro) and [`specs/analytics.md`](specs/analytics.md) § PostHog). To confirm ingestion is healthy after a deploy:
 
 1. Load https://nathanpayne.com with DevTools → Network open.
-2. **SDK loads via the proxy:** `GET https://d.nathanpayne.com/static/array.js` returns `200`. In the console, `posthog.__loaded === true`, `posthog.config.api_host === 'https://d.nathanpayne.com'`, and `posthog.config.ui_host === 'https://us.posthog.com'`.
-3. **Events post via the proxy:** capturing an event issues a `POST https://d.nathanpayne.com/i/v0/e/` that returns `200`; no requests go to `us.i.posthog.com`.
+2. **SDK loads via the proxy:** `GET https://d.nathanpayne.com/static/array.js` returns `200` (session replay similarly loads `/static/recorder.js`). In the console, `posthog.config.api_host === 'https://d.nathanpayne.com'` and `posthog.config.ui_host === 'https://us.posthog.com'`, and `posthog.__loaded === true` (PostHog's internal flag, set once `array.js` finishes initializing — confirms the real library loaded rather than the queue stub).
+3. **Events post via the proxy:** capturing an event issues a `POST https://d.nathanpayne.com/i/v0/e/` that returns `200`. The managed proxy forwards every PostHog path the SDK calls — assets under `/static/*`, ingest under `/i/*`, and feature-flag/config requests — so the decisive check is that the Network tab shows **only** `d.nathanpayne.com` for PostHog traffic and never a direct host such as `us.i.posthog.com` (which would mean a path bypassed the proxy).
 4. **Ingestion lands in PostHog:** open Activity → Live (project `469428`) and watch a fresh event arrive, or run a recent-events query. A pass shows `$pageview` / `$pageleave` / `$autocapture` with current timestamps.
 
 Headless check via the query API (the personal API key lives in 1Password — item "Claude & Codex MCP for Posthog"; read it at runtime, never commit it):
 
 ```bash
 # POSTHOG_PERSONAL_API_KEY sourced from 1Password (e.g. via `op read`)
-curl -s -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" -H "Content-Type: application/json" \
+# -fsS makes curl fail loudly on an HTTP error (e.g. 401/403) instead of printing the error body
+curl -fsS -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" -H "Content-Type: application/json" \
   https://us.posthog.com/api/projects/469428/query/ \
   -d '{"query":{"kind":"HogQLQuery","query":"SELECT event, count() AS n, max(timestamp) AS latest FROM events WHERE timestamp > now() - INTERVAL 24 HOUR GROUP BY event ORDER BY latest DESC LIMIT 100"}}' | jq .
 ```


### PR DESCRIPTION
Authoring-Agent: claude

## Summary

Adds a "Validating PostHog ingestion" subsection to DEPLOYMENT.md (under Post-Deployment Verification), documenting how to verify events flow through the d.nathanpayne.com reverse proxy after a deploy. Follow-up to the proxy migration (#540 / #541).

Covers: SDK loads via the proxy (array.js 200, api_host/ui_host), events POST to /i/v0/e/ returning 200, ingestion lands in PostHog (Activity Live or a HogQL recent-events query), a headless query-API check, and a link to the PostHog validation notebook.

## Self-Review

- Correctness: Documentation only; the steps mirror the validation actually performed on the live site (array.js 200 via the proxy, POST /i/v0/e/ 200, events visible in Activity Live, and a HogQL query returning recent events).
- Regression risk: None. DEPLOYMENT.md is an ops doc, not part of the Astro build output; no code, tests, or site behavior change.
- Style: Matches the surrounding Post-Deployment Verification formatting and the repo link conventions.
- Test coverage: N/A for a markdown ops doc. Ran npm run lint (clean). Skipped the build/vitest suite since nothing in the build or test surface changed.
- Security / dependency hygiene: No secrets. The query-API example reads the personal API key from an env var sourced from 1Password and states it must never be committed; only the public project id and proxy host appear. No dependency changes.

## Test plan

- [x] npm run lint
- [x] Manual: links resolve (posthog.astro, specs/analytics.md, notebook URL)