### PR TITLE
Harden read in matchline issue-driver scripts with -r (#551)

### DIFF
--- a/scripts/gh-projects/examples/matchline/additions/add-plan-refinements.sh
+++ b/scripts/gh-projects/examples/matchline/additions/add-plan-refinements.sh
@@ -61,13 +61,13 @@ echo "Resolved parents: P0=#$P0_NUM, P1=#$P1_NUM"
 # Phase 0 additions
 # -----------------------------------------------------------------------------
 F=$(prep_body "$SCRIPT_DIR/p0-cost-tracker.md" "$P0_NUM")
-read P0_COST_URL P0_COST_NUM _ <<<"$(create_child \
+read -r P0_COST_URL P0_COST_NUM _ <<<"$(create_child \
   "Cost tracker on LLM calls + CI budget alarm" \
   "$F" "matchline,phase-0,agent-action" "$P0_NUM")"
 echo "  P0 cost-tracker: $P0_COST_URL"
 
 F=$(prep_body "$SCRIPT_DIR/p0-eval-bootstrap.md" "$P0_NUM")
-read P0_EVAL_URL P0_EVAL_NUM _ <<<"$(create_child \
+read -r P0_EVAL_URL P0_EVAL_NUM _ <<<"$(create_child \
   "Eval harness bootstrap (scaffolding; fixtures + 80/80 gate land in #25)" \
   "$F" "matchline,phase-0,agent-action" "$P0_NUM")"
 echo "  P0 eval-bootstrap: $P0_EVAL_URL"
@@ -76,13 +76,13 @@ echo "  P0 eval-bootstrap: $P0_EVAL_URL"
 # Phase 1 additions
 # -----------------------------------------------------------------------------
 F=$(prep_body "$SCRIPT_DIR/p1-prompt-versioning.md" "$P1_NUM")
-read P1_PROMPT_URL P1_PROMPT_NUM _ <<<"$(create_child \
+read -r P1_PROMPT_URL P1_PROMPT_NUM _ <<<"$(create_child \
   "Prompt versioning convention + loader (functions/src/prompts/<stage>/<name>.v<N>.md)" \
   "$F" "matchline,phase-1,agent-action" "$P1_NUM")"
 echo "  P1 prompt-versioning: $P1_PROMPT_URL"
 
 F=$(prep_body "$SCRIPT_DIR/p1-pdf-prototype.md" "$P1_NUM")
-read P1_PDF_URL P1_PDF_NUM _ <<<"$(create_child \
+read -r P1_PDF_URL P1_PDF_NUM _ <<<"$(create_child \
   "PDF rendering prototype on Nathan's real resume (de-risk pulled from Phase 2)" \
   "$F" "matchline,phase-1,agent-action" "$P1_NUM")"
 echo "  P1 pdf-prototype: $P1_PDF_URL"

--- a/scripts/gh-projects/examples/matchline/create-issues.sh
+++ b/scripts/gh-projects/examples/matchline/create-issues.sh
@@ -46,47 +46,47 @@ P0_NUM="${P0_URL##*/}"
 echo "P0 PARENT: $P0_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-0/c1.md" "$P0_NUM")
-read P0_C1_URL P0_C1_NUM _ <<<"$(create_child "Fix P0: invalid Anthropic Haiku model ID in functions/src/llm/config.ts" \
+read -r P0_C1_URL P0_C1_NUM _ <<<"$(create_child "Fix P0: invalid Anthropic Haiku model ID in functions/src/llm/config.ts" \
   "$F" "matchline,phase-0,agent-action" "$P0_NUM")"
 echo "  C1: $P0_C1_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-0/c2.md" "$P0_NUM")
-read P0_C2_URL P0_C2_NUM _ <<<"$(create_child "Fix P1: owner-scoping seam between firestore.rules and service queries" \
+read -r P0_C2_URL P0_C2_NUM _ <<<"$(create_child "Fix P1: owner-scoping seam between firestore.rules and service queries" \
   "$F" "matchline,phase-0,agent-action" "$P0_NUM")"
 echo "  C2: $P0_C2_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-0/c3.md" "$P0_NUM")
-read P0_C3_URL P0_C3_NUM _ <<<"$(create_child "Fix broken CI workflows: needs-external-review label + github-token input" \
+read -r P0_C3_URL P0_C3_NUM _ <<<"$(create_child "Fix broken CI workflows: needs-external-review label + github-token input" \
   "$F" "matchline,phase-0,agent-action" "$P0_NUM")"
 echo "  C3: $P0_C3_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-0/c4.md" "$P0_NUM" "$P0_C1_NUM" "$P0_C2_NUM" "$P0_C3_NUM")
-read P0_C4_URL P0_C4_NUM _ <<<"$(create_child "Merge PR #4 after review and CI are clean" \
+read -r P0_C4_URL P0_C4_NUM _ <<<"$(create_child "Merge PR #4 after review and CI are clean" \
   "$F" "matchline,phase-0,agent-action" "$P0_NUM")"
 echo "  C4: $P0_C4_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-0/c5.md" "$P0_NUM")
-read P0_C5_URL P0_C5_NUM _ <<<"$(create_child "[Human] Add reviewer identities (nathanpayne-claude/cursor/codex) as write collaborators" \
+read -r P0_C5_URL P0_C5_NUM _ <<<"$(create_child "[Human] Add reviewer identities (nathanpayne-claude/cursor/codex) as write collaborators" \
   "$F" "matchline,phase-0,human-action" "$P0_NUM")"
 echo "  C5: $P0_C5_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-0/c6.md" "$P0_NUM")
-read P0_C6_URL P0_C6_NUM _ <<<"$(create_child "[Human] Create Firebase project matchline-dev (and optionally matchline-prod)" \
+read -r P0_C6_URL P0_C6_NUM _ <<<"$(create_child "[Human] Create Firebase project matchline-dev (and optionally matchline-prod)" \
   "$F" "matchline,phase-0,human-action" "$P0_NUM")"
 echo "  C6: $P0_C6_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-0/c7.md" "$P0_NUM" "$P0_C6_NUM")
-read P0_C7_URL P0_C7_NUM _ <<<"$(create_child "[Human] Run op-firebase-setup for matchline-dev" \
+read -r P0_C7_URL P0_C7_NUM _ <<<"$(create_child "[Human] Run op-firebase-setup for matchline-dev" \
   "$F" "matchline,phase-0,human-action" "$P0_NUM")"
 echo "  C7: $P0_C7_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-0/c8.md" "$P0_NUM" "$P0_C6_NUM")
-read P0_C8_URL P0_C8_NUM _ <<<"$(create_child "[Human] Store ANTHROPIC_API_KEY and OPENAI_API_KEY in Firebase secrets" \
+read -r P0_C8_URL P0_C8_NUM _ <<<"$(create_child "[Human] Store ANTHROPIC_API_KEY and OPENAI_API_KEY in Firebase secrets" \
   "$F" "matchline,phase-0,human-action" "$P0_NUM")"
 echo "  C8: $P0_C8_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-0/c9.md" "$P0_NUM" "$P0_C6_NUM")
-read P0_C9_URL P0_C9_NUM _ <<<"$(create_child "[Human] Populate .env.local from .env.example" \
+read -r P0_C9_URL P0_C9_NUM _ <<<"$(create_child "[Human] Populate .env.local from .env.example" \
   "$F" "matchline,phase-0,human-action" "$P0_NUM")"
 echo "  C9: $P0_C9_URL"
 
@@ -99,57 +99,57 @@ P1_NUM="${P1_URL##*/}"
 echo "P1 PARENT: $P1_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-1/c1.md" "$P1_NUM")
-read P1_C1_URL P1_C1_NUM _ <<<"$(create_child "Auth + owner_uid wiring (schema, rules, service-layer queries)" \
+read -r P1_C1_URL P1_C1_NUM _ <<<"$(create_child "Auth + owner_uid wiring (schema, rules, service-layer queries)" \
   "$F" "matchline,phase-1,agent-action" "$P1_NUM")"
 echo "  C1: $P1_C1_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-1/c2.md" "$P1_NUM" "$P1_C1_NUM")
-read P1_C2_URL P1_C2_NUM _ <<<"$(create_child "Experience Unit extraction endpoint (pasted resume → ExperienceUnit[])" \
+read -r P1_C2_URL P1_C2_NUM _ <<<"$(create_child "Experience Unit extraction endpoint (pasted resume → ExperienceUnit[])" \
   "$F" "matchline,phase-1,agent-action" "$P1_NUM")"
 echo "  C2: $P1_C2_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-1/c3.md" "$P1_NUM" "$P1_C2_NUM")
-read P1_C3_URL P1_C3_NUM _ <<<"$(create_child "Unit Review surface (list, filter, inline edit, approve/reject, manual add)" \
+read -r P1_C3_URL P1_C3_NUM _ <<<"$(create_child "Unit Review surface (list, filter, inline edit, approve/reject, manual add)" \
   "$F" "matchline,phase-1,agent-action" "$P1_NUM")"
 echo "  C3: $P1_C3_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-1/c4.md" "$P1_NUM" "$P1_C1_NUM")
-read P1_C4_URL P1_C4_NUM _ <<<"$(create_child "Job Requirement parsing endpoint (pasted JD → JobRequirementUnit[])" \
+read -r P1_C4_URL P1_C4_NUM _ <<<"$(create_child "Job Requirement parsing endpoint (pasted JD → JobRequirementUnit[])" \
   "$F" "matchline,phase-1,agent-action" "$P1_NUM")"
 echo "  C4: $P1_C4_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-1/c5.md" "$P1_NUM" "$P1_C2_NUM" "$P1_C4_NUM")
-read P1_C5_URL P1_C5_NUM _ <<<"$(create_child "Matching engine + canonical skill/tool/domain ontology seed" \
+read -r P1_C5_URL P1_C5_NUM _ <<<"$(create_child "Matching engine + canonical skill/tool/domain ontology seed" \
   "$F" "matchline,phase-1,agent-action" "$P1_NUM")"
 echo "  C5: $P1_C5_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-1/c6.md" "$P1_NUM" "$P1_C5_NUM")
-read P1_C6_URL P1_C6_NUM _ <<<"$(create_child "Role Detail → Matches tab (ranked matches, rationale, gaps, approve/reject)" \
+read -r P1_C6_URL P1_C6_NUM _ <<<"$(create_child "Role Detail → Matches tab (ranked matches, rationale, gaps, approve/reject)" \
   "$F" "matchline,phase-1,agent-action" "$P1_NUM")"
 echo "  C6: $P1_C6_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-1/c7.md" "$P1_NUM" "$P1_C6_NUM")
-read P1_C7_URL P1_C7_NUM _ <<<"$(create_child "Resume generation (grounded-generation prompt, functions endpoint)" \
+read -r P1_C7_URL P1_C7_NUM _ <<<"$(create_child "Resume generation (grounded-generation prompt, functions endpoint)" \
   "$F" "matchline,phase-1,agent-action" "$P1_NUM")"
 echo "  C7: $P1_C7_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-1/c8.md" "$P1_NUM" "$P1_C7_NUM")
-read P1_C8_URL P1_C8_NUM _ <<<"$(create_child "Validation layer (claim extraction, traceability, specificity)" \
+read -r P1_C8_URL P1_C8_NUM _ <<<"$(create_child "Validation layer (claim extraction, traceability, specificity)" \
   "$F" "matchline,phase-1,agent-action" "$P1_NUM")"
 echo "  C8: $P1_C8_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-1/c9.md" "$P1_NUM" "$P1_C7_NUM" "$P1_C8_NUM")
-read P1_C9_URL P1_C9_NUM _ <<<"$(create_child "Application Editor surface (two-pane, inline annotations, flag badges, export block)" \
+read -r P1_C9_URL P1_C9_NUM _ <<<"$(create_child "Application Editor surface (two-pane, inline annotations, flag badges, export block)" \
   "$F" "matchline,phase-1,agent-action" "$P1_NUM")"
 echo "  C9: $P1_C9_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-1/c10.md" "$P1_NUM")
-read P1_C10_URL P1_C10_NUM _ <<<"$(create_child "Evaluation harness (extraction ≥80%, match ≥80%, zero-fabrication invariant)" \
+read -r P1_C10_URL P1_C10_NUM _ <<<"$(create_child "Evaluation harness (extraction ≥80%, match ≥80%, zero-fabrication invariant)" \
   "$F" "matchline,phase-1,agent-action" "$P1_NUM")"
 echo "  C10: $P1_C10_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-1/c11.md" "$P1_NUM")
-read P1_C11_URL P1_C11_NUM _ <<<"$(create_child "Phase 1 milestone: end-to-end QA on 3+ real JDs" \
+read -r P1_C11_URL P1_C11_NUM _ <<<"$(create_child "Phase 1 milestone: end-to-end QA on 3+ real JDs" \
   "$F" "matchline,phase-1,agent-action" "$P1_NUM")"
 echo "  C11: $P1_C11_URL"
 
@@ -162,47 +162,47 @@ P2_NUM="${P2_URL##*/}"
 echo "P2 PARENT: $P2_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-2/c1.md" "$P2_NUM")
-read P2_C1_URL P2_C1_NUM _ <<<"$(create_child "LinkedIn HTML parser (view-source paste → Experience Units)" \
+read -r P2_C1_URL P2_C1_NUM _ <<<"$(create_child "LinkedIn HTML parser (view-source paste → Experience Units)" \
   "$F" "matchline,phase-2,agent-action" "$P2_NUM")"
 echo "  C1: $P2_C1_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-2/c2.md" "$P2_NUM")
-read P2_C2_URL P2_C2_NUM _ <<<"$(create_child "Long-form career context parser with source provenance" \
+read -r P2_C2_URL P2_C2_NUM _ <<<"$(create_child "Long-form career context parser with source provenance" \
   "$F" "matchline,phase-2,agent-action" "$P2_NUM")"
 echo "  C2: $P2_C2_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-2/c3.md" "$P2_NUM")
-read P2_C3_URL P2_C3_NUM _ <<<"$(create_child "Cover letter generation (same grounding + validation as resumes)" \
+read -r P2_C3_URL P2_C3_NUM _ <<<"$(create_child "Cover letter generation (same grounding + validation as resumes)" \
   "$F" "matchline,phase-2,agent-action" "$P2_NUM")"
 echo "  C3: $P2_C3_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-2/c4.md" "$P2_NUM")
-read P2_C4_URL P2_C4_NUM _ <<<"$(create_child "Application Editor polish (hover-source, edit-preserves-traceability)" \
+read -r P2_C4_URL P2_C4_NUM _ <<<"$(create_child "Application Editor polish (hover-source, edit-preserves-traceability)" \
   "$F" "matchline,phase-2,agent-action" "$P2_NUM")"
 echo "  C4: $P2_C4_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-2/c5.md" "$P2_NUM")
-read P2_C5_URL P2_C5_NUM _ <<<"$(create_child "Pipeline Kanban (7 stages, cards, click-through to Role Detail)" \
+read -r P2_C5_URL P2_C5_NUM _ <<<"$(create_child "Pipeline Kanban (7 stages, cards, click-through to Role Detail)" \
   "$F" "matchline,phase-2,agent-action" "$P2_NUM")"
 echo "  C5: $P2_C5_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-2/c6.md" "$P2_NUM")
-read P2_C6_URL P2_C6_NUM _ <<<"$(create_child "Export to PDF, DOCX, and plain text" \
+read -r P2_C6_URL P2_C6_NUM _ <<<"$(create_child "Export to PDF, DOCX, and plain text" \
   "$F" "matchline,phase-2,agent-action" "$P2_NUM")"
 echo "  C6: $P2_C6_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-2/c7.md" "$P2_NUM")
-read P2_C7_URL P2_C7_NUM _ <<<"$(create_child "Tasks + follow-up reminders sidebar" \
+read -r P2_C7_URL P2_C7_NUM _ <<<"$(create_child "Tasks + follow-up reminders sidebar" \
   "$F" "matchline,phase-2,agent-action" "$P2_NUM")"
 echo "  C7: $P2_C7_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-2/c8.md" "$P2_NUM")
-read P2_C8_URL P2_C8_NUM _ <<<"$(create_child "Capability Graph JSON export (portability)" \
+read -r P2_C8_URL P2_C8_NUM _ <<<"$(create_child "Capability Graph JSON export (portability)" \
   "$F" "matchline,phase-2,agent-action" "$P2_NUM")"
 echo "  C8: $P2_C8_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-2/c9.md" "$P2_NUM")
-read P2_C9_URL P2_C9_NUM _ <<<"$(create_child "Phase 2 milestone: first real application submitted end-to-end" \
+read -r P2_C9_URL P2_C9_NUM _ <<<"$(create_child "Phase 2 milestone: first real application submitted end-to-end" \
   "$F" "matchline,phase-2,agent-action" "$P2_NUM")"
 echo "  C9: $P2_C9_URL"
 
@@ -215,32 +215,32 @@ P3_NUM="${P3_URL##*/}"
 echo "P3 PARENT: $P3_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-3/c1.md" "$P3_NUM")
-read P3_C1_URL P3_C1_NUM _ <<<"$(create_child "Extraction prompt tuning on Nathan's real resumes" \
+read -r P3_C1_URL P3_C1_NUM _ <<<"$(create_child "Extraction prompt tuning on Nathan's real resumes" \
   "$F" "matchline,phase-3,agent-action" "$P3_NUM")"
 echo "  C1: $P3_C1_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-3/c2.md" "$P3_NUM")
-read P3_C2_URL P3_C2_NUM _ <<<"$(create_child "Matching rationale + weight tuning from approval/rejection patterns" \
+read -r P3_C2_URL P3_C2_NUM _ <<<"$(create_child "Matching rationale + weight tuning from approval/rejection patterns" \
   "$F" "matchline,phase-3,agent-action" "$P3_NUM")"
 echo "  C2: $P3_C2_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-3/c3.md" "$P3_NUM")
-read P3_C3_URL P3_C3_NUM _ <<<"$(create_child "Generation prompt tuning (tone + specificity)" \
+read -r P3_C3_URL P3_C3_NUM _ <<<"$(create_child "Generation prompt tuning (tone + specificity)" \
   "$F" "matchline,phase-3,agent-action" "$P3_NUM")"
 echo "  C3: $P3_C3_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-3/c4.md" "$P3_NUM")
-read P3_C4_URL P3_C4_NUM _ <<<"$(create_child "Cost + latency telemetry + lightweight dashboard" \
+read -r P3_C4_URL P3_C4_NUM _ <<<"$(create_child "Cost + latency telemetry + lightweight dashboard" \
   "$F" "matchline,phase-3,agent-action" "$P3_NUM")"
 echo "  C4: $P3_C4_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-3/c5.md" "$P3_NUM")
-read P3_C5_URL P3_C5_NUM _ <<<"$(create_child "Bug triage during real use (umbrella — split as needed)" \
+read -r P3_C5_URL P3_C5_NUM _ <<<"$(create_child "Bug triage during real use (umbrella — split as needed)" \
   "$F" "matchline,phase-3,agent-action" "$P3_NUM")"
 echo "  C5: $P3_C5_URL"
 
 F=$(prep_body "$SCRIPT_DIR/phase-3/c6.md" "$P3_NUM")
-read P3_C6_URL P3_C6_NUM _ <<<"$(create_child "Phase 3 milestone: 10 serious applications shipped through Matchline" \
+read -r P3_C6_URL P3_C6_NUM _ <<<"$(create_child "Phase 3 milestone: 10 serious applications shipped through Matchline" \
   "$F" "matchline,phase-3,agent-action" "$P3_NUM")"
 echo "  C6: $P3_C6_URL"
 


### PR DESCRIPTION
## What

The matchline issue-driver `create-issues.sh` and its sibling `additions/add-plan-refinements.sh` captured `create_child` output (issue URL + number) into variables with `read VAR <<<"$(...)"` but without `-r`. Without `-r`, `read` interprets backslashes as escapes, which can mangle the URL/number values threaded into later issue bodies as parent references.

Adds `-r` to all **35** `read` invocations in `create-issues.sh` and all **4** in `additions/add-plan-refinements.sh`. Mechanical and behavior-preserving for backslash-free input.

## Verification

Post-fix: zero bare `read` remain in either script; `bash -n` passes on both. (`shellcheck` is unavailable offline on this machine; `bash -n` used as the syntax gate.)

Closes #551

---
_Resolves the Repo-local VALID finding from the 2026-06-22 sweep (mergepath#524; rubric mergepath#236). Reviewer thread: PR#263 r3140590557._
