### PR TITLE
[claude] Refine Current TV resume entry (systems + launch titles)

### DIFF
--- a/src/content/experience/current-tv.md
+++ b/src/content/experience/current-tv.md
@@ -8,4 +8,4 @@ order: 5
 logo: "/images/logos/current-tv.png"
 ---
 
-Built ingest, playout, and live tweet moderation systems through Current TV's pivot from user-generated content to prime-time network news. Launched *Say Anything with Joy Behar* and *The War Room with Jennifer Granholm* within 30 days of acquisition.
+Built ingest, play-out, on-air graphics, and live tweet moderation systems through Current TV's pivot from user-generated content to prime-time network news. Launched *Joy Behar: Say Anything*, *The Gavin Newsom Show*, and *The War Room with Jennifer Granholm* within 30 days of acquisition.


### PR DESCRIPTION
## Summary

Refines the Current TV experience entry on the /resume page (sourced from `src/content/experience/current-tv.md`):

- Systems list: hyphenate play-out and add on-air graphics, giving "ingest, play-out, on-air graphics, and live tweet moderation systems".
- Launched shows: rename to *Joy Behar: Say Anything*, add *The Gavin Newsom Show*, and keep *The War Room with Jennifer Granholm*.

Requested verbatim by the repo owner. Show titles keep the existing italic markdown convention already used in this file (a double space in the request was normalized to single).

Authoring-Agent: claude

## Self-Review

- **Correctness**: One content-collection markdown file; frontmatter untouched. Three show titles italicized consistently with the prior two. Rendered copy matches the requested wording.
- **Regression risk**: None to logic. Content-only change to a single experience entry; no schema, component, or route changes. A repo-wide grep confirmed no test, spec, or component hard-codes the old wording.
- **Style**: Matches the file convention (italicized titles, single-sentence flow).
- **Test coverage**: N/A (static content). CI is lint-only; no assertions reference this copy.
- **Security/dependency hygiene**: No dependencies, secrets, or config touched. The Dependabot alerts surfaced on push are pre-existing on the default branch and unrelated to this diff.