### PR TITLE
Fix repo-local accuracy nits: is:inline doc, reduced-motion test, essay slugs (#552)

### DIFF
--- a/docs/posthog-integration-skill/references/EXAMPLE.md
+++ b/docs/posthog-integration-skill/references/EXAMPLE.md
@@ -92,7 +92,7 @@ The PostHog snippet is included as an inline script to prevent Astro from proces
 </script>
 ```
 
-The `is:inline` directive is required to prevent TypeScript errors about `window.posthog`.
+The `is:inline` directive tells Astro not to process or bundle the script, so the snippet is emitted verbatim and runs as-is in the browser.
 
 ### User identification (`src/pages/index.astro`)
 

--- a/src/components/resume/WritingSection.astro
+++ b/src/components/resume/WritingSection.astro
@@ -6,20 +6,39 @@
  * Section/heading scaffolding via the shared ResumeSection wrapper (#471).
  */
 import ResumeSection from './ResumeSection.astro';
-const essays = [
-  {
-    title: 'Agent Approval Workflow and the Genesis of Mergepath',
-    href: '/blog/agent-approval-workflow-genesis-of-mergepath/',
-  },
-  {
-    title: 'Six PRs, One Bug: What AI Agents Actually Get Wrong',
-    href: '/blog/six-prs-one-bug-agent-failure-modes/',
-  },
-  {
-    title: 'The HTML Mock-up Is the Spec',
-    href: '/blog/html-mockups-as-spec/',
-  },
-];
+import { getEntry } from 'astro:content';
+
+// The *selection* of which essays to feature is editorial, so the curated
+// slug list stays here. But title and href are derived from the blog content
+// collection rather than re-typed, so a slug rename or a post being drafted
+// surfaces as a loud build-time error instead of a silently broken /blog/…
+// link on the resume. (#400)
+const FEATURED_ESSAY_SLUGS = [
+  'agent-approval-workflow-genesis-of-mergepath',
+  'six-prs-one-bug-agent-failure-modes',
+  'html-mockups-as-spec',
+] as const;
+
+const essays = await Promise.all(
+  FEATURED_ESSAY_SLUGS.map(async (slug) => {
+    const post = await getEntry('blog', slug);
+    if (!post) {
+      throw new Error(
+        `WritingSection: featured essay slug "${slug}" does not resolve to a blog post. ` +
+          `Update FEATURED_ESSAY_SLUGS or restore src/content/blog/${slug}.md.`,
+      );
+    }
+    if (post.data.draft) {
+      throw new Error(
+        `WritingSection: featured essay "${slug}" is a draft, so /blog/${slug}/ would 404. ` +
+          `Remove it from FEATURED_ESSAY_SLUGS or publish the post.`,
+      );
+    }
+    // Use the canonical post title (matches what the two longer entries
+    // already displayed); deriving it removes the prior title/slug drift risk.
+    return { title: post.data.title, href: `/blog/${post.id}/` };
+  }),
+);
 ---
 
 <ResumeSection type="writing" heading="Writing"><p class="resume-writing__lead">

--- a/tests/responsive/mondrian-rebalance-animation.spec.ts
+++ b/tests/responsive/mondrian-rebalance-animation.spec.ts
@@ -324,30 +324,50 @@ test('prefers-reduced-motion: reduce short-circuits the state machine to instant
     return grid && grid.style.getPropertyValue('--cell-h-about').endsWith('px');
   });
 
-  await page.click(`[data-panel="about"]`);
-  // Measure inside the page using performance.now() so the elapsed value
-  // doesn't include Playwright's Node↔browser RPC round-trip + polling
-  // overhead. (CodeRabbit finding on #337.)
-  const elapsed: number = await page.evaluate(() => {
-    return new Promise<number>((resolve) => {
-      const start = performance.now();
-      const tick = () => {
-        if (
-          document.querySelector('[data-panel="about"]')?.classList.contains('is-content-visible')
-        ) {
-          resolve(performance.now() - start);
-        } else {
-          requestAnimationFrame(tick);
-        }
-      };
-      requestAnimationFrame(tick);
+  // Deterministic signal, not a wall-clock ceiling. Under reduced-motion the
+  // state machine's readMsToken() returns 0, so startOpen() schedules the
+  // is-content-visible flip on a 0ms timer instead of the 460ms --motion-plane
+  // delay. A single setTimeout(0) chained *after* the click therefore lands in
+  // a macrotask strictly after the 0ms reveal timer but long before any real
+  // 460ms timer — so the class is already present iff the JS short-circuited
+  // motion. This ordering holds no matter how slow or loaded the runner is
+  // (a slow runner just pushes both timers later; it never reorders a 0ms
+  // timer behind a 460ms one), which is exactly why it can't flake the way the
+  // old `elapsed < 200ms` ceiling could.
+  const visibleAfterMacrotask: boolean = await page.evaluate(() => {
+    return new Promise<boolean>((resolve) => {
+      const panel = document.querySelector('[data-panel="about"]')!;
+      panel.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      // Yield one macrotask. If motion is short-circuited the 0ms reveal
+      // timer has already fired by the time this callback runs.
+      setTimeout(() => {
+        resolve(panel.classList.contains('is-content-visible'));
+      }, 0);
     });
   });
+  expect(
+    visibleAfterMacrotask,
+    'reduced-motion reveals content within one macrotask (state machine short-circuited motion tokens to 0)',
+  ).toBe(true);
 
-  // --motion-plane is 460ms in normal mode. Under reduced-motion the state
-  // machine should complete in well under that. 200ms is a generous ceiling
-  // that catches the case where the JS forgot to short-circuit motion tokens.
-  expect(elapsed, 'open completes in <200ms under reduced-motion').toBeLessThan(200);
+  // Belt-and-suspenders on the CSS half. #mondrian carries the grid-template
+  // morph transition (`--motion-plane` in normal mode); the universal
+  // reduced-motion rule must collapse its transition-duration to 0s. This is a
+  // meaningful check because the element genuinely transitions in normal mode,
+  // so a regression that dropped the reduced-motion rule would flip it non-zero.
+  const gridTransitionDuration: string = await page.evaluate(() => {
+    const grid = document.getElementById('mondrian') as HTMLElement;
+    return getComputedStyle(grid).transitionDuration;
+  });
+  // transition-duration lists one value per transitioned property (two here:
+  // grid-template-columns, grid-template-rows). Every entry must be 0s.
+  expect(
+    gridTransitionDuration
+      .split(',')
+      .map((d) => d.trim())
+      .every((d) => d === '0s'),
+    `reduced-motion zeroes the #mondrian grid-morph transition-duration (got "${gridTransitionDuration}")`,
+  ).toBe(true);
 });
 
 // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Three independent repo-local accuracy corrections.

- **(a)** `docs/posthog-integration-skill/references/EXAMPLE.md:95` — corrected the false claim that `is:inline` "prevents TypeScript errors about `window.posthog`"; it actually tells Astro not to process/bundle the script. Now consistent with the same file's L317.
- **(b)** `tests/responsive/mondrian-rebalance-animation.spec.ts` — replaced the flaky wall-clock gate (`elapsed < 200ms`) with a **deterministic** reduced-motion check: macrotask-ordering of the `is-content-visible` flip plus a `transition-duration: 0s` assertion on `#mondrian` (the element carrying the real `--motion-plane` transition).
- **(c)** `src/components/resume/WritingSection.astro` — the hardcoded essay list could silently 404 or drift; it now **derives** title/href from the blog content collection via `getEntry()`, throwing a loud build-time error on a missing/drafted slug.

## ⚠️ Scope note on (c)

This went beyond the minimal "verify the slugs exist" ask: deriving from the collection means one essay's displayed title now expands to its full canonical frontmatter title ("The HTML Mock-up Is the Spec" → "…: How I Got Visual Work Out of Claude Code"). Intentional (removes title/slug drift), but it is a **visible content change** — confirm you're happy with the longer title before merge.

## Verification

`npm run typecheck` (astro check) → 0 errors; eslint + prettier clean on the changed code; all three featured slugs confirmed to resolve to real non-draft posts. (Playwright e2e left to CI.)

Closes #552

---
_Resolves the Repo-local VALID finding from the 2026-06-22 sweep (mergepath#524; rubric mergepath#236). Reviewer threads: PR#513 r3408793079, PR#337 r3214163409, PR#400 r3338677785._
