### PR TITLE
[claude] Repo-local accuracy nits: is:inline doc, reduced-motion test, resume slugs

### DIFF
--- a/docs/posthog-integration-skill/references/EXAMPLE.md
+++ b/docs/posthog-integration-skill/references/EXAMPLE.md
@@ -92,7 +92,7 @@ The PostHog snippet is included as an inline script to prevent Astro from proces
 </script>
 ```
 
-The `is:inline` directive is required to prevent TypeScript errors about `window.posthog`.
+The `is:inline` directive tells Astro not to process or bundle the script, so the PostHog snippet is emitted into the page exactly as written.
 
 ### User identification (`src/pages/index.astro`)
 

--- a/src/components/resume/WritingSection.astro
+++ b/src/components/resume/WritingSection.astro
@@ -5,21 +5,41 @@
  * selected essays, using the site's → arrow convention.
  * Section/heading scaffolding via the shared ResumeSection wrapper (#471).
  */
+import { getCollection } from 'astro:content';
 import ResumeSection from './ResumeSection.astro';
+
+// Curated, ordered selection. Display titles are intentionally editorial
+// (e.g. "The HTML Mock-up Is the Spec" is a deliberately shortened form of
+// that post's longer frontmatter title), so they live here rather than being
+// derived from the collection. The ids ARE validated against the published
+// blog collection below, so a renamed or unpublished post fails the build
+// instead of silently shipping a dead link (#552).
 const essays = [
   {
     title: 'Agent Approval Workflow and the Genesis of Mergepath',
-    href: '/blog/agent-approval-workflow-genesis-of-mergepath/',
+    id: 'agent-approval-workflow-genesis-of-mergepath',
   },
   {
     title: 'Six PRs, One Bug: What AI Agents Actually Get Wrong',
-    href: '/blog/six-prs-one-bug-agent-failure-modes/',
+    id: 'six-prs-one-bug-agent-failure-modes',
   },
   {
     title: 'The HTML Mock-up Is the Spec',
-    href: '/blog/html-mockups-as-spec/',
+    id: 'html-mockups-as-spec',
   },
 ];
+
+const publishedBlogIds = new Set(
+  (await getCollection('blog', ({ data }) => !data.draft)).map((post) => post.id),
+);
+const missingEssays = essays.filter((essay) => !publishedBlogIds.has(essay.id));
+if (missingEssays.length > 0) {
+  throw new Error(
+    `WritingSection: selected essay id(s) not in the published blog collection: ${missingEssays
+      .map((essay) => essay.id)
+      .join(', ')}`,
+  );
+}
 ---
 
 <ResumeSection type="writing" heading="Writing"><p class="resume-writing__lead">
@@ -33,7 +53,7 @@ const essays = [
   <ul class="resume-writing__essays">
     {essays.map((essay) => (
       <li>
-        <a href={essay.href}>{essay.title} <span class="link-arrow" aria-hidden="true">→</span></a>
+        <a href={`/blog/${essay.id}/`}>{essay.title} <span class="link-arrow" aria-hidden="true">→</span></a>
       </li>
     ))}
   </ul></ResumeSection>

--- a/tests/responsive/mondrian-rebalance-animation.spec.ts
+++ b/tests/responsive/mondrian-rebalance-animation.spec.ts
@@ -324,18 +324,37 @@ test('prefers-reduced-motion: reduce short-circuits the state machine to instant
     return grid && grid.style.getPropertyValue('--cell-h-about').endsWith('px');
   });
 
+  // Deterministic check #1 (CSS): under reduced-motion the global
+  // `* { transition-duration: 0 }` rule zeroes the grid morph that
+  // --motion-plane drives. This is a computed-style read — no timing — so it
+  // cannot flake on a slow runner.
+  const gridTransitionDurations: string = await page.evaluate(
+    () => getComputedStyle(document.getElementById('mondrian')!).transitionDuration,
+  );
+  expect(
+    gridTransitionDurations.split(',').every((d) => parseFloat(d) === 0),
+    `every grid transition-duration is 0s under reduced-motion (got: ${gridTransitionDurations})`,
+  ).toBe(true);
+
+  // Deterministic check #2 (JS state machine): readMsToken() returns 0 under
+  // reduced-motion, so startOpen() reveals content on a setTimeout(…, 0)
+  // macrotask — within a couple of animation frames. We count *frames*, not
+  // milliseconds: a loaded runner stretches each frame's wall-time, but a
+  // zeroed-timer reveal still lands in a handful of frames whereas the
+  // un-short-circuited 460ms path would need ~28. This replaces the #337
+  // wall-clock `<200ms` gate, which could still flake on a slow CI runner (#552).
   await page.click(`[data-panel="about"]`);
-  // Measure inside the page using performance.now() so the elapsed value
-  // doesn't include Playwright's Node↔browser RPC round-trip + polling
-  // overhead. (CodeRabbit finding on #337.)
-  const elapsed: number = await page.evaluate(() => {
+  const frames: number = await page.evaluate(() => {
     return new Promise<number>((resolve) => {
-      const start = performance.now();
+      let count = 0;
       const tick = () => {
+        count += 1;
         if (
           document.querySelector('[data-panel="about"]')?.classList.contains('is-content-visible')
         ) {
-          resolve(performance.now() - start);
+          resolve(count);
+        } else if (count >= 600) {
+          resolve(count); // ~10s safety valve; lets the assertion fail with a count
         } else {
           requestAnimationFrame(tick);
         }
@@ -343,11 +362,7 @@ test('prefers-reduced-motion: reduce short-circuits the state machine to instant
       requestAnimationFrame(tick);
     });
   });
-
-  // --motion-plane is 460ms in normal mode. Under reduced-motion the state
-  // machine should complete in well under that. 200ms is a generous ceiling
-  // that catches the case where the JS forgot to short-circuit motion tokens.
-  expect(elapsed, 'open completes in <200ms under reduced-motion').toBeLessThan(200);
+  expect(frames, 'content reveals within a few frames under reduced-motion').toBeLessThanOrEqual(5);
 });
 
 // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Authoring-Agent: claude

Closes #552.

Three low-severity repo-local correctness cleanups flagged by the unresolved-feedback validation pass.

### 1. is:inline doc nit (docs/posthog-integration-skill/references/EXAMPLE.md)
L95 claimed the `is:inline` directive prevents TypeScript errors about `window.posthog`, which is incorrect and inconsistent with the correct rationale already stated at L317. Reworded so it states that is:inline tells Astro not to process or bundle the script.

### 2. Deflake the reduced-motion test (tests/responsive/mondrian-rebalance-animation.spec.ts)
The test gated on a wall-clock ceiling (elapsed < 200ms). #337 moved the measurement in-page but kept the threshold, so a slow or loaded CI runner can still flake. Replaced with two deterministic checks: the grid transition-duration computes to 0s under reduced-motion (a computed-style read, no timing); and content reveal lands within a small frame budget (frames, not milliseconds), which a loaded runner cannot flake because a zeroed-timer reveal still resolves in a handful of frames whereas the un-short-circuited 460ms path needs ~28.

### 3. Validate resume essay slugs at build time (src/components/resume/WritingSection.astro)
The selected-essays list hardcoded title plus href. The display titles stay curated (one is a deliberately shortened form of its post title), but the ids are now validated against the published blog collection at build time and the hrefs derive from them, so a renamed or unpublished post fails the build instead of silently shipping a dead link.

## Self-Review

- **Correctness:** Doc reword matches the L317 statement. The resume change preserves rendered output exactly (same /blog/<id>/ hrefs, unchanged titles); all three ids exist in the published collection so the build does not throw.
- **Regression risk:** Low. The doc change is prose-only; the test change is stricter and deterministic, not weaker; the resume change adds a build-time guard with identical output and fails loudly only if a slug is wrong (the intended behavior).
- **Style:** eslint clean on the changed .astro and .ts files; astro check reports 0 errors.
- **Test coverage:** Ran the full spec on the Desktop 1440 project, all 9 tests pass including the rewritten reduced-motion test. Ran astro build, the resume page renders and slug validation passes.
- **Security/dependency hygiene:** No dependency, credential, or workflow changes.