### PR TITLE
[claude] Tidy Connect-panel link CSS: tokenize translateX, drop unused override

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -904,7 +904,7 @@ html[data-fonts-pending] .panel-label {
 
 /* === Site-wide link affordance ============================================
    ONE arrow (→), ONE resting state (text underlined, arrow not), ONE hover
-   behavior (arrow translates 3px right). Captured here so future links can
+   behavior (arrow translates by --shift-medium). Captured here so future links can
    reach for the same convention without inventing new ones.
 
    Markup convention: every link with a trailing arrow contains
@@ -939,7 +939,7 @@ a:hover .link-arrow,
 a:focus-visible .link-arrow,
 .social-row:hover .s-arrow,
 .social-row:focus-visible .s-arrow {
-  transform: translateX(3px);
+  transform: translateX(var(--shift-medium));
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -3735,13 +3735,6 @@ a:focus-visible {
 
   .panel--blue .availability-signal .p-link {
     color: var(--blue-contrast);
-    border-bottom-color: color-mix(in srgb, var(--blue-contrast) 48%, transparent);
-  }
-
-  .panel--blue .availability-signal .p-link:hover {
-    border-bottom-color: var(--blue-contrast);
-    box-shadow: inset 0 -2px 0 var(--blue-contrast);
-    background-color: color-mix(in srgb, var(--blue-contrast) 12%, transparent);
   }
 
   .panel--blue .social-row {


### PR DESCRIPTION
## Summary

Two small cleanups to the homepage Connect-panel link affordance in `src/styles/global.css`:

1. Use the existing `--shift-medium` design token (defined as 3px) for the site-wide link-arrow hover translate instead of a hardcoded 3px. Renders identically.
2. Remove the `.panel--blue .availability-signal .p-link` override. Its resting `border-bottom-color` colored a zero-width border (no rendered effect), and its hover block (box-shadow underline + faint background tint) was the only hover treatment for the Connect-panel hire mailto link.

Net effect: resting appearance unchanged; a subtle hover flourish on that one link is dropped, falling back to the default underlined `p-link` style.

Authoring-Agent: claude

## Self-Review

- **Correctness**: Verified live via preview inspect — the link resting state is identical before/after (`border-bottom-width` is 0, underline comes from `text-decoration`, so the removed `border-bottom-color` had no rendered effect). `--shift-medium` is defined as 3px on main, so part 1 is a no-op.
- **Regression risk**: Minimal, scoped to one homepage link. The only behavioral change is loss of a hover flourish on the Connect-panel mailto link; the link stays clearly styled (blue, bold, underlined). No other element matches the removed selector.
- **Style**: Uses the established design token; removes redundant CSS.
- **Test coverage**: N/A (presentational). CI lint applies.
- **Security/dependency hygiene**: None touched. Not a protected path; under-threshold.