### PR TITLE
sync: bulk reconcile to mergepath@b17c998

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -56,7 +56,11 @@ jobs:
       reviewers: ${{ steps.config.outputs.reviewers }}
       author_identity: ${{ steps.config.outputs.author_identity }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Explicit-token gh / github-script only, no authenticated git, so
+          # don't leave the checkout token in .git/config (#548 / Codex #550).
+          persist-credentials: false
 
       - name: Parse review-policy.yml
         id: config
@@ -278,7 +282,11 @@ jobs:
     if: github.event_name == 'pull_request_review'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Explicit-token gh / github-script only, no authenticated git, so
+          # don't leave the checkout token in .git/config (#548 / Codex #550).
+          persist-credentials: false
 
       - name: Install js-yaml
         run: npm install --no-save --ignore-scripts --legacy-peer-deps js-yaml
@@ -385,7 +393,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dismiss self-approval from reviewer bot accounts
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Explicit-token github-script only, no authenticated git, so don't
+          # leave the checkout token in .git/config (#548 / Codex #550).
+          persist-credentials: false
 
       - name: Install js-yaml
         run: npm install --no-save --ignore-scripts --legacy-peer-deps js-yaml
@@ -488,7 +500,7 @@ jobs:
   # are event-shape-agnostic. Only the `if:` and the approval-gate step
   # branch on event name.
   auto-merge-on-approval:
-    needs: [detect-disagreement, block-self-approval, triage]
+    needs: [load-config, detect-disagreement, block-self-approval, triage]
     if: >
       always() &&
       ((github.event_name == 'pull_request_review' &&
@@ -503,7 +515,11 @@ jobs:
       !contains(github.event.pull_request.labels.*.name, 'human-hold')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Explicit-token gh merge path only, no authenticated git, so don't
+          # leave the checkout token in .git/config (#548 / Codex #550).
+          persist-credentials: false
 
       # Re-arm gate (#495). On the `synchronize` / `reopened` re-trigger
       # the approval is NOT in the event payload, so confirm via the API
@@ -522,13 +538,47 @@ jobs:
       # earlier APPROVED, so a withdrawn approval does NOT re-arm.
       - name: Gate require existing non-author approval
         id: require_approval
-        if: github.event_name == 'pull_request'
+        if: >
+          github.event_name == 'pull_request' ||
+          github.event_name == 'pull_request_review'
         env:
           GH_TOKEN: ${{ secrets.REVIEWER_ASSIGNMENT_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           REPO: ${{ github.repository }}
+          # #529 / #544: restrict the approval that arms auto-merge to a
+          # REGISTERED agent reviewer identity (available_reviewers), matching
+          # scripts/codex-review-check.sh gate (b) and the required
+          # merge-clearance-gate. An APPROVED from an account that is NOT a
+          # mapped reviewer identity must not arm auto-merge on EITHER path:
+          # the synchronize re-arm (existing-review API check below) OR the
+          # direct pull_request_review approved event. #544 review: the gate
+          # previously ran only on pull_request, so a direct approval from an
+          # unregistered non-author skipped it (the merge-clearance-gate still
+          # backstopped the actual merge, but the arming gate should be
+          # consistent on both paths).
+          EVENT_REVIEWER: ${{ github.event.review.user.login }}
+          REVIEWERS_JSON: ${{ needs.load-config.outputs.reviewers }}
         run: |
+          REVIEWERS_JSON="${REVIEWERS_JSON:-[]}"
+          # Direct approval event: the approval IS the trigger, so verify the
+          # event reviewer is a registered, non-author reviewer here (#544).
+          if [ "${GITHUB_EVENT_NAME:-}" = "pull_request_review" ]; then
+            if [ -z "$EVENT_REVIEWER" ] || [ "$EVENT_REVIEWER" = "$PR_AUTHOR" ]; then
+              echo "::notice::Approval reviewer '$EVENT_REVIEWER' is empty or the PR author; not arming auto-merge."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if ! printf '%s' "$REVIEWERS_JSON" | jq -e --arg r "$EVENT_REVIEWER" 'index($r) != null' >/dev/null 2>&1; then
+              echo "::notice::Approval reviewer '$EVENT_REVIEWER' is not a registered reviewer (available_reviewers); not arming auto-merge (#544)."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Direct approval from registered reviewer $EVENT_REVIEWER; proceeding."
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # --- synchronize / reopened re-arm path (existing API check) ---
           if [ -z "${GH_TOKEN:-}" ]; then
             echo "::notice::REVIEWER_ASSIGNMENT_TOKEN is not configured; cannot confirm an existing approval for the synchronize re-arm. Skipping auto-merge arming."
             echo "proceed=false" >> "$GITHUB_OUTPUT"
@@ -548,15 +598,22 @@ jobs:
             exit 0
           fi
 
-          # Latest opinionated review per non-author reviewer; pass only
-          # when at least one such reviewer's latest state is APPROVED.
-          # `-s` (slurp) merges the per-page arrays into one list-of-arrays;
-          # `add // []` then flattens them to the full review array.
+          # Latest opinionated review per non-author REGISTERED reviewer;
+          # pass only when at least one such reviewer's latest state is
+          # APPROVED. `-s` (slurp) merges the per-page arrays into one
+          # list-of-arrays; `add // []` then flattens to the full review
+          # array. #529: the `IN($reviewers[])` filter restricts to
+          # available_reviewers identities — an approval from a non-reviewer
+          # account does NOT count. Default to [] so an empty/failed
+          # load-config fails CLOSED (no reviewer matches → no re-arm).
+          REVIEWERS_JSON="${REVIEWERS_JSON:-[]}"
           if ! APPROVER=$(printf '%s' "$RAW" | jq -r -s \
-            --arg author "$PR_AUTHOR" '
+            --arg author "$PR_AUTHOR" \
+            --argjson reviewers "$REVIEWERS_JSON" '
               [ (add // []) | .[]
                 | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
                 | select(.user.login != $author)
+                | select(.user.login | IN($reviewers[]))
               ]
               | group_by(.user.login)
               | map(max_by(.submitted_at))
@@ -569,7 +626,7 @@ jobs:
           fi
 
           if [ -z "$APPROVER" ]; then
-            echo "::notice::No valid non-author APPROVED review on PR #$PR_NUMBER; a push does not arm auto-merge without an existing approval (#495)."
+            echo "::notice::No valid non-author APPROVED review from a registered reviewer (available_reviewers) on PR #$PR_NUMBER; a push does not arm auto-merge without one (#495/#529)."
             echo "proceed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -579,10 +636,12 @@ jobs:
 
       - name: Check author merge token
         id: author_merge_token
-        # Skip the entire merge path when the synchronize re-arm gate
-        # found no existing approval. On the pull_request_review path the
-        # step above is skipped, so `proceed` is empty and the `!= 'false'`
-        # test lets the original approval-triggered flow through unchanged.
+        # Skip the entire merge path when the require_approval gate set
+        # proceed=false — either the synchronize re-arm found no existing
+        # registered-reviewer approval, or (since #544) the direct
+        # pull_request_review approver was not a registered reviewer. The
+        # `!= 'false'` test still lets a genuine registered-reviewer approval
+        # (proceed=true) and any other event shape (empty) through.
         if: steps.require_approval.outputs.proceed != 'false'
         env:
           GH_TOKEN: ${{ secrets.AUTHOR_MERGE_TOKEN }}

--- a/.github/workflows/auto-clear-blocking-labels.yml
+++ b/.github/workflows/auto-clear-blocking-labels.yml
@@ -110,7 +110,7 @@ jobs:
       )
     steps:
       - name: Checkout repo (for codex-review-check.sh)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           # SECURITY: pin to the default branch so we always run the
           # TRUSTED copy of scripts/codex-review-check.sh — never the
@@ -125,6 +125,9 @@ jobs:
           # PR HEAD against base. The script doesn't currently do that
           # but a future tightening might.
           fetch-depth: 0
+          # Explicit-token gh only, no authenticated git, so don't leave the
+          # checkout token in .git/config (#548 / Codex #550).
+          persist-credentials: false
 
       - name: Resolve PR number from event
         id: pr
@@ -260,7 +263,16 @@ jobs:
                 # delimiter must be column-0 unless using `<<-` with
                 # tabs; YAML run blocks make that brittle).
                 comment_body='**Automated label removal.** `scripts/codex-review-check.sh` cleared the merge gate on this HEAD (CI green + reviewer-identity APPROVED + Codex cleared). Removed `needs-external-review` so Label Gate passes and the PR can merge. See [.github/workflows/auto-clear-blocking-labels.yml](.github/workflows/auto-clear-blocking-labels.yml) (#191/#195) for the trigger doctrine.'
-                with_gh_retry gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
+                # #530 (IMPLEMENTED — was DEFER+DOCUMENT, human-ratified
+                # 2026-06-28): this attribution-comment POST is NON-idempotent,
+                # so it is deliberately NOT wrapped in with_gh_retry. A retry
+                # after a timeout-after-accept would post a DUPLICATE comment;
+                # a single unretried attempt cannot. Failure stays warn-only
+                # (non-fatal) and is purely cosmetic — the label is already
+                # cleared and the workflow log records the action. The other
+                # retried writes here are check-runs keyed on (name, head_sha),
+                # which GitHub UPSERTS (idempotent), so those stay wrapped.
+                gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
                   || echo "::warning::Failed to post attribution comment for PR #$PR"
                 ;;
               1)
@@ -383,7 +395,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (for codex-review-check.sh)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           # Schedule events have no PR context, so default GITHUB_REF
           # is the default branch already — pin explicitly for
@@ -391,6 +403,9 @@ jobs:
           # job above.
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
+          # Explicit-token gh only, no authenticated git, so don't leave the
+          # checkout token in .git/config (#548 / Codex #550).
+          persist-credentials: false
 
       - name: Find PRs carrying needs-external-review
         id: find
@@ -502,7 +517,10 @@ jobs:
                 still_present=$(with_gh_retry gh pr view "$PR" --repo "$REPO" --json labels --jq 'any(.labels[]?; .name == "needs-external-review")' || echo "unknown")
                 if [ "$still_present" = "false" ]; then
                   comment_body='**Automated label removal (scheduled sweep).** `scripts/codex-review-check.sh` cleared the merge gate on this HEAD between event triggers (typical: Codex 👍 after the last push, with no synchronize / review / workflow_run event to fire the event-driven path). Removed `needs-external-review`. See [.github/workflows/auto-clear-blocking-labels.yml](.github/workflows/auto-clear-blocking-labels.yml) (#191/#197) for the sweep doctrine.'
-                  with_gh_retry gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
+                  # #530: non-idempotent comment POST — deliberately unretried
+                  # (a single attempt cannot duplicate); see the event-driven
+                  # job above for the full rationale. Failure is warn-only.
+                  gh pr comment "$PR" --repo "$REPO" --body "$comment_body" \
                     || echo "::warning::Failed to post attribution comment for PR #$PR"
                 else
                   # Removal did not take (label still present or verify read

--- a/.github/workflows/codex-p1-gate.yml
+++ b/.github/workflows/codex-p1-gate.yml
@@ -87,10 +87,21 @@ jobs:
         # PR diff anyway: it takes a PR number + repo and queries the
         # GitHub API. Same trusted-checkout posture as the scheduled-
         # sweep job below. (Codex P1, #271.)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
-          fetch-depth: 0
+          # persist-credentials: false (#545 review / zizmor artipacked):
+          # this job only runs the API-driven scripts/codex-p1-gate.sh — it
+          # never pushes or uses the workspace git remote, so no token needs
+          # to linger in .git/config.
+          persist-credentials: false
+          # Shallow checkout (#536): this job only runs
+          # scripts/codex-p1-gate.sh, which is API-driven (takes a PR
+          # number + repo and queries the GitHub API) — it never reads
+          # git history. `fetch-depth: 0` cloned the entire history for
+          # nothing; the default depth-1 checkout is sufficient for the
+          # trusted gate script.
+          fetch-depth: 1
 
       - name: Resolve PR number
         id: pr
@@ -154,10 +165,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (default branch — trusted scripts)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
-          fetch-depth: 0
+          # persist-credentials: false (#545 review / zizmor artipacked):
+          # this job only runs the API-driven scripts/codex-p1-gate.sh — it
+          # never pushes or uses the workspace git remote, so no token needs
+          # to linger in .git/config.
+          persist-credentials: false
+          # Shallow checkout (#536): the scheduled sweep also only runs
+          # the API-driven scripts/codex-p1-gate.sh per open PR (listed
+          # via `gh pr list`, head SHA via `gh api`). No git history is
+          # read, so the full-history clone was pure overhead.
+          fetch-depth: 1
 
       - name: Find open PRs
         id: find

--- a/.github/workflows/daily-feedback-rollup.yml
+++ b/.github/workflows/daily-feedback-rollup.yml
@@ -48,6 +48,12 @@ permissions:
 jobs:
   rollup:
     name: Classify + post rollup issues
+    # Reject manual dispatch from a non-default ref (#550 Codex P1): on
+    # workflow_dispatch GitHub runs the workflow DEFINITION from the chosen
+    # ref, which the checkout pin cannot constrain — a feature branch could
+    # leak REVIEWER_ASSIGNMENT_TOKEN before checkout. Scheduled runs and
+    # default-branch dispatch pass; a feature-branch dispatch is skipped.
+    if: github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -58,9 +64,13 @@ jobs:
         # ref the checkout would honor an attacker-influenceable GITHUB_REF and
         # could run an untrusted version of the rollup scripts under the write
         # token. Always run the canonical scripts from the default branch.
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
+          # The rollup only runs gh with REVIEWER_ASSIGNMENT_TOKEN (an explicit
+          # env token) and does no authenticated git, so don't leave the
+          # checkout token in .git/config (#548 / Codex #550).
+          persist-credentials: false
 
       - name: Ensure jq + gh present
         run: |

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -27,7 +27,7 @@ jobs:
       # validation in the next step. github.event.pull_request.base.sha
       # is the merge target's tip at the moment the PR opened.
       # codex r2 on PR #179 caught the missing checkout.
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           # Don't persist the checkout token — we use REVIEWER_ASSIGNMENT_TOKEN

--- a/.github/workflows/merge-clearance-gate.yml
+++ b/.github/workflows/merge-clearance-gate.yml
@@ -90,7 +90,7 @@ jobs:
         # required check, and merge past the gate. "Read-only" does NOT
         # mean "can't be weaponized" — satisfying a required check IS the
         # weaponization. Same trusted-checkout posture as codex-p1-gate.yml.
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
@@ -164,7 +164,7 @@ jobs:
       checks: write
     steps:
       - name: Checkout repo (default branch — trusted scripts)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -29,9 +29,27 @@ permissions:
 jobs:
   audit:
     name: Audit Merged PRs
+    # Reject manual dispatch from a non-default ref (#550 Codex P1): on
+    # workflow_dispatch GitHub runs the workflow DEFINITION from the chosen
+    # ref, which the checkout pin cannot constrain — a feature branch could
+    # leak REVIEWER_ASSIGNMENT_TOKEN before checkout. Scheduled runs and
+    # default-branch dispatch pass; a feature-branch dispatch is skipped.
+    if: github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      # Pin to the trusted default branch (#548): this workflow has a
+      # workflow_dispatch trigger and runs the inline actions/github-script
+      # audit under the cross-repo REVIEWER_ASSIGNMENT_TOKEN, reading
+      # .github/review-policy.yml from the checkout. Without an explicit ref a
+      # manually-dispatched branch could supply tampered policy/code that runs
+      # under that privileged PAT. Always audit from the canonical default branch.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          # The audit reads via gh / github-script with an explicit token; it
+          # never does git-authenticated writes, so don't leave the checkout
+          # token in .git/config (#548 defense-in-depth).
+          persist-credentials: false
 
       - name: Install js-yaml
         run: npm install --no-save --ignore-scripts --legacy-peer-deps js-yaml
@@ -251,6 +269,20 @@ jobs:
               // Hand-creating all four signals at once is possible but is
               // an explicit, traceable action that would surface during
               // self-review.
+              //
+              // #528 (ruled DEFER + DOCUMENT): this audit identifies a
+              // propagation PR by a FINGERPRINT (trusted author + same-repo
+              // head + mergepath-sync/<sha> branch + mergepath@<sha> title
+              // marker), NOT by re-running the merge lane's full byte-for-byte
+              // verify-propagation-pr.sh proof. That is accepted
+              // defense-in-depth, not a gap: pr-audit is a RETROSPECTIVE
+              // detector (it flags an already-merged PR that skipped review),
+              // while the load-bearing teeth — the byte-level faithful-mirror
+              // proof — runs at MERGE time in pr-review-policy.yml +
+              // merge-clearance-gate. A forged fingerprint cannot MERGE without
+              // also passing that proof, so duplicating the heavy verify here
+              // would add audit cost without closing a demonstrated bypass.
+              // Revisit if a fingerprint-only merge bypass is ever shown.
               const isTrustedSyncAuthor =
                 pr.user && pr.user.login === authorIdentity;
               const isSameRepoHead =

--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -56,9 +56,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          # The external-review check only reads local history (git diff / show
+          # / worktree) and clones PUBLIC mergepath unauthenticated; it never
+          # pushes or uses the workspace remote, so don't leave the checkout
+          # token in .git/config (#548 defense-in-depth).
+          persist-credentials: false
 
       - name: Check for external review triggers from review-policy.yml
         id: check
@@ -192,13 +197,38 @@ jobs:
               if git clone --quiet --filter=blob:none \
                    https://github.com/nathanjohnpayne/mergepath "$MP_DIR" \
                  && git -C "$MP_DIR" checkout --quiet "$SYNC_SHA" 2>/dev/null; then
-                VERIFIER="$MP_DIR/scripts/workflow/verify-propagation-pr.sh"
-                if [ -x "$VERIFIER" ] || [ -f "$VERIFIER" ]; then
-                  if bash "$VERIFIER" "$MP_DIR" "$PWD" "$BASE_SHA" "$HEAD_SHA"; then
+                # #531: run the TRUSTED in-repo verifier from the PR's
+                # BASE commit (propagated + reviewed; the PR cannot edit
+                # its own base), NOT the verifier shipped inside the
+                # runtime-cloned mergepath@<sha>. The clone ($MP_DIR) is
+                # passed only as a DATA source (manifest + canonical
+                # content); no shell is executed out of it. This removes
+                # the RCE surface of running runtime-fetched code under a
+                # `pull-requests: write` workflow. The base verifier
+                # sources its helpers from its own dir, so they are the
+                # base commit's trusted copies too. fetch-depth:0 above
+                # guarantees BASE_SHA is present for the worktree add.
+                BASE_TREE=$(mktemp -d)
+                if git worktree add --quiet --detach "$BASE_TREE" "$BASE_SHA" 2>/dev/null; then
+                  VERIFIER="$BASE_TREE/scripts/workflow/verify-propagation-pr.sh"
+                  if [ ! -f "$VERIFIER" ]; then
+                    echo "Propagation lane: base commit has no scripts/workflow/verify-propagation-pr.sh (consumer not yet on the vendored verifier) — not lane-eligible; falls through to normal review."
+                  elif ! grep -q 'mergepath-verifier-contract: self-sourced-helpers-v1' "$VERIFIER"; then
+                    # #545 (4a P1): a base verifier predating the #531
+                    # self-sourcing hardening would source its helpers from
+                    # the runtime-cloned mergepath ($MP_DIR) — fetched shell
+                    # under a pull-requests: write job (RCE). Fail closed: do
+                    # NOT run it; fall through to normal review. The lane turns
+                    # on once the hardened verifier itself has propagated into
+                    # the consumer base.
+                    echo "Propagation lane: base verifier predates the #531 self-sourcing contract (no self-sourced-helpers-v1 tag) — not lane-eligible; falls through to normal review."
+                  elif bash "$VERIFIER" "$MP_DIR" "$PWD" "$BASE_SHA" "$HEAD_SHA"; then
                     PROPAGATION_LANE=true
                   fi
+                  git worktree remove --force "$BASE_TREE" 2>/dev/null || rm -rf "$BASE_TREE"
                 else
-                  echo "Propagation lane: mergepath@$SYNC_SHA has no verify-propagation-pr.sh — not lane-eligible."
+                  echo "Propagation lane: could not materialize the base-commit verifier (worktree add failed) — not lane-eligible."
+                  rm -rf "$BASE_TREE"
                 fi
               else
                 echo "Propagation lane: could not check out mergepath@$SYNC_SHA — not lane-eligible."

--- a/scripts/audit-propagation-lane.sh
+++ b/scripts/audit-propagation-lane.sh
@@ -200,15 +200,18 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-command -v yq >/dev/null 2>&1 || { err "yq is required (brew install yq)"; exit 2; }
-yq --version 2>&1 | grep -q "mikefarah/yq" || { err "mikefarah/yq v4+ required"; exit 2; }
-command -v gh >/dev/null 2>&1 || { err "gh is required"; exit 2; }
-[ -f "$MANIFEST" ] || { err "$MANIFEST not found (run from the mergepath root)"; exit 2; }
-
 # --- live-mode credential binding (#454) ------------------------------------
 # Live mode does GitHub reads; bind them to a VERIFIED reviewer token rather
 # than ambient gh state. --check-files mode returned above, so none of this
 # runs offline (that mode needs no token, preflight, gh, or network).
+#
+# #521: the token-presence check is ordered BEFORE the manifest/yq/gh
+# prerequisite checks so a missing reviewer token fails fast with its own
+# diagnostic (exit 3), rather than first erroring on a missing yq/manifest
+# (exit 2) — which is the wrong signal when the real blocker is the absent
+# credential. The token-presence path depends only on the preflight cache,
+# not on yq/gh/the manifest. The IDENTITY verification below still runs
+# after the `gh` check, since it calls `gh api user`.
 __LANE_AUDIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Auto-source the op-preflight cache when GH_TOKEN is unset and a fresh cache
 # exists — the #282 pattern the sibling helpers use. A caller-supplied
@@ -222,6 +225,14 @@ if [ -z "${GH_TOKEN:-}" ]; then
   err "live mode needs a reviewer token. Run: eval \"\$(scripts/op-preflight.sh --agent <agent> --mode review)\", or set GH_TOKEN to a reviewer PAT."
   exit 3
 fi
+
+# Manifest / tooling prerequisites (needed for the live per-consumer loop
+# AND the identity verification's `gh api user` call below).
+command -v yq >/dev/null 2>&1 || { err "yq is required (brew install yq)"; exit 2; }
+yq --version 2>&1 | grep -q "mikefarah/yq" || { err "mikefarah/yq v4+ required"; exit 2; }
+command -v gh >/dev/null 2>&1 || { err "gh is required"; exit 2; }
+[ -f "$MANIFEST" ] || { err "$MANIFEST not found (run from the mergepath root)"; exit 2; }
+
 # Verify the effective token identity is an available_reviewers reviewer
 # (fail closed). Hard-require the shared reader: an unverifiable token must
 # error rather than read live data under an unknown identity.

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -16,6 +16,7 @@ Local scripts:
 - `check_codex_scripts` — verifies `scripts/codex-review-request.sh`, `scripts/codex-review-check.sh`, and `scripts/codex-record-feedback.sh` exist and are executable, then runs the Phase 4a helper test suites including `tests/test_codex_record_feedback.sh` (the #487 validated-👍/👎 feedback loop)
 - `check_codex_p1_gate` — verifies `scripts/codex-p1-gate.sh` + `.github/workflows/codex-p1-gate.yml` + `tests/test_codex_p1_gate.sh` exist, then runs the fixture-driven test suite (Codex P1 unresolved-thread merge gate, #235)
 - `check_sync_manifest` — validates `.mergepath-sync.yml` (manifest read by `scripts/sync-to-downstream.sh`): schema version, consumer shape, every referenced path exists, every path type is recognized. Requires `yq` (mikefarah/yq v4+) on the runner. See #168.
+- `check_propagation_closure` — the INVERSE of `check_sync_manifest` (#519/#521). Scans references *out of* every propagated `scripts/ci/check_*` + canonical `.github/workflows/*` file and fails if any on-disk `tests/`+`scripts/` reference is undeclared (not an exact manifest path, not inside a kit, not in any `requires:`) — i.e. a propagation dependency that would silently *not travel* to consumers and make the referencing tool fail closed there. Skips refs that do not resolve to a real file (fixture strings, doc examples) plus an allow-list of orchestrator/mergepath-internal paths. Requires `yq` (mikefarah/yq v4+); SKIPs on a consumer checkout. See #521.
 - `check_coderabbit_config` — validates `.coderabbit.yml` parses as YAML and (in the Mergepath template repo only) stays on `reviews.profile: chill` (the nit-suppressing profile per CodeRabbit's docs). Consumer repos inheriting this workflow via the template-mirror bootstrap get the parse + existence checks but may override `profile: assertive` locally without failing CI. Template detection prefers `GITHUB_REPOSITORY` (CI) and falls back to the `origin` remote URL for local runs; override via `MERGEPATH_TEMPLATE_CHECK=force|skip`. Requires `yq` (mikefarah/yq v4+) on the runner. See #237 and #256 P2.
 - `check_coderabbit_config_tests` — unit tests for `check_coderabbit_config` itself. Drives the template-vs-consumer detection via fixture repos under `tests/test_check_coderabbit_config.sh`. See #256 P2.
 - `check_coderabbit_wait` — runs `tests/test_coderabbit_wait_status_probe.sh`, covering `scripts/coderabbit-wait.sh` timeout status probing, unchanged exit-4 semantics, and the guard that prevents status replies from counting as review clearance. See #417.
@@ -27,5 +28,6 @@ Local scripts:
 Inline in `repo_lint.yml` (no local script):
 
 - `check_review_policy_exists` — verifies `.github/review-policy.yml` and `REVIEW_POLICY.md` both exist
+- `check_governance_files` — verifies `SECURITY.md`, `.github/CODEOWNERS`, and `.github/dependabot.yml` all exist
 
 See `rules/repo_rules.md` for the full list of enforced checks.

--- a/scripts/ci/check_auto_clear_workflow
+++ b/scripts/ci/check_auto_clear_workflow
@@ -35,7 +35,11 @@ if command -v yq >/dev/null 2>&1; then
     echo "  FAIL: workflow YAML invalid (per yq)" >&2
   fi
 elif python3 -c "import yaml" >/dev/null 2>&1; then
-  if python3 -c "import yaml; yaml.safe_load(open('$WORKFLOW'))" 2>/dev/null; then
+  # Pass the path via argv (sys.argv[1]) instead of string-interpolating
+  # `$WORKFLOW` into the Python source literal. Interpolation was brittle:
+  # a path containing a quote or backslash would break the literal (or
+  # worse). argv keeps the path out of the parsed Python text entirely.
+  if WORKFLOW="$WORKFLOW" python3 -c 'import sys, yaml; yaml.safe_load(open(sys.argv[1]))' "$WORKFLOW" 2>/dev/null; then
     pass=$((pass + 1))
     echo "  PASS: workflow YAML parses (via python+PyYAML)"
   else
@@ -274,10 +278,17 @@ fi
 # `gh pr edit ... --remove-label` executable line, not anywhere in
 # the file (header comments/attribution-message would otherwise
 # satisfy the match even if the executable line regressed).
-if grep -qE 'gh pr edit .+--remove-label needs-external-review' "$WORKFLOW" && \
-   ! grep -qE 'gh pr edit .+--remove-label needs-human-review' "$WORKFLOW" && \
-   ! grep -qE 'gh pr edit .+--remove-label policy-violation' "$WORKFLOW" && \
-   ! grep -qE 'gh pr edit .+--remove-label human-hold' "$WORKFLOW"; then
+# #536 hardening: anchor with `^[^#]*` so a `#` appearing before
+# `gh pr edit` disqualifies the line — a COMMENT that merely mentions
+# `gh pr edit --remove-label needs-external-review` can no longer satisfy
+# the positive check (nor can a commented-out forbidden-label removal
+# trip the negatives, which would have caused a spurious FAIL). Indented
+# executable lines inside `run:` blocks still match (no `#` precedes the
+# command).
+if grep -qE '^[^#]*gh pr edit[^#]*--remove-label needs-external-review([[:space:]]|$)' "$WORKFLOW" && \
+   ! grep -qE '^[^#]*gh pr edit[^#]*--remove-label needs-human-review([[:space:]]|$)' "$WORKFLOW" && \
+   ! grep -qE '^[^#]*gh pr edit[^#]*--remove-label policy-violation([[:space:]]|$)' "$WORKFLOW" && \
+   ! grep -qE '^[^#]*gh pr edit[^#]*--remove-label human-hold([[:space:]]|$)' "$WORKFLOW"; then
   pass=$((pass + 1))
   echo "  PASS: scope discipline — only needs-external-review is auto-removed (executable line)"
 else

--- a/scripts/ci/check_merge_clearance_gate
+++ b/scripts/ci/check_merge_clearance_gate
@@ -20,7 +20,10 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO_ROOT"
 
 SCRIPT="scripts/merge-clearance-gate.sh"
-WORKFLOW=".github/workflows/merge-clearance-gate.yml"
+# WORKFLOW path is overridable so the test suite can point the workflow-shape
+# assertions (in particular the job-name contract below) at a fixture without
+# touching the canonical workflow on disk. Defaults to the real workflow.
+WORKFLOW="${MERGE_CLEARANCE_WORKFLOW:-.github/workflows/merge-clearance-gate.yml}"
 TEST="tests/test_merge_clearance_gate.sh"
 
 FAILED=0
@@ -86,9 +89,41 @@ if [ -f "$WORKFLOW" ]; then
   # scheduled-sweep posts AND the entry in audit-branch-protection.sh's
   # CANONICAL_REQUIRED_CHECKS. Branch protection keys on the job name, so
   # a drift here would silently de-wire the gate.
-  if ! grep -qE '^[[:space:]]+name:[[:space:]]*Merge clearance gate[[:space:]]*$' "$WORKFLOW"; then
-    echo "FAIL: $WORKFLOW must define a job named exactly 'Merge clearance gate'"
+  #
+  # Scope the assertion to the jobs: block and require the match to be a
+  # JOB name (a `name:` key at the job-content indent, directly under a job
+  # key) — NOT just any indented `name:`. A plain grep for an indented
+  # `name:` also matched a step-level `name: Merge clearance gate` (a
+  # non-first step key, deeper-indented, no leading dash). That let a
+  # coincidentally-named *step* satisfy the required-check contract even if
+  # the *job* name had drifted. The awk state machine below tracks the
+  # jobs: block, records each job key's content indent, and only matches a
+  # `name: Merge clearance gate` at that exact indent.
+  if ! awk '
+    /^jobs:[[:space:]]*$/ { in_jobs=1; next }
+    in_jobs && /^[^[:space:]#]/ { in_jobs=0 }
+    !in_jobs { next }
+    {
+      n=0
+      while (substr($0, n+1, 1) == " ") n++
+    }
+    # A job key is indented exactly two spaces under jobs: and is a bare
+    # "<name>:" block opener (nothing after the colon). Record the indent
+    # of its content (job-name / runs-on / steps live one level deeper).
+    in_jobs && n==2 && $0 ~ /^  [A-Za-z0-9_-]+:[[:space:]]*$/ {
+      job_content_indent = n + 2
+      next
+    }
+    # A job name sits at the job-content indent. Only this counts.
+    in_jobs && job_content_indent>0 && n==job_content_indent &&
+      $0 ~ /name:[[:space:]]*Merge clearance gate[[:space:]]*$/ {
+      found=1; exit
+    }
+    END { exit (found ? 0 : 1) }
+  ' "$WORKFLOW"; then
+    echo "FAIL: $WORKFLOW must define a JOB named exactly 'Merge clearance gate'"
     echo "      (the required-check context; must match the sweep CHECK_NAME and audit-branch-protection.sh)."
+    echo "      A step-level name: does NOT satisfy this — branch protection keys on the job name."
     FAILED=1
   fi
 fi

--- a/scripts/ci/check_no_bare_gh_writes
+++ b/scripts/ci/check_no_bare_gh_writes
@@ -29,7 +29,105 @@ if [ "${#FILES[@]}" -eq 0 ]; then
 fi
 
 set +e
-awk -v root="$REPO_ROOT/" '
+# sq carries a single-quote char into the (single-quoted) awk program so it
+# can match quotes inside command substitutions without a literal quote (#540).
+awk -v root="$REPO_ROOT/" -v sq="'" '
+# The write-class matchers, factored out so they can be run against BOTH a
+# whole line AND the contents of an echo/printf command substitution (#533).
+function gh_write_class(s) {
+  if (s ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+pr[[:space:]]+(-R[[:space:]]+[^[:space:]]+[[:space:]]+|--repo[[:space:]]+[^[:space:]]+[[:space:]]+|--repo=[^[:space:]]+[[:space:]]+)?(create|merge|review|comment|edit)([[:space:]]|$)/) return 1
+  if (s ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+pr[[:space:]]+close([[:space:]]|$)/) return 1
+  if (s ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+issue[[:space:]]+(create|comment|edit|close)([[:space:]]|$)/) return 1
+  if (s ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+repo[[:space:]]+(create|delete|edit)([[:space:]]|$)/) return 1
+  if (s ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+label[[:space:]]+(create|edit|delete)([[:space:]]|$)/) return 1
+  if (s ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+secret[[:space:]]+set([[:space:]]|$)/) return 1
+  if (s ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+variable[[:space:]]+set([[:space:]]|$)/) return 1
+  if (s ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+project[[:space:]]+(create|edit|field-create|item-add|item-edit)([[:space:]]|$)/) return 1
+  # Compact and spaced method forms (#466): catch -X POST, -XPOST,
+  # --method POST, and --method=POST (the compact -X<METHOD> / --method=<METHOD>
+  # forms previously slipped through the space-requiring matcher).
+  if (s ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+api[[:space:]].*(-X[[:space:]]*|--method[[:space:]]*=?[[:space:]]*)(POST|PATCH|PUT|DELETE)([[:space:]]|$)/) return 1
+  if (s ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+api[[:space:]]+graphql/ && s ~ /(mutation|resolveReviewThread|addPullRequestReviewThreadReply|addComment|updateIssue|closeIssue)/) return 1
+  return 0
+}
+# Collect ONLY the interiors of command substitutions on a line — the text
+# between a `$(` and its matching `)` (handling nesting), plus the text
+# between a pair of backticks. Returns that text joined by spaces. Text that
+# merely sits inside the echo/printf string but OUTSIDE a substitution (e.g.
+# a log message that literally spells "gh project create") is excluded, so it
+# does not falsely match. Bash-3.2-safe / POSIX-awk: manual character walk,
+# no capture groups.
+function cmdsub_interiors(line,   i, c, n, depth, out, inbt, prev, q, oq, esc) {
+  n = length(line)
+  out = ""
+  depth = 0   # nesting depth inside $(...)
+  inbt = 0    # currently inside a backtick pair
+  q = ""      # quote state inside $(): "" none, single, or double quote
+  oq = ""     # OUTER quote at depth 0: "" none, single, or double quote
+  esc = 0     # previous char at depth 0 was an active backslash escape
+  prev = ""
+  for (i = 1; i <= n; i++) {
+    c = substr(line, i, 1)
+    if (inbt) {
+      if (c == "`") { inbt = 0; out = out " " }
+      else { out = out c }
+      prev = c
+      continue
+    }
+    if (depth > 0) {
+      # Inside a command substitution. Track quotes so a ) or ( that sits
+      # inside a single- or double-quoted string is treated as literal,
+      # not as structure (bash does not end a substitution on a quoted
+      # paren). Quoted content is still captured so a gh write inside the
+      # quotes is not lost (the #540 quoted-paren-before-write bypass).
+      # sq holds a single-quote char (passed via -v) so this single-quoted
+      # awk program needs no literal quote of its own.
+      if (q != "") {
+        out = out c
+        if (q == sq) { if (c == sq) q = "" }
+        else if (c == "\"" && prev != "\\") { q = "" }
+        prev = c
+        continue
+      }
+      if (c == sq) { q = sq; out = out c; prev = c; continue }
+      if (c == "\"") { q = "\""; out = out c; prev = c; continue }
+      if (c == "(" && prev == "$") { depth++ }
+      else if (c == ")") { depth--; if (depth == 0) out = out " " }
+      else { out = out c }
+      prev = c
+      continue
+    }
+    # Outside any substitution (depth 0). Track the OUTER quote and a
+    # backslash escape so a $( or backtick inside single-quotes, or an
+    # escaped backslash-dollar, is literal (bash runs no substitution
+    # there) and an echo of such text is not treated as a write (#540 P2).
+    if (esc) { esc = 0; prev = "x"; continue }
+    if (oq == sq) { if (c == sq) oq = ""; prev = c; continue }
+    if (c == "\\") { esc = 1; prev = c; continue }
+    if (oq == "\"") {
+      if (c == "\"") { oq = ""; prev = c; continue }
+      if (c == "(" && prev == "$") { depth = 1; q = ""; prev = c; continue }
+      if (c == "`") { inbt = 1; prev = c; continue }
+      prev = c; continue
+    }
+    if (c == sq) { oq = sq; prev = c; continue }
+    if (c == "\"") { oq = "\""; prev = c; continue }
+    if (c == "(" && prev == "$") { depth = 1; q = ""; prev = c; continue }
+    if (c == "`") { inbt = 1; prev = c; continue }
+    prev = c
+  }
+  return out
+}
+# Does an echo/printf line hide a gh WRITE inside a command substitution
+# ($(...) or backticks)? A plain documented echo of non-write text — or a
+# read like `echo "$(gh pr view 1)"`, or a log line that merely names a gh
+# write OUTSIDE the substitution — stays exempt, while
+# `echo "$(gh repo create x)"` / `printf "%s" "$(gh secret set X)"` are
+# caught (#533).
+function gh_write_in_cmdsub(line) {
+  if (line !~ /\$\(/ && line !~ /`/) return 0
+  return gh_write_class(cmdsub_interiors(line))
+}
 function bare_write(line) {
   if (line ~ /^[[:space:]]*($|#)/) return 0
   # Exemption requires a documented reason after the colon (#466): a bare
@@ -37,26 +135,24 @@ function bare_write(line) {
   # bypass. The error message has always promised "with a reason"; enforce it.
   if (line ~ /NO_BARE_GH_WRITE_EXEMPT:[[:space:]]*[^[:space:]]/) return 0
   if (line ~ /\\`[^`]*gh[[:space:]]+(pr|issue|api)[^`]*\\`/) return 0
-  if (line ~ /^[[:space:]]*(echo|printf)[[:space:]]/ &&
-      line !~ /\$\([[:space:]]*gh[[:space:]]+(pr|issue|api)[[:space:]]/ &&
-      line !~ /`[^`]*gh[[:space:]]+(pr|issue|api)[^`]*`/) return 0
+  # Verified-wrapper / helper exemptions. Evaluated BEFORE the echo/printf
+  # branch so a wrapped write that happens to live inside an echo
+  # substitution (e.g. echo "$(scripts/gh-as-author.sh -- gh pr merge ...)")
+  # stays exempt, exactly as the prior ordering allowed.
   if (line ~ /gh-as-(author|reviewer)\.sh[^;&|]*--[[:space:]]+gh/) return 0
   if (line ~ /\$"?[A-Z_]*AS_(AUTHOR|REVIEWER)"?[[:space:]]+--[[:space:]]+gh/) return 0
   if (line ~ /(^|[[:space:]])(sync_author_gh|bootstrap::run_author_gh|bootstrap::author_gh|ghp_gh|gh_reviewer|gh_pat)[[:space:]]+/) return 0
-  if (line ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+pr[[:space:]]+(-R[[:space:]]+[^[:space:]]+[[:space:]]+|--repo[[:space:]]+[^[:space:]]+[[:space:]]+|--repo=[^[:space:]]+[[:space:]]+)?(create|merge|review|comment|edit)([[:space:]]|$)/) return 1
-  if (line ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+pr[[:space:]]+close([[:space:]]|$)/) return 1
-  if (line ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+issue[[:space:]]+(create|comment|edit|close)([[:space:]]|$)/) return 1
-  if (line ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+repo[[:space:]]+(create|delete|edit)([[:space:]]|$)/) return 1
-  if (line ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+label[[:space:]]+(create|edit|delete)([[:space:]]|$)/) return 1
-  if (line ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+secret[[:space:]]+set([[:space:]]|$)/) return 1
-  if (line ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+variable[[:space:]]+set([[:space:]]|$)/) return 1
-  if (line ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+project[[:space:]]+(create|edit|field-create|item-add|item-edit)([[:space:]]|$)/) return 1
-  # Compact and spaced method forms (#466): catch -X POST, -XPOST,
-  # --method POST, and --method=POST (the compact -X<METHOD> / --method=<METHOD>
-  # forms previously slipped through the space-requiring matcher).
-  if (line ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+api[[:space:]].*(-X[[:space:]]*|--method[[:space:]]*=?[[:space:]]*)(POST|PATCH|PUT|DELETE)([[:space:]]|$)/) return 1
-  if (line ~ /(^|[^A-Za-z0-9_.\/-])gh[[:space:]]+api[[:space:]]+graphql/ && line ~ /(mutation|resolveReviewThread|addPullRequestReviewThreadReply|addComment|updateIssue|closeIssue)/) return 1
-  return 0
+  # echo/printf masking (#533): an echo/printf line is exempt UNLESS it hides
+  # a gh write inside a command substitution. The prior negative-check only
+  # looked for gh pr|issue|api in the substitution, so a write via any OTHER
+  # verb (repo create, secret set, label create, variable set, project ...,
+  # gh api -X POST) slipped through. Run the full write-class matchers on the
+  # substitution contents before granting the exemption.
+  if (line ~ /^[[:space:]]*(echo|printf)[[:space:]]/) {
+    if (gh_write_in_cmdsub(line)) return 1
+    return 0
+  }
+  return gh_write_class(line)
 }
 {
   rel = FILENAME

--- a/scripts/ci/check_phase_4b_classifier
+++ b/scripts/ci/check_phase_4b_classifier
@@ -259,6 +259,83 @@ fi
 rm -rf "$SCRATCH_GH"
 
 echo
+echo "phase-4b-classifier.sh reviewer-PAT pin tests (#533)"
+
+# The live `gh api .../pulls/{pr}/files` (and the PR body fetch) must
+# authenticate under the reviewer PAT, not under a bare ambient GH_TOKEN.
+# The stub records the GH_TOKEN it observed on each call; we assert the
+# reviewer-PAT sentinel — NOT the differing ambient GH_TOKEN — reached gh.
+SCRATCH_PAT=$(mktemp -d)
+GH_TOKEN_LOG="$SCRATCH_PAT/gh-token.log"
+cat > "$SCRATCH_PAT/gh" <<GH_STUB
+#!/usr/bin/env bash
+# Record the effective GH_TOKEN per call, then return a benign payload so
+# the classifier runs to completion (no trigger → exit 0).
+printf 'TOKEN=%s ARGS=%s\n' "\${GH_TOKEN:-}" "\$*" >> "$GH_TOKEN_LOG"
+case " \$* " in
+  *" repos/"*"/pulls/"*"/files "*|*" repos/"*"/pulls/"*"/files")
+    printf '%s\n' '[{"filename":"README.md","patch":"+docs\n"}]'
+    exit 0
+    ;;
+  *" repos/"*"/pulls/"*)
+    printf '%s\n' 'a benign body with no triggers'
+    exit 0
+    ;;
+  *)
+    echo "Error: unstubbed gh call: \$*" >&2
+    exit 1
+    ;;
+esac
+GH_STUB
+chmod +x "$SCRATCH_PAT/gh"
+mkdir -p "$SCRATCH_PAT/.github"
+echo "phase_4b_default: complex-changes" > "$SCRATCH_PAT/.github/review-policy.yml"
+
+set +e
+out=$(cd "$SCRATCH_PAT" && PATH="$SCRATCH_PAT:$PATH" \
+  GH_TOKEN=ambient-bare-token \
+  OP_PREFLIGHT_REVIEWER_PAT=reviewer-pat-sentinel \
+  MERGEPATH_REVIEW_POLICY_PATH="$SCRATCH_PAT/.github/review-policy.yml" \
+  bash "$ROOT/$CLASSIFIER" 99999 --repo nathanjohnpayne/mergepath 2>&1)
+rc=$?
+set -e
+# The files endpoint is the call the issue calls out; assert it ran under
+# the reviewer PAT and that the ambient bare token never reached gh.
+if [ "$rc" = "0" ] \
+   && grep -q 'TOKEN=reviewer-pat-sentinel ARGS=.*pulls/99999/files' "$GH_TOKEN_LOG" \
+   && ! grep -q 'TOKEN=ambient-bare-token' "$GH_TOKEN_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: live gh api files+body fetch pinned to reviewer PAT (ambient GH_TOKEN not used)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: live gh api should run under the reviewer PAT (#533) (rc=$rc)" >&2
+  echo "    gh-token log:" >&2
+  sed 's/^/      /' "$GH_TOKEN_LOG" >&2 2>/dev/null || true
+  echo "$out" | sed 's/^/      /' >&2
+fi
+
+# Fallback: with no reviewer PAT, the pin falls back to the ambient GH_TOKEN
+# (the empty-token guard requires one or the other). The call must still run.
+: > "$GH_TOKEN_LOG"
+set +e
+out=$(cd "$SCRATCH_PAT" && PATH="$SCRATCH_PAT:$PATH" \
+  GH_TOKEN=ambient-only-token \
+  MERGEPATH_REVIEW_POLICY_PATH="$SCRATCH_PAT/.github/review-policy.yml" \
+  bash "$ROOT/$CLASSIFIER" 99999 --repo nathanjohnpayne/mergepath 2>&1)
+rc=$?
+set -e
+if [ "$rc" = "0" ] && grep -q 'TOKEN=ambient-only-token ARGS=.*pulls/99999/files' "$GH_TOKEN_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: no reviewer PAT → pin falls back to ambient GH_TOKEN (call still runs)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: reviewer-PAT-absent fallback should use ambient GH_TOKEN (#533) (rc=$rc)" >&2
+  sed 's/^/      /' "$GH_TOKEN_LOG" >&2 2>/dev/null || true
+  echo "$out" | sed 's/^/      /' >&2
+fi
+rm -rf "$SCRATCH_PAT"
+
+echo
 echo "phase-4b-classifier.sh argument-validation tests"
 
 # Bad PR# (non-integer) → exit 3

--- a/scripts/ci/check_pr_audit_codex_clearance
+++ b/scripts/ci/check_pr_audit_codex_clearance
@@ -61,9 +61,15 @@ for f in "$FIXTURES_DIR" "$WORKFLOW"; do
   fi
 done
 
+# #527 (ruled fail-closed): this script mirrors the node-based
+# `codexCleared` computation in pr-audit.yml as a parity self-test. A
+# self-test that silently no-ops when its interpreter is absent can mask
+# drift between this mirror and the workflow, so fail closed when node is
+# missing rather than passing vacuously. The real merge gate runs in the
+# workflow, where node is guaranteed.
 if ! command -v node >/dev/null 2>&1; then
-  echo "check_pr_audit_codex_clearance: SKIP — node not on PATH" >&2
-  exit 0
+  echo "check_pr_audit_codex_clearance: FAIL — node not on PATH; the parity self-test cannot run (fail-closed per #527)" >&2
+  exit 1
 fi
 
 # The mirrored algorithm. Keep this in sync with the

--- a/scripts/ci/check_propagation_closure
+++ b/scripts/ci/check_propagation_closure
@@ -1,0 +1,368 @@
+#!/usr/bin/env bash
+# check_propagation_closure
+#
+# Systemic closure-completeness guard — the INVERSE of
+# check_sync_manifest. See #519 / #521 for the drift class this closes.
+#
+# ─────────────────────────────────────────────────────────────────────
+# The gap this closes
+# ─────────────────────────────────────────────────────────────────────
+#
+# check_sync_manifest validates that every DECLARED `requires:` entry is
+# COVERED by the manifest (an exact path, inside a kit, or another
+# requires:). It cannot detect a MISSING one: a PROPAGATED file — a
+# `scripts/ci/check_*` wrapper, or a propagated `.github/workflows/*.yml`
+# — that hard-references a `tests/` or `scripts/` path which is neither a
+# manifest path, inside a kit, nor in any `requires:` list. That
+# referenced file then does NOT travel to consumers, and the referencing
+# tool fails closed on the consumer.
+#
+# This is the #519 / #521 drift class (3rd occurrence): e.g.
+# scripts/ci/check_coderabbit_wait referenced
+# tests/test_coderabbit_wait_codex_failover.sh +
+# tests/test_coderabbit_automerge_rate_limit_gate.sh, and
+# agent-review.yml referenced scripts/coderabbit-automerge-rate-limit-gate.sh,
+# none declared — fixed in #526 by adding them to the manifest. This
+# check would have caught all three at manifest-edit time.
+#
+# ─────────────────────────────────────────────────────────────────────
+# What it does
+# ─────────────────────────────────────────────────────────────────────
+#
+# Enumerate references OUT of every propagated check_*/workflow file;
+# FAIL if any tests/+scripts/ reference is undeclared — i.e. not an exact
+# manifest path, not inside a kit, not in any requires: list — UNLESS:
+#
+#   - the referenced path does NOT exist on disk in this mergepath
+#     checkout. A non-existent ref cannot be a propagation dependency:
+#     there is nothing to propagate, and the referencing tool is not
+#     shelling out to a real file at runtime. In practice these are
+#     fixture-string paths embedded in a check's heredoc test data
+#     (e.g. `"path": "scripts/a.sh"` inside a synthetic PR body), doc
+#     examples in a comment (e.g. `scripts/cinema/foo.js`), or test
+#     assertion literals (`scripts/has-type.sh`). Skipping them is
+#     fail-CLOSED in the right direction — a real undeclared dependency
+#     is, by definition, a real file in mergepath that must travel.
+#
+#   - the ref is on the orchestrator/mergepath-internal ALLOW_LIST below
+#     (refs intentionally NOT propagated — the propagation engine
+#     itself, the new-repo bootstrap seeders, the weekly-sweep pipeline,
+#     and the self-tests of checks that are mergepath-only / SKIP on
+#     consumers / are never wired into a consumer's repo_lint.yml). Each
+#     entry is justified inline; keep entries SPECIFIC so the allow-list
+#     never masks a genuine gap.
+#
+#   - the ref is the scan file's OWN path (self-reference).
+#
+# This check is read-only and does NOT contact downstream repos.
+
+set -euo pipefail
+
+# Env overrides for tests/test_check_propagation_closure.sh — same
+# contract as check_sync_manifest:
+#   MERGEPATH_MANIFEST_PATH — point at a fixture manifest YAML
+#   MERGEPATH_REPO_ROOT     — point at a fixture repo tree (so the scan
+#                             enumerates the fixture's check_*/workflow
+#                             files and the exists-on-disk filter probes
+#                             the fixture). Default is the script's own
+#                             repo root in PR CI.
+REPO_ROOT="${MERGEPATH_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+MANIFEST="${MERGEPATH_MANIFEST_PATH:-$REPO_ROOT/.mergepath-sync.yml}"
+
+# ─────────────────────────────────────────────────────────────────────
+# Consumer-side vs mergepath-side disambiguation — BEFORE the yq check.
+# ─────────────────────────────────────────────────────────────────────
+#
+# Identical posture to check_sync_manifest. The manifest is
+# mergepath-internal by design (it lists every consumer's private
+# metadata, #268/#271), so a consumer that received THIS check via the
+# scripts/ci/ kit must no-op rather than fail. The marker file
+# scripts/sync-to-downstream.sh exists in mergepath and is intentionally
+# NOT propagated, so its presence distinguishes a mergepath checkout
+# from a consumer one.
+#
+#   (a) consumer checkout (sync-to-downstream.sh ALSO absent) → SKIP exit 0.
+#   (b) mergepath checkout (sync-to-downstream.sh present)    → FAIL exit 1
+#       (the manifest was accidentally deleted/renamed in a PR that
+#       modifies the canonical repo).
+if [ ! -f "$MANIFEST" ]; then
+  MARKER="$REPO_ROOT/scripts/sync-to-downstream.sh"
+  if [ ! -f "$MARKER" ]; then
+    echo "check_propagation_closure: SKIP (mergepath-only: .mergepath-sync.yml not present in this checkout; scripts/sync-to-downstream.sh also absent → consumer checkout)"
+    exit 0
+  fi
+  echo "FAIL: .mergepath-sync.yml is missing at repo root (but scripts/sync-to-downstream.sh IS present — looks like mergepath itself; the manifest must not be deleted/renamed)"
+  exit 1
+fi
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "FAIL: yq is required (mikefarah/yq v4+). Install via 'brew install yq' or apt."
+  exit 2
+fi
+
+# Parse-check: yq exits non-zero on a malformed YAML.
+if ! yq '.' "$MANIFEST" >/dev/null 2>&1; then
+  echo "FAIL: .mergepath-sync.yml does not parse as YAML"
+  yq '.' "$MANIFEST" || true
+  exit 1
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Build the COVERED set from the manifest.
+# ─────────────────────────────────────────────────────────────────────
+#
+# Same fail-closed extraction idioms as check_sync_manifest: capture
+# each yq stream into a variable with an explicit error check so a
+# malformed manifest fails loudly instead of yielding an empty set (which
+# would silently flag every ref).
+#
+#   exact_set    — comma-joined .paths[].path, sentinel-padded so a
+#                  substring lookup can't false-match (",foo/bar," is
+#                  unambiguous).
+#   requires_set — comma-joined every .requires[] entry, same padding.
+#   kit_prefixes — each kit .path forced to a trailing slash so the
+#                  prefix match is slash-bounded (scripts/ci/ covers
+#                  scripts/ci/x but NOT scripts/cinema/x).
+if ! exact_rows=$(yq -r '.paths[].path' "$MANIFEST" 2>&1); then
+  echo "FAIL: could not extract manifest paths (yq error):"
+  printf '%s\n' "$exact_rows"
+  echo "check_propagation_closure: FAIL"
+  exit 1
+fi
+if ! requires_rows=$(yq -r '.paths[] | select(has("requires")) | .requires[]' "$MANIFEST" 2>&1); then
+  echo "FAIL: could not extract manifest requires: entries (yq error):"
+  printf '%s\n' "$requires_rows"
+  echo "check_propagation_closure: FAIL"
+  exit 1
+fi
+if ! kit_rows=$(yq -r '.paths[] | select(.type == "kit") | .path' "$MANIFEST" 2>&1); then
+  echo "FAIL: could not extract kit paths from the manifest (yq error):"
+  printf '%s\n' "$kit_rows"
+  echo "check_propagation_closure: FAIL"
+  exit 1
+fi
+
+exact_set=",$(echo "$exact_rows" | tr '\n' ',')"
+requires_set=",$(echo "$requires_rows" | tr '\n' ',')"
+
+kit_prefixes=""
+while IFS= read -r kp; do
+  [ -z "$kp" ] && continue
+  case "$kp" in
+    */) kit_prefixes="$kit_prefixes $kp" ;;
+    *)  kit_prefixes="$kit_prefixes $kp/" ;;
+  esac
+done <<< "$kit_rows"
+
+# is_covered <ref> — 0 if the manifest propagates the ref: an exact
+# entry, a declared requires:, or strictly inside a kit subtree.
+is_covered() {
+  local ref="$1" kp
+  [[ "$exact_set" == *",$ref,"* ]] && return 0
+  [[ "$requires_set" == *",$ref,"* ]] && return 0
+  for kp in $kit_prefixes; do
+    [[ "$ref" == "$kp"* ]] && return 0
+  done
+  return 1
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# ALLOW_LIST — orchestrator / mergepath-internal refs NOT propagated.
+# ─────────────────────────────────────────────────────────────────────
+#
+# Each pattern is matched against a ref with bash `case` glob semantics
+# (so a trailing /* matches a whole subtree). SEEDED from the #521 design
+# and refined empirically against the live tree: every entry below was
+# verified to belong to a check/workflow that is EITHER never wired into
+# a consumer's repo_lint.yml OR SKIPs on a consumer (manifest-absent
+# guard), so the referenced file legitimately never needs to travel.
+# Verified 2026-06-24: device-source-of-truth + swipewatch consumers
+# carry none of these scripts/tests, and their repo_lint.yml wires none
+# of the referencing checks.
+#
+# Keep entries SPECIFIC. A pattern broad enough to swallow a real
+# consumer-wired dependency would re-open the #519/#521 gap.
+ALLOW_LIST=(
+  # The propagation engine itself + its project-doc-mirror sibling.
+  # scripts/sync-to-downstream.sh is the orchestrator — explicitly NEVER
+  # propagated (see the manifest's "NOT propagated" note). Referenced
+  # only in comments by pr-audit.yml / pr-review-policy.yml and by the
+  # sync/manifest checks. project-doc-sync.sh (#508) is its mergepath-only
+  # sibling; check_sync_to_downstream SKIPs on consumers.
+  "scripts/sync-to-downstream.sh"
+  "scripts/project-doc-sync.sh"
+  "tests/test_sync_to_downstream.sh"
+  "tests/test_sync_overrides.sh"
+  "tests/test_project_doc_sync.sh"
+
+  # New-repo bootstrap seeders (scripts/bootstrap.sh, bootstrap-new-repo.sh,
+  # bootstrap-config.sh, and the scripts/bootstrap/ subtree). These seed a
+  # NEW repo once; they are orchestrator-only and never propagated. Their
+  # check_bootstrap_* wrappers are not wired into any consumer repo_lint.
+  # NB: glob patterns are STORED LITERALLY (fully quoted) so the array
+  # literal is not subject to pathname expansion at definition time; the
+  # `case` statement in is_allow_listed() does the glob match.
+  "scripts/bootstrap.sh"
+  "scripts/bootstrap-new-repo.sh"
+  "scripts/bootstrap-config.sh"
+  "scripts/bootstrap/*"
+  "tests/test_bootstrap*"
+
+  # Weekly unresolved-feedback sweep pipeline — mergepath-only cron
+  # workhorse; check_sweep_unresolved_feedback is not wired on consumers.
+  "scripts/sweep-unresolved-feedback/*"
+  "tests/test_sweep*"
+
+  # Propagation-lane audit test family. audit-propagation-lane.sh IS
+  # declared (already covered), kept here only for robustness to a future
+  # manifest reshuffle.
+  #
+  # NB: scripts/workflow/* is deliberately NOT allow-listed (nathanpayne-codex
+  # Phase-4b finding on #543). scripts/workflow/ is a propagated kit, so a
+  # reference to a workflow helper that genuinely travels is already covered
+  # by is_covered (the kit prefix). A blanket scripts/workflow/* allow-list
+  # would instead MASK the exact closure gap this check exists to catch — a
+  # propagated workflow that hard-references a scripts/workflow/ helper which
+  # is NOT in the kit/manifest. If a specific workflow helper is genuinely
+  # mergepath-only, exempt that one reference with a narrow justification.
+  "scripts/audit-propagation-lane.sh"
+  "tests/test_audit*"
+
+  # Templated-propagation engine lib (#313). check_template_substitution
+  # and check_workflow_verify_propagation_templated both SKIP on a
+  # consumer (manifest-absent guard); the lib + its templated-verify test
+  # are mergepath-internal and never travel.
+  "scripts/lib/template-substitution.sh"
+  "tests/test_verify_propagation_pr_templated.sh"
+
+  # 1Password headless-proof setup — mergepath-only operator tooling;
+  # check_onepassword_headless_proof_workflow is not wired on consumers.
+  "scripts/onepassword-headless-proof-setup.sh"
+
+  # Self-tests of mergepath-only CI checks that are NOT wired into any
+  # consumer's repo_lint.yml (verified against live consumers). The
+  # check wrapper ships via the scripts/ci/ kit but never runs on a
+  # consumer, so its paired test legitimately does not travel:
+  #   - check_eslint_config_policy  → test_eslint_policy_check.sh
+  #   - check_mktemp_portability    → test_check_mktemp_portability.sh
+  #   - check_session_finalization  → test_session_finalization_check.sh
+  #   - check_sync_manifest         → test_check_sync_manifest.sh (also
+  #     SKIPs on consumers via the manifest-absent guard)
+  "tests/test_eslint_policy_check.sh"
+  "tests/test_check_mktemp_portability.sh"
+  "tests/test_session_finalization_check.sh"
+  "tests/test_check_sync_manifest.sh"
+)
+
+is_allow_listed() {
+  local ref="$1" pat
+  for pat in "${ALLOW_LIST[@]}"; do
+    # shellcheck disable=SC2254  # intentional glob match against the pattern
+    case "$ref" in
+      $pat) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# Enumerate scan files: every propagated check_* + every exact-manifest
+# workflow.
+# ─────────────────────────────────────────────────────────────────────
+#
+# Bash 3.2 portable — no mapfile, no associative arrays. Build a
+# newline-delimited list in a variable.
+scan_files=""
+
+# (1) every scripts/ci/check_* that is_covered (i.e. actually propagated).
+if [ -d "$REPO_ROOT/scripts/ci" ]; then
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    rel="${f#"$REPO_ROOT"/}"
+    if is_covered "$rel"; then
+      scan_files="$scan_files$f
+"
+    fi
+  done <<EOF
+$(find "$REPO_ROOT/scripts/ci" -maxdepth 1 -type f -name 'check_*' | LC_ALL=C sort)
+EOF
+fi
+
+# (2) every .github/workflows/*.yml|*.yaml that is an EXACT manifest
+# entry (propagated workflows are canonical, not kit, so an exact-set
+# membership test is the right gate).
+while IFS= read -r p; do
+  [ -z "$p" ] && continue
+  case "$p" in
+    .github/workflows/*.yml|.github/workflows/*.yaml)
+      if [ -f "$REPO_ROOT/$p" ]; then
+        scan_files="$scan_files$REPO_ROOT/$p
+"
+      fi
+      ;;
+  esac
+done <<< "$exact_rows"
+
+FAILED=0
+SCANNED=0
+
+# ─────────────────────────────────────────────────────────────────────
+# For each scan file, extract refs and check coverage.
+# ─────────────────────────────────────────────────────────────────────
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  SCANNED=$((SCANNED + 1))
+  rel="${f#"$REPO_ROOT"/}"
+
+  # Extract candidate references: tests/test_<name>.sh and
+  # scripts/<path>.{sh,cjs,js}. sort -u dedupes within a file.
+  refs=$(grep -oE '(tests/test_[A-Za-z0-9_-]+\.sh|scripts/[A-Za-z0-9_./-]+\.(sh|cjs|js))' "$f" | sort -u || true)
+
+  while IFS= read -r ref; do
+    [ -z "$ref" ] && continue
+    # Self-reference — a file naming its own path is not a dependency.
+    [ "$ref" = "$rel" ] && continue
+    # Allow-listed orchestrator / mergepath-internal ref.
+    is_allow_listed "$ref" && continue
+    # A ref that does not resolve to a real file in mergepath cannot be a
+    # propagation dependency (fixture string / doc example / assertion
+    # literal). Skip — fail-closed: a real undeclared dependency IS a
+    # real file that must travel.
+    [ -e "$REPO_ROOT/$ref" ] || continue
+    # The load-bearing test: a real, propagated, on-disk dependency that
+    # the manifest does NOT carry.
+    if ! is_covered "$ref"; then
+      echo "FAIL: '$rel' references '$ref' but that path is NOT covered by the manifest"
+      echo "      (no exact entry, not inside any kit, not in any requires: list). '$rel' is"
+      echo "      propagated to consumers, so '$ref' must travel with it — otherwise the"
+      echo "      consumer receives '$rel' without '$ref' and any tool that hard-requires it"
+      echo "      fails closed at consumer lint time. This is the #519/#521 drift class."
+      echo "      Fix by adding '$ref' to the requires: of the manifest entry that propagates"
+      echo "      '$rel' (e.g. the scripts/ci/ kit entry, or the workflow's own entry), or by"
+      echo "      giving '$ref' its own manifest path entry."
+      FAILED=1
+    fi
+  done <<< "$refs"
+done <<< "$scan_files"
+
+if [ "$FAILED" -eq 1 ]; then
+  echo "check_propagation_closure: FAIL"
+  exit 1
+fi
+
+# Run the regression test suite if present — same guard as
+# check_sync_manifest: skip when this invocation was itself driven by a
+# fixture (MERGEPATH_MANIFEST_PATH set), since that is the test harness
+# calling back into us.
+TEST_SUITE="$REPO_ROOT/tests/test_check_propagation_closure.sh"
+if [ -z "${MERGEPATH_MANIFEST_PATH:-}" ] && [ -x "$TEST_SUITE" ]; then
+  echo "check_propagation_closure: running regression test suite"
+  if ! bash "$TEST_SUITE"; then
+    echo "check_propagation_closure: FAIL (regression test suite failed)"
+    exit 1
+  fi
+fi
+
+echo "check_propagation_closure: PASS ($SCANNED propagated file(s) scanned; all tests/+scripts/ references are covered, allow-listed, or non-propagated)"
+exit 0

--- a/scripts/ci/check_workflow_parsers
+++ b/scripts/ci/check_workflow_parsers
@@ -142,6 +142,28 @@ assert_eq "inline comment stripped from payments entry" "1" "$got"
 got=$(bash "$PARSE" "$FIXTURE" external_review_paths | grep 'payments' | head -1)
 assert_eq "payments entry is clean glob, no trailing comment" "src/payments/**" "$got"
 
+# #536: single-quoted list entries must have their quotes stripped, same
+# as double-quoted. Before the fix, `- '.github/**'` came out as the
+# literal `'.github/**'` (quotes intact), so downstream glob matching
+# silently missed it. Mixed single/double + an inline comment on a
+# single-quoted entry exercises the close-quote + comment strip.
+sq_fixture=$(mktemp "${TMPDIR:-/tmp}/policy-singlequote.XXXXXX")
+cat >"$sq_fixture" <<'YAML'
+external_review_paths:
+  - '.github/**'
+  - 'src/auth/**'  # single-quoted with trailing comment
+  - "src/payments/**"
+  - unquoted/**
+next_key: stop
+YAML
+got=$(bash "$PARSE" "$sq_fixture" external_review_paths)
+want='.github/**
+src/auth/**
+src/payments/**
+unquoted/**'
+assert_eq "#536: single-quoted entries strip quotes (mixed single/double/unquoted)" "$want" "$got"
+rm -f "$sq_fixture"
+
 echo
 echo "match_protected_paths.sh tests"
 
@@ -505,7 +527,7 @@ enable_auto_merge_block=$(awk '
   in_block && /- name:/ && $0 !~ /- name: Enable auto-merge/ {exit}
   in_block {print}
 ' "$agent_review_workflow")
-if printf '%s\n' "$enable_auto_merge_block" | grep -Fq 'GH_TOKEN: ${{ secrets.AUTHOR_MERGE_TOKEN }}'; then
+if grep -Fq 'GH_TOKEN: ${{ secrets.AUTHOR_MERGE_TOKEN }}' <<<"$enable_auto_merge_block"; then
   pass=$((pass + 1))
   echo "  PASS: Enable auto-merge step runs under AUTHOR_MERGE_TOKEN"
 else
@@ -513,7 +535,7 @@ else
   echo "  FAIL: Enable auto-merge step must set GH_TOKEN from AUTHOR_MERGE_TOKEN" >&2
 fi
 
-if printf '%s\n' "$enable_auto_merge_block" | grep -Fq 'REVIEWER_ASSIGNMENT_TOKEN'; then
+if grep -Fq 'REVIEWER_ASSIGNMENT_TOKEN' <<<"$enable_auto_merge_block"; then
   fail=$((fail + 1))
   echo "  FAIL: Enable auto-merge step still references REVIEWER_ASSIGNMENT_TOKEN" >&2
 else
@@ -521,7 +543,7 @@ else
   echo "  PASS: Enable auto-merge step does not use REVIEWER_ASSIGNMENT_TOKEN"
 fi
 
-if printf '%s\n' "$enable_auto_merge_block" | grep -Fq '|| true'; then
+if grep -Fq '|| true' <<<"$enable_auto_merge_block"; then
   fail=$((fail + 1))
   echo "  FAIL: Enable auto-merge step must not swallow merge failures with '|| true'" >&2
 else
@@ -546,10 +568,8 @@ auto_merge_job_block=$(awk '
 ' "$agent_review_workflow")
 
 # 1. The original approval-event trigger is preserved.
-if printf '%s\n' "$auto_merge_job_block" \
-  | grep -Fq "github.event_name == 'pull_request_review'" \
-  && printf '%s\n' "$auto_merge_job_block" \
-  | grep -Fq "github.event.review.state == 'approved'"; then
+if grep -Fq "github.event_name == 'pull_request_review'" <<<"$auto_merge_job_block" \
+  && grep -Fq "github.event.review.state == 'approved'" <<<"$auto_merge_job_block"; then
   pass=$((pass + 1))
   echo "  PASS: auto-merge retains the pull_request_review + approved trigger"
 else
@@ -558,10 +578,8 @@ else
 fi
 
 # 2. The synchronize/reopened re-arm trigger is present in the job if:.
-if printf '%s\n' "$auto_merge_job_block" \
-  | grep -Fq "github.event.action == 'synchronize'" \
-  && printf '%s\n' "$auto_merge_job_block" \
-  | grep -Fq "github.event.action == 'reopened'"; then
+if grep -Fq "github.event.action == 'synchronize'" <<<"$auto_merge_job_block" \
+  && grep -Fq "github.event.action == 'reopened'" <<<"$auto_merge_job_block"; then
   pass=$((pass + 1))
   echo "  PASS: auto-merge re-arms on pull_request synchronize/reopened (#495)"
 else
@@ -578,8 +596,8 @@ pr_trigger_types=$(awk '
   in_pr && /^  [a-z]/ {exit}
   in_pr && /^    types:/ {print; exit}
 ' "$agent_review_workflow")
-if printf '%s\n' "$pr_trigger_types" | grep -Fq "synchronize" \
-  && printf '%s\n' "$pr_trigger_types" | grep -Fq "reopened"; then
+if grep -Fq "synchronize" <<<"$pr_trigger_types" \
+  && grep -Fq "reopened" <<<"$pr_trigger_types"; then
   pass=$((pass + 1))
   echo "  PASS: on.pull_request.types subscribes synchronize + reopened so the re-arm if: is live (#495)"
 else
@@ -587,22 +605,24 @@ else
   echo "  FAIL: on.pull_request.types must include synchronize AND reopened, else the re-arm if: is dead code (#495)" >&2
 fi
 
-# 3. A dedicated approval gate runs only on the pull_request (push) path.
-if printf '%s\n' "$auto_merge_job_block" | grep -Fq 'id: require_approval' \
-  && printf '%s\n' "$auto_merge_job_block" \
-  | grep -Eq "if:[[:space:]]*github\.event_name == 'pull_request'$"; then
+# 3. A dedicated approval gate runs on the pull_request (re-arm) path and,
+#    since #544, the direct pull_request_review approval path too — so an
+#    unregistered non-author approval arms auto-merge on neither path.
+if grep -Fq 'id: require_approval' <<<"$auto_merge_job_block" \
+  && grep -Eq "github\.event_name == 'pull_request'( \|\||$)" <<<"$auto_merge_job_block" \
+  && grep -Fq "github.event_name == 'pull_request_review'" <<<"$auto_merge_job_block"; then
   pass=$((pass + 1))
-  echo "  PASS: re-arm path has a require_approval gate scoped to pull_request events"
+  echo "  PASS: require_approval gate covers the pull_request re-arm (#495) and the pull_request_review approval (#544)"
 else
   fail=$((fail + 1))
-  echo "  FAIL: re-arm path must add a require_approval step gated on github.event_name == 'pull_request' (#495)" >&2
+  echo "  FAIL: require_approval step must gate on github.event_name == 'pull_request' (#495) AND 'pull_request_review' (#544)" >&2
 fi
 
 # 4. The gate confirms an EXISTING non-author APPROVED review: it must
 #    exclude the PR author and require a latest-state APPROVED. Without
 #    this, a push with no approval would arm.
-if printf '%s\n' "$auto_merge_job_block" | grep -Fq '.user.login != $author' \
-  && printf '%s\n' "$auto_merge_job_block" | grep -Fq 'map(select(.state == "APPROVED"))'; then
+if grep -Fq '.user.login != $author' <<<"$auto_merge_job_block" \
+  && grep -Fq 'map(select(.state == "APPROVED"))' <<<"$auto_merge_job_block"; then
   pass=$((pass + 1))
   echo "  PASS: re-arm gate requires a non-author latest-state APPROVED review"
 else
@@ -612,8 +632,8 @@ fi
 
 # 5. The gate collapses to each reviewer's LATEST opinionated state so a
 #    withdrawn approval (later CHANGES_REQUESTED/DISMISSED) does not re-arm.
-if printf '%s\n' "$auto_merge_job_block" | grep -Fq 'group_by(.user.login)' \
-  && printf '%s\n' "$auto_merge_job_block" | grep -Fq 'max_by(.submitted_at)'; then
+if grep -Fq 'group_by(.user.login)' <<<"$auto_merge_job_block" \
+  && grep -Fq 'max_by(.submitted_at)' <<<"$auto_merge_job_block"; then
   pass=$((pass + 1))
   echo "  PASS: re-arm gate collapses to each reviewer's latest review (supersedes a withdrawn approval)"
 else
@@ -623,9 +643,8 @@ fi
 
 # 6. Fail-closed: when the approval cannot be confirmed the gate emits
 #    proceed=false, and the merge path is skipped via proceed != 'false'.
-if printf '%s\n' "$auto_merge_job_block" | grep -Fq 'proceed=false' \
-  && printf '%s\n' "$auto_merge_job_block" \
-  | grep -Fq "steps.require_approval.outputs.proceed != 'false'"; then
+if grep -Fq 'proceed=false' <<<"$auto_merge_job_block" \
+  && grep -Fq "steps.require_approval.outputs.proceed != 'false'" <<<"$auto_merge_job_block"; then
   pass=$((pass + 1))
   echo "  PASS: re-arm fails closed (proceed=false) and the merge path honors it"
 else
@@ -636,8 +655,8 @@ fi
 # 7. Aggregation happens AFTER flattening all pages: a slurped `add // []`
 #    over the raw --paginate stream, not a per-page `gh api --jq` collapse
 #    that would miss a CHANGES_REQUESTED on a later page.
-if printf '%s\n' "$auto_merge_job_block" | grep -Fq 'jq -r -s' \
-  && printf '%s\n' "$auto_merge_job_block" | grep -Fq '(add // [])'; then
+if grep -Fq 'jq -r -s' <<<"$auto_merge_job_block" \
+  && grep -Fq '(add // [])' <<<"$auto_merge_job_block"; then
   pass=$((pass + 1))
   echo "  PASS: re-arm gate flattens paginated reviews before aggregating"
 else
@@ -665,8 +684,8 @@ triage_job_block=$(awk '
   in_block {print}
 ' "$agent_review_workflow")
 
-if printf '%s\n' "$load_config_job_block" | grep -Fq "github.event.action == 'synchronize'" \
-  && printf '%s\n' "$load_config_job_block" | grep -Fq "github.event.action == 'reopened'"; then
+if grep -Fq "github.event.action == 'synchronize'" <<<"$load_config_job_block" \
+  && grep -Fq "github.event.action == 'reopened'" <<<"$load_config_job_block"; then
   pass=$((pass + 1))
   echo "  PASS: load-config re-parses policy on synchronize/reopened (re-arm sees fresh threshold/paths) (#495)"
 else
@@ -674,8 +693,8 @@ else
   echo "  FAIL: load-config must run on synchronize/reopened so the re-arm path sees a freshly parsed policy, not a stale snapshot (#495)" >&2
 fi
 
-if printf '%s\n' "$triage_job_block" | grep -Fq "github.event.action == 'synchronize'" \
-  && printf '%s\n' "$triage_job_block" | grep -Fq "github.event.action == 'reopened'"; then
+if grep -Fq "github.event.action == 'synchronize'" <<<"$triage_job_block" \
+  && grep -Fq "github.event.action == 'reopened'" <<<"$triage_job_block"; then
   pass=$((pass + 1))
   echo "  PASS: triage refreshes threshold/protected-path labels on synchronize/reopened before the re-arm (#495)"
 else
@@ -688,8 +707,7 @@ fi
 #    blocking-label re-verify reads labels. Without the ordering edge,
 #    triage and auto-merge run in parallel on synchronize/reopened and the
 #    re-verify can read labels before needs-external-review lands (#495).
-if printf '%s\n' "$auto_merge_job_block" \
-  | grep -Eq '^[[:space:]]*needs:.*\btriage\b'; then
+if grep -Eq '^[[:space:]]*needs:.*\btriage\b' <<<"$auto_merge_job_block"; then
   pass=$((pass + 1))
   echo "  PASS: auto-merge needs triage, so synchronize/reopened label refresh precedes the merge re-verify (#495)"
 else
@@ -702,8 +720,8 @@ fi
 #     because event-mismatched sibling jobs are expected to skip, but a
 #     synchronize/reopened re-arm cannot proceed unless triage succeeded and
 #     had the chance to refresh needs-external-review.
-if printf '%s\n' "$auto_merge_job_block" | grep -Fq "github.event_name != 'pull_request'" \
-  && printf '%s\n' "$auto_merge_job_block" | grep -Fq "needs.triage.result == 'success'"; then
+if grep -Fq "github.event_name != 'pull_request'" <<<"$auto_merge_job_block" \
+  && grep -Fq "needs.triage.result == 'success'" <<<"$auto_merge_job_block"; then
   pass=$((pass + 1))
   echo "  PASS: pull_request re-arm fails closed unless triage succeeds (#495)"
 else

--- a/scripts/coderabbit-automerge-rate-limit-gate.sh
+++ b/scripts/coderabbit-automerge-rate-limit-gate.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# scripts/coderabbit-automerge-rate-limit-gate.sh
+#
+# #489: decide whether a CodeRabbit rate-limit stall (coderabbit-wait.sh
+# exit 5 / status=rate_limit_stalled) should BLOCK the auto-merge workflow
+# (.github/workflows/agent-review.yml "Wait for CodeRabbit" step) or is a
+# NON-BLOCKING note because the Codex failover engaged.
+#
+# Two conditions must BOTH hold to PROCEED (downgrade exit 5):
+#
+#   1. The Codex failover engaged — coderabbit-wait.sh's JSON reports
+#      `codex_failover_requested: true` (it requested `@codex review`).
+#   2. An external-review gate will ACTUALLY gate the merge on Codex —
+#      i.e. the PR is ABOVE the external-review threshold, where
+#      merge-clearance-gate.sh's external_review_gate blocks until Codex /
+#      external clearance lands. (Passed in as the second arg.)
+#
+# Why condition 2 (Codex P2 on #512 round 3): for UNDER-threshold PRs the
+# merge-clearance gate passes *vacuously* (no Codex requirement), and the
+# failover only *requests* Codex via `--trigger-only` (it does not wait for a
+# review). So downgrading exit 5 on an under-threshold PR would let a
+# rate-limited PR auto-merge with NEITHER CodeRabbit nor Codex having reviewed
+# it. Under-threshold rate-limit stalls therefore keep BLOCKING, exactly as
+# before this feature. Above-threshold PRs are safe to proceed because the
+# external-review gate still blocks the merge until Codex/external clears.
+#
+# Usage:
+#   coderabbit-automerge-rate-limit-gate.sh '<coderabbit-wait-json>' <external-review-required>
+#
+#     external-review-required: "true" if the PR is above the external-review
+#       threshold (the workflow derives this from the `needs-external-review`
+#       label). Anything other than "true" is treated as under-threshold.
+#
+# Exit 0 = PROCEED; exit 1 = BLOCK. Fail-closed: a missing flag, missing
+# threshold arg, or unparseable JSON BLOCKS, so a malformed input never
+# silently lets a rate-limited PR through.
+
+set -euo pipefail
+
+WAIT_JSON="${1:-}"
+EXTERNAL_REVIEW_REQUIRED="${2:-false}"
+
+if [ -z "$WAIT_JSON" ]; then
+  echo "rate-limit-gate: no coderabbit-wait JSON provided — blocking (fail-closed)" >&2
+  exit 1
+fi
+
+failover=$(printf '%s' "$WAIT_JSON" | jq -r '.codex_failover_requested // false' 2>/dev/null || echo "false")
+
+if [ "$failover" != "true" ]; then
+  echo "rate-limit-gate: codex_failover_requested=${failover} — no failover engaged; block" >&2
+  exit 1
+fi
+
+if [ "$EXTERNAL_REVIEW_REQUIRED" != "true" ]; then
+  echo "rate-limit-gate: failover engaged but PR is under-threshold (external_review_required=${EXTERNAL_REVIEW_REQUIRED}) — no downstream Codex gate; block (#512 r3)" >&2
+  exit 1
+fi
+
+echo "rate-limit-gate: failover engaged + external review required — merge-clearance gates Codex; proceed" >&2
+exit 0

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -227,7 +227,7 @@ fi
 
 if [ -z "${GH_TOKEN:-}" ]; then
   echo "ERROR: GH_TOKEN is required. Either:" >&2
-  echo "  - Run: eval \"\$(scripts/op-preflight.sh --agent <agent> --mode review)\"" >&2
+  echo "  - Run: eval \"\$(scripts/op-preflight.sh --agent <agent> --mode all)\"" >&2
   echo "    so this helper auto-sources OP_PREFLIGHT_REVIEWER_PAT, OR" >&2
   echo "  - Set GH_TOKEN to the expected reviewer PAT." >&2
   exit 3
@@ -253,7 +253,10 @@ fi
 
 gh_reviewer() (
   unset GITHUB_TOKEN
-  gh "$@"
+  # Pin reviewer writes to the reviewer PAT rather than inheriting ambient
+  # creds (#533): prefer the preflight-cached reviewer PAT, falling back to
+  # GH_TOKEN. Mirrors scripts/resolve-pr-threads.sh's PAT_GH_TOKEN pattern.
+  GH_TOKEN="${OP_PREFLIGHT_REVIEWER_PAT:-${GH_TOKEN:-}}" gh "$@"
 )
 
 # --- config readers ---------------------------------------------------------
@@ -770,10 +773,17 @@ scan_latest_comment_best_effort() {
 count_potential_issues() {
   local reviews pulls_comments latest_review_id
   reviews=$(fetch_api_array "repos/$REPO/pulls/$PR_NUMBER/reviews" "reviews")
-  latest_review_id=$(echo "$reviews" | jq --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" '
+  # Pin the latest-review selection to the current HEAD commit
+  # (`commit_id == HEAD_SHA`), not just freshness (`submitted_at >=
+  # HEAD_ANCHOR`). A review submitted after the anchor but referencing an
+  # intermediate commit (e.g. a rapid push sequence where CodeRabbit
+  # reviewed an earlier SHA) must not be chosen as the HEAD review. Mirror
+  # the HEAD-pinning in scripts/codex-review-check.sh (commit_id == $sha).
+  latest_review_id=$(echo "$reviews" | jq --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" --arg head_sha "$HEAD_SHA" '
     [ .[]
       | select(.user.login == $bot)
       | select(.submitted_at >= $after)
+      | select(.commit_id == $head_sha)
     ]
     | sort_by(.submitted_at) | last
     | if . == null then null else .id end
@@ -802,6 +812,32 @@ count_potential_issues() {
       | select(.id as $id | ($addressed_root_ids | index($id)) == null)
     ] | length
   '
+}
+
+# Returns 0 (true) if the latest PR-level CodeRabbit SUMMARY comment body
+# carries a `Potential issue` / ⚠️ marker, else 1.
+#
+# count_potential_issues() scans only INLINE `pulls/{pr}/comments`. When
+# CodeRabbit surfaces a finding solely in its PR-level summary body
+# (issues/{pr}/comments) while the inline count is zero, the findings gate
+# would otherwise wrongly clear. This OR-side check closes that gap (#535).
+# Mirrors latest_comment_from_issue_comments: filter to the bot login,
+# newest comment on/after the HEAD anchor (max of created_at/updated_at,
+# since CodeRabbit edits the summary in place).
+summary_body_has_potential_issue_marker() {
+  local issue_comments latest_body
+  issue_comments=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/comments" "issue comments")
+  latest_body=$(echo "$issue_comments" | jq -r --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" '
+    [ .[]
+      | select(.user.login == $bot)
+      | . + {fresh_at: ([.created_at, (.updated_at // .created_at)] | max)}
+      | select(.fresh_at >= $after)
+    ]
+    | sort_by(.fresh_at)
+    | last
+    | (.body // "")
+  ')
+  printf '%s' "$latest_body" | grep -qiE 'Potential issue|⚠️'
 }
 
 # SHA-scoped variant of count_potential_issues, used by the StatusContext
@@ -1043,8 +1079,14 @@ emit_terminal_review_after_probe_if_present() {
     review)
       potential_issues=$(count_potential_issues)
       review_json=$(echo "$latest" | jq '{id, created_at, endpoint, body_excerpt: (.body[0:200])}')
+      # #535: also honor a PR-level summary-body marker (the inline count
+      # scans only pulls/{pr}/comments) so the probe-wait clearance path
+      # cannot false-clear over a summary-only finding either.
       if [ "$potential_issues" -gt 0 ]; then
         log "CodeRabbit review landed during status-probe wait with $potential_issues Potential issue/⚠️ marker(s) — emitting findings (exit 2)"
+        emit_json_and_exit "findings" 2 "$review_json" "$potential_issues"
+      elif summary_body_has_potential_issue_marker; then
+        log "CodeRabbit review landed during status-probe wait with 0 inline markers but a Potential issue/⚠️ marker in the PR-level summary body — emitting findings (exit 2)"
         emit_json_and_exit "findings" 2 "$review_json" "$potential_issues"
       fi
       log "CodeRabbit review landed during status-probe wait with no high-severity markers — emitting cleared (exit 0)"
@@ -1588,8 +1630,14 @@ while :; do
     review)
       POTENTIAL_ISSUES=$(count_potential_issues)
       REVIEW_JSON=$(echo "$LATEST" | jq '{id, created_at, endpoint, body_excerpt: (.body[0:200])}')
+      # #535: the inline count scans only pulls/{pr}/comments. Also honor a
+      # PR-level summary-body marker so a finding surfaced solely in the
+      # summary body still yields findings instead of false-clearing.
       if [ "$POTENTIAL_ISSUES" -gt 0 ]; then
         log "CodeRabbit review posted with $POTENTIAL_ISSUES Potential issue/⚠️ markers"
+        emit_json_and_exit "findings" 2 "$REVIEW_JSON" "$POTENTIAL_ISSUES"
+      elif summary_body_has_potential_issue_marker; then
+        log "CodeRabbit review posted with 0 inline markers but a Potential issue/⚠️ marker in the PR-level summary body — findings"
         emit_json_and_exit "findings" 2 "$REVIEW_JSON" "$POTENTIAL_ISSUES"
       else
         log "CodeRabbit review posted with no high-severity markers — cleared"

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -108,8 +108,9 @@
 # Architecture notes:
 #
 #   The hook does ALL its parsing on a tokenized form of the
-#   command produced by `xargs -n 1`, which honors POSIX shell
-#   quoting. Earlier iterations used substring `grep` on the raw
+#   command produced by a python3 shlex.split tokenizer (see the
+#   tokenizer section below; an earlier version used `xargs -n 1`),
+#   which honors POSIX shell quoting. Earlier iterations used substring `grep` on the raw
 #   command string and were buggy in two correlated ways:
 #
 #     1. nathanpayne-codex caught (PR #66 round 2) that
@@ -140,6 +141,15 @@
 #     comment). This is deliberately conservative: split multi-step
 #     GitHub work into separate Bash tool calls so each write gets
 #     the same single-command guard path (#348).
+#
+#   - eval / sh -c / bash -c / dash -c payloads are re-tokenized so a
+#     guarded gh write hidden inside a quoted shell-string payload is
+#     surfaced to the token walk instead of passing as one opaque
+#     token. The python tokenizer expands these recursively before the
+#     walk runs (over-expansion is safe — the walk re-establishes
+#     command position on the expanded stream), and malformed inner
+#     quoting fails closed like any other parse error. Closes the
+#     eval / bash -c / sh -c admin-merge bypass (#533 item 1).
 #
 #   - The CODEX_CLEARED check is a hook-layer defense-in-depth.
 #     The authoritative merge gate is scripts/codex-review-check.sh;
@@ -227,7 +237,32 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 # token walk below strips quotes itself and the */gh case catches it — but
 # only if we do NOT early-exit here. Stripping quotes for this fast-path
 # probe is safe; it only governs whether the authoritative tokenizer runs.
-if ! echo "$COMMAND" | tr -d "\"'" | grep -qE '(^|[[:space:]])([^[:space:]]*/)?gh([[:space:]]|$)'; then
+#
+# #540 Phase-4b: the boundary classes are [^A-Za-z0-9_] on BOTH sides, not
+# just whitespace, so a `gh` reached through a command substitution or a
+# subshell — `$(gh ...)`, `(gh ...)`, `;gh`, backtick gh — is not skipped
+# here (after quote-stripping it is preceded by `(` / `$` / `;` / a
+# backtick, never a space, so the old whitespace-only boundary missed it
+# and the hook exited before tokenizing). Erring toward NOT early-exiting
+# is the fail-closed direction: a false positive costs one tokenizer run;
+# a false negative is a bypass.
+# #551 (Codex): env -S / --split-string can synthesize `gh` dynamically (e.g.
+# from an octal printf in a $(...) substitution), so the raw command may carry
+# NO literal `gh` yet still run `gh pr merge`. A no-`gh` early-exit would then
+# skip the env -S fail-closed branch in the tokenizer below. Force tokenization
+# whenever the command carries `gh` OR an env -S / --split-string flag (the
+# tokenizer then blocks the env -S, fail-closed). Over-matching only costs one
+# tokenizer run; a false negative is a bypass.
+NEEDS_TOKENIZE=0
+if echo "$COMMAND" | tr -d "\"'" | grep -qE '(^|[^A-Za-z0-9_])([^[:space:]]*/)?gh([^A-Za-z0-9_]|$)'; then
+  NEEDS_TOKENIZE=1
+elif echo "$COMMAND" | tr -d "\"'" | grep -qE '(^|[^A-Za-z0-9_])env([[:space:]]|$)' \
+     && echo "$COMMAND" | tr -d "\"'" | grep -qE '(-[A-Za-z]*S|--split-string)'; then
+  # Quote-stripped (Codex #551): a quoted `'env'` runs env but would otherwise
+  # leave a quote, not whitespace, after `env` and dodge this probe.
+  NEEDS_TOKENIZE=1
+fi
+if [ "$NEEDS_TOKENIZE" -eq 0 ]; then
   exit 0
 fi
 
@@ -282,46 +317,394 @@ trap 'rm -f "$TMP_TOKENS" "$TMP_TOKENS_ERR"' EXIT
 # on swipewatch propagation PR #33 round 6 — privilege escalation
 # via newline-separated prefix command was the same shape as the
 # round-5 echo-prefix env spoof, just on a different separator.
+#
+# --- #546: single source of truth for prefix value-consuming options ---
+# Both the python pre-pass (which surfaces a bash -c payload hidden behind a
+# prefix) and the bash compound-scan + main walk (which skip prefix options
+# to find a command-position gh) MUST agree on which options consume the
+# NEXT token. If the two drift, a "<prefix> <value-opt> VALUE bash -c
+# <gh write>" payload slips through whichever layer is missing the option
+# (#546 gap 2: the bash walk lacked the long forms the python table had).
+# Defined ONCE here and read by BOTH, so they cannot drift. Per-prefix
+# because the same letter differs by tool (nice -n takes a value; sudo -n
+# does not). Format: ";"-joined "<prefix>=<opt>,<opt>,..." entries. ONLY
+# value-CONSUMING options belong here: ionice -t/--ignore is a no-value flag
+# (CodeRabbit #551), and env -S/--split-string is NOT a value either — it runs
+# its argument as a SPLIT command with exotic dynamic semantics, so it FAILS
+# CLOSED in expand_wrappers (Codex #551) rather than being skipped here.
+PREFIX_VALUE_OPTS_SPEC="sudo=-u,--user,-g,--group,-p,--prompt,-h,--host,-t,--type,-r,--role,-C,--close-from,-D,--chdir,-R,--chroot,-U,--other-user,-T,--command-timeout;nice=-n,--adjustment;ionice=-c,--class,-n,--classdata,-p,--pid;env=-u,--unset,-C,--chdir;exec=-a;time=-f,--format,-o,--output"
+export PREFIX_VALUE_OPTS_SPEC
 if ! printf '%s' "$COMMAND" | python3 -c '
-import sys, shlex
+import sys, shlex, re, os
 
-def normalize_unquoted_newlines(cmd):
-    """Replace newlines OUTSIDE of single/double quotes with `; `.
-    Preserves newlines inside quoted strings as literal characters."""
-    out = []
+# chr(39)/chr(34) are single/double quote; chr() avoids embedding a
+# literal single quote inside the python3 -c surrounding heredoc.
+_SQ = chr(39)
+_DQ = chr(34)
+
+def _read_paren_span(cmd, start):
+    # `start` points just AFTER the opening "$(". Return (inner, index
+    # after the matching ")"). Tracks nested $( / ( and an INDEPENDENT
+    # quote context (a ) inside quotes does not close the span), matching
+    # bash command-substitution parsing. Raises on an unterminated span.
+    depth = 1
+    i = start
+    n = len(cmd)
     in_single = False
     in_double = False
-    i = 0
-    while i < len(cmd):
+    while i < n:
         c = cmd[i]
-        # Handle backslash-escaped char in double quotes / unquoted
-        if c == "\\" and not in_single and i + 1 < len(cmd):
+        if c == "\\" and not in_single and i + 1 < n:
+            i += 2
+            continue
+        if c == _SQ and not in_double:
+            in_single = not in_single
+            i += 1
+            continue
+        if c == _DQ and not in_single:
+            in_double = not in_double
+            i += 1
+            continue
+        if not in_single and not in_double:
+            if c == "$" and i + 1 < n and cmd[i + 1] == "(":
+                depth += 1
+                i += 2
+                continue
+            if c == "(":
+                depth += 1
+                i += 1
+                continue
+            if c == ")":
+                depth -= 1
+                if depth == 0:
+                    return cmd[start:i], i + 1
+                i += 1
+                continue
+        i += 1
+    raise ValueError("unterminated command substitution")
+
+def _read_backtick_span(cmd, start):
+    # `start` points just AFTER the opening backtick. Return (inner, index
+    # after the closing backtick). Backticks do not nest; backslash escapes
+    # the next char. Raises on an unterminated span.
+    i = start
+    n = len(cmd)
+    bt = chr(96)
+    while i < n:
+        c = cmd[i]
+        if c == "\\" and i + 1 < n:
+            i += 2
+            continue
+        if c == bt:
+            return cmd[start:i], i + 1
+        i += 1
+    raise ValueError("unterminated backtick substitution")
+
+def flatten_command(cmd, depth=0):
+    """Normalize a command for shlex tokenization so the downstream walk
+    sees every command-position gh write. Three jobs (#533, plus the #540
+    Phase-4b findings):
+      1. Replace UNQUOTED newlines AND shell separators (; | & && || |& ( ))
+         with space-padded standalone tokens. shlex never splits on these,
+         so without padding a `"foo";gh pr merge` or `$(...)`-glued `;`
+         leaves a top-level guarded write fused to a data token and unseen.
+      2. Extract $(...) and `...` command-substitution spans (with correct
+         nested + independent-quote tracking) and append each as its own
+         `; <span>` command segment, so a gh write that EXECUTES inside a
+         substitution is surfaced. The outer keeps a placeholder token.
+      3. Preserve quoted separators/newlines verbatim.
+    Unbalanced quotes / unterminated substitutions raise ValueError -> the
+    hook fails closed exactly like any other parse error."""
+    if depth > 25:
+        raise ValueError("command-substitution nesting too deep")
+    out = []
+    spans = []
+    i = 0
+    n = len(cmd)
+    in_single = False
+    in_double = False
+    while i < n:
+        c = cmd[i]
+        if c == "\\" and not in_single and i + 1 < n:
             out.append(c)
             out.append(cmd[i + 1])
             i += 2
             continue
-        # chr(39) is a single quote; using chr() avoids embedding a
-        # literal single quote inside the bash heredoc (which would
-        # break the python3 -c '...' surrounding quote).
-        if c == chr(39) and not in_double:
+        if c == _SQ and not in_double:
             in_single = not in_single
-        elif c == chr(34) and not in_single:
-            in_double = not in_double
-        elif c == "\n" and not in_single and not in_double:
-            # Pad with spaces on BOTH sides so shlex parses the
-            # `;` as its own token rather than gluing it to the
-            # preceding word (e.g. "ok;" instead of "ok" + ";").
-            out.append(" ; ")
+            out.append(c)
             i += 1
             continue
+        if c == _DQ and not in_single:
+            in_double = not in_double
+            out.append(c)
+            i += 1
+            continue
+        # Command substitution is performed unquoted AND inside double
+        # quotes, never inside single quotes.
+        if not in_single and c == "$" and i + 1 < n and cmd[i + 1] == "(":
+            span, j = _read_paren_span(cmd, i + 2)
+            spans.append(span)
+            out.append(" __MERGEPATH_CMDSUB__ ")
+            i = j
+            continue
+        if not in_single and c == chr(96):
+            span, j = _read_backtick_span(cmd, i + 1)
+            spans.append(span)
+            out.append(" __MERGEPATH_CMDSUB__ ")
+            i = j
+            continue
+        if not in_single and not in_double:
+            two = cmd[i:i + 2]
+            if two in ("&&", "||", "|&"):
+                out.append(" " + two + " ")
+                i += 2
+                continue
+            if c in (";", "|", "&", "(", ")"):
+                out.append(" " + c + " ")
+                i += 1
+                continue
+            if c == "\n":
+                out.append(" ; ")
+                i += 1
+                continue
         out.append(c)
         i += 1
-    return "".join(out)
+    if in_single or in_double:
+        raise ValueError("unbalanced quote")
+    result = "".join(out)
+    for span in spans:
+        result = result + " ; " + flatten_command(span, depth + 1)
+    return result
+
+# --- #533 item 1: surface inner commands hidden behind eval / sh -c ---
+# eval "<payload>" and sh|bash|dash -c "<payload>" run <payload> as a
+# fresh command line, but shlex keeps that payload as one opaque token,
+# so the downstream walk never sees the inner gh write and SAW_GH stays
+# 0 (the admin-merge bypass: eval/bash -c/sh -c forms passed rc=0).
+# Re-tokenize those payloads here, recursively, so the walk evaluates
+# the real inner gh write. Over-expansion is safe: the walk re-
+# establishes command position on the expanded stream, so a quoted-data
+# gh (echo "gh ...") is still not in command position. Malformed inner
+# quoting raises ValueError, failing closed exactly like a top-level
+# parse error.
+_SEPARATORS = {"&&", "||", ";", "|", "|&", "&", "(", ")"}
+_SHELL_BASENAMES = {"sh", "bash", "dash", "zsh", "ksh"}
+_PREFIX_CMDS = {"sudo", "time", "nohup", "env", "command", "exec", "nice", "ionice"}
+# The canonical gh wrappers run "<wrapper> -- <command>". Treat the wrapper
+# (and the -- separator) as prefix-like so a "<wrapper> -- bash -c <gh write>"
+# payload keeps command position and the inner gh write is surfaced and
+# re-checked, not hidden behind the wrapper as an opaque shell-c token
+# (#546 gap 1).
+_WRAPPER_CMDS = {"gh-as-author.sh", "gh-as-reviewer.sh"}
+# sh/bash options that consume the NEXT token as their value, so the -c
+# command flag (and the script positional) lie AFTER that value. Skipping
+# only the option (not its value) would mis-read the value as the script
+# and miss a trailing -c (#540: bash --rcfile FILE -c "<payload>").
+_SHELL_VALUE_OPTS = {"--rcfile", "--init-file", "-o", "+o", "-O", "+O"}
+_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+# Per-prefix options that consume the NEXT token as a value, so the value
+# is not mistaken for the wrapped command. Read from the shared
+# PREFIX_VALUE_OPTS_SPEC env var (#546) so THIS python table and the bash
+# prefix_flag_takes_value table cannot drift. Per-prefix because the same
+# letter differs by tool: nice -n N takes a value, but sudo -n is a
+# no-value flag. A prefix not listed is treated as flags-only. Fail closed
+# when the spec is absent: without it every prefix looks flags-only and a
+# "value-opt VALUE" pair would be mis-read as the wrapped command, hiding a
+# trailing bash -c gh-write.
+_PREFIX_VALUE_OPTS = {}
+_RAW_PREFIX_SPEC = os.environ.get("PREFIX_VALUE_OPTS_SPEC", "")
+if not _RAW_PREFIX_SPEC:
+    print("gh-pr-guard: PREFIX_VALUE_OPTS_SPEC unset", file=sys.stderr)
+    sys.exit(1)
+for _entry in _RAW_PREFIX_SPEC.split(";"):
+    if not _entry:
+        continue
+    _pfx, _eq, _opts = _entry.partition("=")
+    _PREFIX_VALUE_OPTS[_pfx] = frozenset(o for o in _opts.split(",") if o)
+_EMPTY_FROZENSET = frozenset()
+
+def expand_wrappers(tokens, depth=0):
+    if depth > 25:
+        raise ValueError("eval/shell -c nesting too deep")
+    out = []
+    i = 0
+    n = len(tokens)
+    at_cmd = True
+    while i < n:
+        tok = tokens[i]
+        if tok in _SEPARATORS:
+            out.append(tok)
+            at_cmd = True
+            i += 1
+            continue
+        if not at_cmd:
+            out.append(tok)
+            i += 1
+            continue
+        if _ASSIGN_RE.match(tok):
+            out.append(tok)
+            i += 1
+            # NAME=$(...) is split by flatten_command into "NAME=" + the
+            # __MERGEPATH_CMDSUB__ placeholder; re-attach the placeholder as the
+            # assignment value so it does not read as "NAME= <command>" and let
+            # a following prefix lose command position (Codex #551:
+            # G=$(printf gh) env -S "${G} ..." must still reach the env -S
+            # fail-closed branch). Only a trailing-"=" (empty-value) assignment
+            # immediately followed by the placeholder is the flatten artifact.
+            if tok.endswith("=") and i < n and tokens[i] == "__MERGEPATH_CMDSUB__":
+                out.append(tokens[i])
+                i += 1
+            continue
+        base = tok.rsplit("/", 1)[-1]
+        if base == "eval":
+            # eval joins its args and parses the result as a command.
+            j = i + 1
+            while j < n and tokens[j] not in _SEPARATORS:
+                j += 1
+            inner = " ".join(tokens[i + 1:j])
+            out.extend(expand_wrappers(shlex.split(flatten_command(inner)), depth + 1))
+            i = j
+            continue
+        if base in _SHELL_BASENAMES:
+            # sh|bash|dash -c "<payload>" runs <payload> as a command.
+            seg_end = i + 1
+            while seg_end < n and tokens[seg_end] not in _SEPARATORS:
+                seg_end += 1
+            inner = None
+            k = i + 1
+            while k < seg_end:
+                t = tokens[k]
+                # A value-taking option consumes the NEXT token; skip both so
+                # the value is not mistaken for the script positional and a
+                # trailing -c is still found (#540: bash --rcfile FILE -c CMD).
+                if t in _SHELL_VALUE_OPTS:
+                    k += 2
+                    continue
+                # A long option (--norc, --noprofile, --rcfile=FILE, ...) is
+                # NOT the -c command-string flag even when it contains a c.
+                # #540 finding 1: matching any "c in t" let --norc consume the
+                # real -c as its payload and discard the command string.
+                if t.startswith("--"):
+                    k += 1
+                    continue
+                # A single-dash cluster including c IS the -c command flag
+                # (-c, -lc, -xc, ...). The command is the text attached after
+                # the c (-cCMD) or, failing that, the next token (-c CMD).
+                if t.startswith("-") and "c" in t:
+                    cpos = t.index("c", 1)
+                    attached = t[cpos + 1:]
+                    if attached:
+                        inner = attached
+                    elif k + 1 < seg_end:
+                        inner = tokens[k + 1]
+                    break
+                if t.startswith("-"):
+                    k += 1
+                    continue
+                break
+            if inner is not None:
+                out.extend(expand_wrappers(shlex.split(flatten_command(inner)), depth + 1))
+            else:
+                out.extend(tokens[i:seg_end])
+            i = seg_end
+            continue
+        if base in _PREFIX_CMDS:
+            out.append(tok)
+            i += 1
+            # Consume the options that belong to this prefix before the
+            # wrapped command, keeping command position so a
+            # <prefix> [opts] bash -c "<payload>" form is still expanded.
+            # Value-taking options (sudo -u USER, nice -n N, ...) consume
+            # their value too; env NAME=VALUE assignments are skipped. The
+            # first shell / nested-prefix / eval / bare token is the wrapped
+            # command, left for the main loop at command position. #540 P1:
+            # a prefix option used to fall through and flip at_cmd off,
+            # hiding a trailing bash -c gh-write.
+            vopts = _PREFIX_VALUE_OPTS.get(base, _EMPTY_FROZENSET)
+            while i < n:
+                a = tokens[i]
+                if a in _SEPARATORS:
+                    break
+                a_base = a.rsplit("/", 1)[-1]
+                if a_base in _SHELL_BASENAMES or a_base in _PREFIX_CMDS or a_base == "eval":
+                    break
+                if _ASSIGN_RE.match(a):
+                    out.append(a)
+                    i += 1
+                    continue
+                # env -S STRING / --split-string STRING runs STRING as a SPLIT
+                # command, so its argument is a NESTED command, not a value to
+                # skip: re-tokenize + expand it so a "env -S bash -c <gh write>"
+                # payload is surfaced (CodeRabbit #551, a pre-existing exotic
+                # gap). Handles the next-token, --split-string=STR, and -SSTR
+                # (attached) forms.
+                if base == "env" and (a == "--split-string"
+                                      or a.startswith("--split-string=")
+                                      or (a.startswith("-") and not a.startswith("--")
+                                          and next((c for c in a[1:] if c in "uCS"), "") == "S")):
+                    # A short cluster IS env -S when the first value-taking-or-S
+                    # option in it is S (CodeRabbit #551: -vS etc., not only a
+                    # leading -S). -u/-C consume the rest of the cluster as their
+                    # value, so an S inside e.g. -uNAME_WITH_S is NOT the split
+                    # flag (keeps the #451 env -uNAME tests passing).
+                    # env -S / --split-string FAILS CLOSED (Codex #551 r1-r4).
+                    # GNU env -S has rich, exotic semantics: whitespace
+                    # splitting, $VAR/${VAR} expansion, $(...)/backtick
+                    # substitution (bash expands those first), AND appending the
+                    # remaining argv after the split string (env -S "bash -c"
+                    # "<payload>"). Each partial model we tried surfaced a new
+                    # bypass, and env -S on a command line is an exotic shebang
+                    # feature no gh workflow needs, so BLOCK any env -S rather
+                    # than risk a hidden write. Reformulate without -S if needed.
+                    raise ValueError("env -S / --split-string is not statically resolvable; reformulate without -S")
+                if a in vopts:
+                    out.append(a)
+                    i += 1
+                    if i < n and tokens[i] not in _SEPARATORS:
+                        out.append(tokens[i])
+                        i += 1
+                    continue
+                if a.startswith("-"):
+                    out.append(a)
+                    i += 1
+                    continue
+                break
+            continue
+        if base in _WRAPPER_CMDS:
+            # Wrapper invocation (gh-as-author.sh / gh-as-reviewer.sh): keep
+            # command position through the -- arg separator and any wrapper
+            # flags so a trailing bash -c / sh -c / prefix / eval payload is
+            # expanded by the main loop and the inner gh write is re-checked,
+            # instead of running under the verified token without the
+            # merge-state / CODEX_CLEARED gate (#546 gap 1). A normal
+            # "<wrapper> -- gh pr merge" is unaffected (gh is not a shell to
+            # expand), so this only matters when a shell/prefix follows.
+            out.append(tok)
+            i += 1
+            while i < n:
+                a = tokens[i]
+                if a in _SEPARATORS:
+                    break
+                a_base = a.rsplit("/", 1)[-1]
+                if (a_base in _SHELL_BASENAMES or a_base in _PREFIX_CMDS
+                        or a_base in _WRAPPER_CMDS or a_base == "eval"):
+                    break
+                if a == "--" or a.startswith("-"):
+                    out.append(a)
+                    i += 1
+                    continue
+                break
+            continue
+        out.append(tok)
+        at_cmd = False
+        i += 1
+    return out
 
 try:
     cmd = sys.stdin.read()
-    cmd = normalize_unquoted_newlines(cmd)
-    for tok in shlex.split(cmd):
+    cmd = flatten_command(cmd)
+    for tok in expand_wrappers(shlex.split(cmd)):
         sys.stdout.buffer.write(tok.encode("utf-8", errors="replace") + b"\x00")
 except ValueError as e:
     print(f"shlex error: {e}", file=sys.stderr)
@@ -360,23 +743,28 @@ is_guard_separator() {
 }
 
 prefix_flag_takes_value() {
-  case "$1:$2" in
-    sudo:-u|sudo:-g|sudo:-U|sudo:-h|sudo:-p|sudo:-r|sudo:-s|sudo:-t|sudo:-c|sudo:-D)
-      return 0
-      ;;
-    time:-f|time:-o)
-      return 0
-      ;;
-    nice:-n)
-      return 0
-      ;;
-    ionice:-c|ionice:-n|ionice:-p)
-      return 0
-      ;;
-    env:-u|env:-S|env:--unset)
-      return 0
-      ;;
+  # Single source of truth: PREFIX_VALUE_OPTS_SPEC (#546). The python
+  # pre-pass and this bash walk read the SAME spec, so the two prefix-option
+  # tables cannot drift. The old hand-maintained case list HAD drifted: it
+  # lacked the long forms the python table carried, so "sudo --user X bash
+  # -c <gh write>" surfaced the inner gh in python but the bash compound
+  # scan mis-read X as the command and never saw it. Spec: ";"-joined
+  # "<prefix>=<opt>,<opt>,..." entries.
+  local pfx="$1" opt="$2" spec opts o
+  spec=";$PREFIX_VALUE_OPTS_SPEC"
+  case "$spec" in
+    *";$pfx="*) ;;
+    *) return 1 ;;
   esac
+  opts="${spec##*;$pfx=}"   # text after the (unique) ";<pfx>="
+  opts="${opts%%;*}"        # up to the next prefix entry
+  # Literal equality (NOT a case glob) so an attacker-supplied option token
+  # such as "-*" cannot glob-match a real value-option and mis-skip the
+  # following gh write.
+  local IFS=,
+  for o in $opts; do
+    [ "$o" = "$opt" ] && return 0
+  done
   return 1
 }
 
@@ -1470,11 +1858,42 @@ if [ "$PR_SUBCOMMAND" = "review" ]; then
       PR_AUTHOR=$(printf '%s\n' "$REVIEW_PR_JSON" | grep -oE '"author":[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*"author":[[:space:]]*"([^"]*)".*/\1/' || true)
       LANE_BRANCH_PREFIX="${GH_PR_GUARD_PROPAGATION_BRANCH_PREFIX:-mergepath-sync/}"
       LANE_AUTHOR="${GH_PR_GUARD_EXPECTED_AUTHOR:-nathanjohnpayne}"
-      if [ -n "$PR_HEAD_REF" ] && [ -n "$PR_AUTHOR" ] \
+
+      # #533 item 2: honor propagation_prs.enabled before granting the
+      # lane bypass. A repo that explicitly opts out
+      # (propagation_prs.enabled: false) must NOT get the local
+      # self-approve bypass — mirror the CI Merge Clearance Gate, which
+      # already reads this key. Per the DEFAULT-ON convention (#434) an
+      # absent block or absent `enabled` key counts as enabled; otherwise
+      # ONLY a literal `true` keeps the lane on — any other present value
+      # (`false`, `TRUE`, `yes`, `1`, a typo) fails closed and disables
+      # the bypass (#540), matching the propagation-lane audit's
+      # exact-match rule so a misconfigured policy never silently grants
+      # self-approve. Parsed with the same
+      # grep/awk posture the rest of this hook uses (no yq dependency in
+      # the pre-write hook). The block scoping keeps a sibling block's
+      # `enabled:` (coderabbit/codex/...) from being read by mistake.
+      LANE_ENABLED=1
+      LANE_POLICY_PATH="$(guard_policy_file || true)"
+      if [ -f "$LANE_POLICY_PATH" ]; then
+        LANE_PROP_ENABLED=$(awk '
+          # Accept a trailing comment / text after the key (propagation_prs: # opt-out),
+          # matching the workflow parser; an exact-EOL match failed open (#540 P2).
+          /^propagation_prs:([[:space:]]|$)/ { inblock=1; next }
+          inblock && /^[^[:space:]#]/ { inblock=0 }
+          inblock && /^[[:space:]]+enabled:/ { print $2; exit }
+        ' "$LANE_POLICY_PATH" 2>/dev/null | sed -E "s/^[\"']//; s/[\"']\$//" || true)
+        if [ -n "$LANE_PROP_ENABLED" ] && [ "$LANE_PROP_ENABLED" != "true" ]; then
+          LANE_ENABLED=0
+        fi
+      fi
+
+      if [ "$LANE_ENABLED" -eq 1 ] \
+         && [ -n "$PR_HEAD_REF" ] && [ -n "$PR_AUTHOR" ] \
          && [ "$PR_AUTHOR" = "$LANE_AUTHOR" ] \
          && [ "${PR_HEAD_REF#"$LANE_BRANCH_PREFIX"}" != "$PR_HEAD_REF" ]; then
-        # Lane criteria met — skip the self-approve guard entirely.
-        # Allow the gh pr review --approve to proceed.
+        # Lane criteria met (and lane enabled) — skip the self-approve
+        # guard entirely. Allow the gh pr review --approve to proceed.
         exit 0
       fi
 
@@ -1685,10 +2104,10 @@ fi
 # protection: even if branch protection is misconfigured or
 # disabled for an emergency hotfix, the hook will still refuse
 # to dispatch the merge.
-GH_JQ='.mergeStateStatus, .labels[].name'
-GH_ARGS=(pr view --json labels,mergeStateStatus --jq "$GH_JQ")
+GH_JQ='.mergeStateStatus, .mergeable, ([.statusCheckRollup[] | {n:(.name//.context//"?"), c:(.conclusion//.state//"PENDING"), t:(.completedAt//.startedAt//"")}] | group_by(.n) | map(max_by(.t).c) | map(select(. != "SUCCESS" and . != "SKIPPED" and . != "NEUTRAL")) | length), .labels[].name'
+GH_ARGS=(pr view --json labels,mergeStateStatus,mergeable,statusCheckRollup --jq "$GH_JQ")
 if [ -n "$PR_SELECTOR" ]; then
-  GH_ARGS=(pr view "$PR_SELECTOR" --json labels,mergeStateStatus --jq "$GH_JQ")
+  GH_ARGS=(pr view "$PR_SELECTOR" --json labels,mergeStateStatus,mergeable,statusCheckRollup --jq "$GH_JQ")
 fi
 if [ -n "$REPO_ARG" ]; then
   GH_ARGS+=(--repo "$REPO_ARG")
@@ -1723,13 +2142,19 @@ if ! GH_OUTPUT=$(gh "${GH_ARGS[@]}" 2>"$GH_STDERR"); then
   exit 2
 fi
 
-# Line 1 is mergeStateStatus; lines 2..N are label names (one per
-# line, possibly zero). Empty/missing MERGE_STATE (e.g. transient
-# API state) falls into the `*` case below and fails closed.
-# LABELS keeps the newline-delimited remainder for the exact-match
-# gate further down — never re-join it into a delimited string.
+# Line 1 is mergeStateStatus; line 2 is mergeable (MERGEABLE /
+# CONFLICTING / UNKNOWN — conflict-only, NOT a check-pass signal);
+# line 3 is the count of check names whose LATEST run is non-green
+# (a stale failure superseded by a later passing run does NOT count);
+# lines 4..N are label names (one per line, possibly zero).
+# Empty/missing MERGE_STATE (e.g. transient API state) falls into the
+# `*` case below and fails closed. LABELS keeps the newline-delimited
+# remainder for the exact-match gate further down — never re-join it
+# into a delimited string.
 MERGE_STATE=$(printf '%s\n' "$GH_OUTPUT" | sed -n '1p')
-LABELS=$(printf '%s\n' "$GH_OUTPUT" | sed -n '2,$p')
+MERGEABLE_STATE=$(printf '%s\n' "$GH_OUTPUT" | sed -n '2p')
+ROLLUP_NONGREEN=$(printf '%s\n' "$GH_OUTPUT" | sed -n '3p')
+LABELS=$(printf '%s\n' "$GH_OUTPUT" | sed -n '4,$p')
 
 # `human-hold` is a human-controlled hard freeze. Check it before
 # mergeStateStatus, --admin, or needs-external-review handling so no
@@ -1751,7 +2176,13 @@ fi
 #   BLOCKED     — required check failing OR active CHANGES_REQUESTED
 #                 review
 #   DIRTY       — merge conflict
-#   UNSTABLE    — non-required check failed
+#   UNSTABLE    — a non-passing commit status. Allowed ONLY when the
+#                 check rollup confirms every check name's LATEST run is
+#                 green (a stale pre-approval failure superseded by a
+#                 later pass) AND mergeable=MERGEABLE. A genuinely-red
+#                 (or misconfigured-required) check is NOT trusted as
+#                 benign just because mergeable — which is conflict-only
+#                 — says MERGEABLE; that would reopen #170/#171 (#547)
 #   BEHIND      — base has commits the head lacks (with "Require
 #                 branches to be up to date" enabled)
 #   DRAFT       — PR is in draft mode (covered explicitly so the
@@ -1775,7 +2206,32 @@ case "$MERGE_STATE" in
       exit 2
     fi
     ;;
-  BLOCKED|DIRTY|UNSTABLE|BEHIND)
+  UNSTABLE)
+    # UNSTABLE = a non-passing commit status, but mergeable. The naive
+    # read (allow because mergeable=MERGEABLE) is WRONG: GitHub defines
+    # `mergeable` purely by merge CONFLICTS, not check status, so a red
+    # REQUIRED check surfaced as UNSTABLE (or branch protection
+    # misconfigured) would still be MERGEABLE and slip through —
+    # reopening the #170/#171 red-CI bypass. So verify the check ROLLUP:
+    # allow only when every check name's LATEST run is green
+    # (ROLLUP_NONGREEN == 0). That clears the real #547 case — a STALE
+    # pre-approval failed check-suite superseded by a later passing run
+    # (its latest is green) — while a genuinely-red latest check (count
+    # > 0) stays blocked. mergeable=MERGEABLE is kept as a belt-and-
+    # suspenders conflict guard. BLOCKED/DIRTY/BEHIND still block below.
+    if [ "$ROLLUP_NONGREEN" = "0" ] && [ "$MERGEABLE_STATE" = "MERGEABLE" ]; then
+      echo "ALLOW: mergeStateStatus=UNSTABLE, but every check name's LATEST run is green and mergeable=MERGEABLE — a stale check-suite superseded by a later pass (#547)." >&2
+    elif [ "$EFFECTIVE_BREAK_GLASS_MERGE_STATE" = "1" ]; then
+      echo "BREAK-GLASS: merge with mergeStateStatus=UNSTABLE (non-green latest checks=$ROLLUP_NONGREEN, mergeable=$MERGEABLE_STATE) authorized by human." >&2
+    else
+      echo "BLOCKED: PR mergeStateStatus is UNSTABLE with $ROLLUP_NONGREEN check(s) whose latest run is not green (mergeable=$MERGEABLE_STATE) — fail-closed; a red required check is NOT trusted as benign (mergeable is conflict-only)." >&2
+      echo "  Resolve the failing checks, or wait for GitHub's recompute, then retry." >&2
+      echo "  Override: BREAK_GLASS_MERGE_STATE=1 (export or inline prefix; must be authorized by human in chat)." >&2
+      echo "  See #170 / #171 for the regression this guard closes." >&2
+      exit 2
+    fi
+    ;;
+  BLOCKED|DIRTY|BEHIND)
     if [ "$EFFECTIVE_BREAK_GLASS_MERGE_STATE" = "1" ]; then
       echo "BREAK-GLASS: merge with mergeStateStatus=$MERGE_STATE authorized by human." >&2
     else

--- a/scripts/lib/gh-retry-helpers.sh
+++ b/scripts/lib/gh-retry-helpers.sh
@@ -52,19 +52,67 @@ with_gh_retry() {
   # already caught.
   local attempt=1
   local rc=0
+  local out=""
+  local errtext=""
   local output=""
 
+  # Separate stderr capture (#536): gh writes deprecation notices and
+  # other warnings to stderr even on a successful call. The prior
+  # implementation captured `2>&1` and re-emitted the combined stream on
+  # success, so that stderr chatter contaminated JSON / exact-text
+  # consumers (e.g. codex-review-check.sh parsing statusCheckRollup). We
+  # now route stderr to a tmpfile, emit ONLY stdout on success, and fold
+  # the two streams together (`output`) solely for failure
+  # classification + logging. A tmpfile (not process substitution) keeps
+  # this bash 3.2 safe and avoids the subshell-scoping traps of `<(...)`.
+  local err
+  err=$(mktemp "${TMPDIR:-/tmp}/gh-retry-err.XXXXXX") || {
+    printf '[gh-retry] WARN: mktemp failed; falling back to combined stream\n' >&2
+    err=""
+  }
+  # Clean up the tmpfile on any return path (success, permanent-fail,
+  # exhausted retries) via a RETURN trap that CLEARS ITSELF (trap -
+  # RETURN) as it fires. Self-clearing is required: a bare RETURN trap
+  # lingers after with_gh_retry returns and re-fires on the caller's own
+  # function / source return, where the local `err` is out of scope —
+  # under set -u that aborts the caller with `err: unbound variable`
+  # (#545 P2). No caller in this repo installs its own RETURN trap, so
+  # clearing (rather than save/restore) clobbers nothing.
+  if [ -n "$err" ]; then
+    trap 'rm -f "$err"; trap - RETURN' RETURN
+  fi
+
   while [ "$attempt" -le "$attempts" ]; do
-    # Capture stdout+stderr AND the exit code in one shot. Using
-    # `if output=...; then` would discard `$?` after the failed
+    # Capture stdout and the exit code; stderr goes to the tmpfile.
+    # Using `if out=...; then` would discard `$?` after the failed
     # `if` test (bash resets $? to 0 in that position), so we
     # invoke + check separately. `|| rc=$?` keeps `set -e` happy
     # because the `||` short-circuit consumes the non-zero exit.
     rc=0
-    output=$("$@" 2>&1) || rc=$?
+    if [ -n "$err" ]; then
+      out=$("$@" 2>"$err") || rc=$?
+      errtext=$(cat "$err" 2>/dev/null || true)
+    else
+      # Fallback path (mktemp unavailable): preserve prior combined
+      # behavior rather than dropping stderr entirely.
+      out=$("$@" 2>&1) || rc=$?
+      errtext=""
+    fi
     if [ "$rc" -eq 0 ]; then
-      printf '%s' "$output"
+      # Success: emit ONLY stdout. Any stderr (warnings/deprecations)
+      # is intentionally dropped so downstream parsers see clean output.
+      printf '%s' "$out"
       return 0
+    fi
+
+    # Combined stream for classification + logging on the FAILURE path
+    # only. Joining with a newline keeps grep line-anchored matches
+    # working across the stdout/stderr boundary.
+    if [ -n "$errtext" ]; then
+      output="$out
+$errtext"
+    else
+      output="$out"
     fi
 
     # Classify the failure. Permanent failures break out immediately.

--- a/scripts/lib/gh-token-resolver.sh
+++ b/scripts/lib/gh-token-resolver.sh
@@ -49,28 +49,65 @@ gh_resolve_token_for_identity() {
     return 2
   fi
 
+  # Resolution order (every candidate is verified via identity-check.sh
+  # --expect-token-identity before it can win — no candidate is ever blindly
+  # trusted, and no token material is printed):
+  #
+  #   1. The preferred OP_PREFLIGHT_*_PAT env var (if set). A WRONG identity
+  #      here is a hard error — the caller asked for this specific cached PAT,
+  #      so a mismatch is a misconfiguration to surface, not something to
+  #      paper over by silently using a different token.
+  #   2. An ambient GH_TOKEN (#533). On a token-only runner
+  #      (`GH_TOKEN=... scripts/gh-as-reviewer.sh ...`) with no keyring and no
+  #      OP_PREFLIGHT cache, this is the only token material available. It is
+  #      tried only when (1) supplied no token. A WRONG-identity ambient token
+  #      is REJECTED and falls through to the keyring — never blindly trusted.
+  #   3. The `gh auth token --user <login>` keyring fallback. A WRONG identity
+  #      here is a hard error (the keyring returned a token for the wrong
+  #      account).
+
   token=""
   source=""
+
+  # --- Candidate 1: preferred OP_PREFLIGHT_*_PAT (hard-fail on mismatch) ---
   if [ -n "$preferred_var" ]; then
     # Indirect expansion is supported by the repo's Bash 3.2 baseline.
     token="${!preferred_var:-}"
     if [ -n "$token" ]; then
       source="\$$preferred_var"
+      if ! GH_TOKEN="$token" "$checker" --expect-token-identity "$expected_login"; then
+        echo "$label: selected token source ($source) did not verify as $expected_login." >&2
+        return 2
+      fi
+      GH_RESOLVED_TOKEN="$token"
+      return 0
     fi
   fi
 
-  if [ -z "$token" ]; then
-    if ! command -v gh >/dev/null 2>&1; then
-      echo "$label: gh CLI not on PATH; cannot fall back to gh auth token." >&2
-      return 3
+  # --- Candidate 2: ambient GH_TOKEN (verify; fall through on mismatch) ---
+  # Tried only when the preferred var supplied nothing. A mismatch does NOT
+  # hard-fail here — it falls through to the keyring — because an ambient
+  # GH_TOKEN may belong to a different identity than the one this write needs
+  # (e.g. a CI-default token), and the keyring may still hold the right one.
+  if [ -n "${GH_TOKEN:-}" ]; then
+    if GH_TOKEN="$GH_TOKEN" "$checker" --expect-token-identity "$expected_login" 2>/dev/null; then
+      GH_RESOLVED_TOKEN="$GH_TOKEN"
+      return 0
     fi
-    if ! token="$(env -u GH_TOKEN -u GITHUB_TOKEN gh auth token --user "$expected_login" 2>/dev/null)"; then
-      echo "$label: could not read a token for $expected_login via gh auth token --user." >&2
-      echo "$label: run gh auth login once for that identity, or warm op-preflight." >&2
-      return 3
-    fi
-    source="gh auth token --user $expected_login"
+    echo "$label: ambient GH_TOKEN did not verify as $expected_login; trying gh auth token --user." >&2
   fi
+
+  # --- Candidate 3: gh auth token --user keyring fallback (hard-fail) ------
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "$label: gh CLI not on PATH; cannot fall back to gh auth token." >&2
+    return 3
+  fi
+  if ! token="$(env -u GH_TOKEN -u GITHUB_TOKEN gh auth token --user "$expected_login" 2>/dev/null)"; then
+    echo "$label: could not read a token for $expected_login via gh auth token --user." >&2
+    echo "$label: run gh auth login once for that identity, or warm op-preflight." >&2
+    return 3
+  fi
+  source="gh auth token --user $expected_login"
 
   if [ -z "$token" ]; then
     echo "$label: selected token for $expected_login is empty." >&2

--- a/scripts/lib/template-substitution.sh
+++ b/scripts/lib/template-substitution.sh
@@ -1,0 +1,418 @@
+#!/usr/bin/env bash
+# scripts/lib/template-substitution.sh — render templated propagation
+# sources with per-consumer facts.
+#
+# v1 syntax (intentionally minimal — see docs/agents/templated-
+# propagation.md § Why this syntax for the rationale):
+#
+#   1. Variable substitution. Anywhere in the file:
+#        {{key}}                 → ${MERGEPATH_FACT_KEY:-""}
+#      Missing fact = empty string in lenient mode (default), hard
+#      fail in strict mode (MERGEPATH_TEMPLATE_STRICT=1).
+#
+#   2. Conditional blocks. Lines matching:
+#        >>> if <expr>
+#        ...body...
+#        <<<
+#      The leading comment prefix on the marker line is stripped (the
+#      lib accepts any non-alnum run before the `>>>`/`<<<` sigil so
+#      `//`, `#`, `--`, `<!-- … -->`, `/* … */` all work). Body lines
+#      survive verbatim if <expr> is true; the entire block (markers
+#      included) is omitted otherwise.
+#
+#      <expr> forms accepted in v1:
+#        - <key>                  truthy iff env MERGEPATH_FACT_KEY is set
+#                                 and non-empty
+#        - !<key>                 inverse of the above
+#        - <key> contains <value> for space-separated list facts
+#        - <key> == <value>       string equality
+#        - <key> != <value>       string inequality
+#
+#      Nesting is NOT supported in v1. Two `>>> if` opens without an
+#      intervening `<<<` is a malformed-template error (exit 1). Add
+#      nesting later if a real source file needs it.
+#
+# Facts source: environment variables. Each fact key (lowercase,
+# possibly with hyphens) maps to `MERGEPATH_FACT_<KEY>` (uppercase,
+# hyphens → underscores). List facts are space-separated. Sync
+# integration (scripts/sync-to-downstream.sh) is responsible for
+# extracting per-consumer facts from .mergepath-sync.yml and
+# exporting them before invoking this lib.
+#
+# API:
+#   template_substitution::render <source_file>
+#       Renders to stdout. Exit 0 success, 1 malformed template, 2
+#       source-file missing, 3 unknown fact in strict mode.
+#
+#   template_substitution::render_to <source_file> <dest_file>
+#       Atomic write via mktemp + mv. Same exit codes as render.
+#
+#   template_substitution::eval_expr <expr>
+#       Returns 0 if expr is true, 1 if false, 2 if expr is malformed.
+#       Exposed so tests can drive it directly.
+#
+# Bash 3.2 portable (no associative arrays, no ${var^^}). Matches
+# scripts/bootstrap/substitute.sh's portability bar.
+#
+# This file is a SOURCED library and intentionally does NOT set
+# `set -euo pipefail` at file scope — that would mutate the caller's
+# shell options unexpectedly (CodeRabbit Major / Codex P1 on PR #313).
+# Internal functions use the `|| rc=$?` pattern to capture exit codes
+# without depending on errexit. The executed-directly guard block at
+# the bottom does enable strict mode for the noop-script path.
+
+# Convert a lowercase-with-hyphens fact name to its env var form:
+# "frameworks" → "MERGEPATH_FACT_FRAMEWORKS"
+# "node-version" → "MERGEPATH_FACT_NODE_VERSION"
+template_substitution::_fact_var() {
+  local key=$1
+  local upper
+  upper=$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+  printf 'MERGEPATH_FACT_%s' "$upper"
+}
+
+# Look up a fact value. Echoes the value (empty string if unset).
+# In strict mode, prints a diagnostic to stderr and returns 3 if the
+# fact is referenced but unset.
+#
+# Validates the key against [a-z0-9-] before passing to _fact_var
+# because _fact_var feeds into eval below. Without this guard, a key
+# containing shell metacharacters (e.g. `foo$(id)`) survives the `tr`
+# transformation and is interpreted at eval time as a command
+# substitution — RCE via a malicious manifest fact key (CodeRabbit
+# Critical on PR #313). Keys come from the manifest in practice, but
+# defense-in-depth catches a bad manifest entry or a future code
+# path that synthesizes keys from less-trusted input.
+template_substitution::_fact_value() {
+  local key=$1
+  case "$key" in
+    ''|*[!a-z0-9_-]*)
+      # Reject anything outside [a-z0-9_-]. Underscores stay allowed
+      # because env-var-style fact keys (e.g. `node_version`) are
+      # natural in templates and underscores are not eval metachars.
+      # Shell metacharacters ($, (, ), backtick, ;, &, |, \) and
+      # uppercase letters are blocked: the former are the injection
+      # surface, the latter are reserved for the env-var form
+      # (_fact_var uppercases keys to derive MERGEPATH_FACT_<KEY>).
+      printf 'template: malformed fact key (must match [a-z0-9_-]+): %s\n' "$key" >&2
+      return 2
+      ;;
+  esac
+  local var
+  var=$(template_substitution::_fact_var "$key")
+  # bash 3.2 indirect expansion via eval. Detect set-or-unset with
+  # the `${var+x}` form (echoes "x" if var is set to ANY value
+  # including empty; echoes empty if unset). Earlier versions used
+  # a literal sentinel string compared via `=`, which mis-classified
+  # a fact legitimately set to that exact sentinel as unset
+  # (Codex P3 on PR #313). The +x form has no collision surface —
+  # the test is on the existence of the variable, not its value.
+  local is_set
+  eval "is_set=\${$var+x}"
+  if [ -z "$is_set" ]; then
+    if [ "${MERGEPATH_TEMPLATE_STRICT:-0}" = "1" ]; then
+      printf 'template: strict mode: fact %s (env %s) is not set\n' \
+        "$key" "$var" >&2
+      return 3
+    fi
+    printf ''
+    return 0
+  fi
+  local value
+  eval "value=\${$var}"
+  printf '%s' "$value"
+}
+
+# Evaluate a conditional expression. Returns 0 (true), 1 (false), or
+# 2 (malformed).
+template_substitution::eval_expr() {
+  local expr=$1
+  # Trim leading/trailing whitespace.
+  expr=$(printf '%s' "$expr" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
+  case "$expr" in
+    "")
+      printf 'template: empty conditional expression\n' >&2
+      return 2
+      ;;
+    "!"*)
+      local inner=${expr#!}
+      inner=$(printf '%s' "$inner" | sed -e 's/^[[:space:]]*//')
+      local v
+      v=$(template_substitution::_fact_value "$inner") || return $?
+      if [ -z "$v" ]; then return 0; else return 1; fi
+      ;;
+    *" contains "*)
+      local key=${expr%% contains *}
+      local needle=${expr#* contains }
+      key=$(printf '%s' "$key" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+      needle=$(printf '%s' "$needle" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+      local haystack
+      haystack=$(template_substitution::_fact_value "$key") || return $?
+      # Space-padded match so "react" doesn't match "react-native".
+      case " $haystack " in
+        *" $needle "*) return 0 ;;
+        *) return 1 ;;
+      esac
+      ;;
+    *" == "*)
+      local key=${expr%% == *}
+      local want=${expr#* == }
+      key=$(printf '%s' "$key" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+      want=$(printf '%s' "$want" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+      local have
+      have=$(template_substitution::_fact_value "$key") || return $?
+      if [ "$have" = "$want" ]; then return 0; else return 1; fi
+      ;;
+    *" != "*)
+      local key=${expr%% != *}
+      local want=${expr#* != }
+      key=$(printf '%s' "$key" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+      want=$(printf '%s' "$want" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+      local have
+      have=$(template_substitution::_fact_value "$key") || return $?
+      if [ "$have" != "$want" ]; then return 0; else return 1; fi
+      ;;
+    *" "*)
+      printf 'template: malformed conditional expression: %s\n' "$expr" >&2
+      printf 'template: supported forms: <key>, !<key>, <key> contains <value>, <key> == <value>, <key> != <value>\n' >&2
+      return 2
+      ;;
+    *)
+      # Bare key — truthy iff non-empty.
+      local v
+      v=$(template_substitution::_fact_value "$expr") || return $?
+      if [ -n "$v" ]; then return 0; else return 1; fi
+      ;;
+  esac
+}
+
+# Apply {{key}} substitutions to a single line. Echoes the rewritten
+# line. In strict mode, an unset fact reference returns 3 (caller
+# handles).
+template_substitution::_substitute_vars() {
+  local line=$1
+  # Fast path: no `{{` on the line.
+  case "$line" in
+    *"{{"*) ;;
+    *) printf '%s' "$line"; return 0 ;;
+  esac
+
+  # Walk left-to-right, replacing each {{key}} occurrence.
+  local out=""
+  local remaining=$line
+  while :; do
+    case "$remaining" in
+      *"{{"*)
+        local before=${remaining%%\{\{*}
+        local rest=${remaining#*\{\{}
+        case "$rest" in
+          *"}}"*)
+            local key=${rest%%\}\}*}
+            local after=${rest#*\}\}}
+            local value
+            value=$(template_substitution::_fact_value "$key") || return $?
+            out="$out$before$value"
+            remaining=$after
+            ;;
+          *)
+            # Unclosed {{: emit as-is, stop.
+            out="$out$remaining"
+            remaining=""
+            break
+            ;;
+        esac
+        ;;
+      *)
+        out="$out$remaining"
+        remaining=""
+        break
+        ;;
+    esac
+  done
+  printf '%s' "$out"
+}
+
+# Regex helpers — POSIX BREs, anchored, comment-prefix-agnostic.
+# Marker line pattern: optional whitespace, optional non-alnum prefix
+# (the comment chars), optional whitespace, then the sigil, then space-
+# separated payload. We use grep -E with explicit anchors.
+template_substitution::_is_if_open() {
+  # $1: line. Returns 0 if it's a `>>> if ...` marker, echoing the
+  # expression on stdout. Returns 1 otherwise (no output).
+  local line=$1
+  printf '%s' "$line" | grep -E '^[[:space:]]*[^[:alnum:]{]*[[:space:]]*>>>[[:space:]]+if[[:space:]]+' >/dev/null || return 1
+  # Extract the expression after `>>> if `.
+  printf '%s' "$line" | sed -E 's/^[[:space:]]*[^[:alnum:]{]*[[:space:]]*>>>[[:space:]]+if[[:space:]]+//' \
+    | sed -e 's/[[:space:]]*$//' \
+    | sed -E 's,[[:space:]]*(\*/|-->)[[:space:]]*$,,'
+  return 0
+}
+
+template_substitution::_is_close() {
+  # $1: line. Returns 0 if it's a `<<<` marker line, 1 otherwise.
+  local line=$1
+  printf '%s' "$line" | grep -E '^[[:space:]]*[^[:alnum:]{]*[[:space:]]*<<<[[:space:]]*([^[:alnum:]{]*[[:space:]]*)?$' >/dev/null
+}
+
+# Render a template file to stdout. Implements the v1 syntax.
+template_substitution::render() {
+  local source=$1
+  if [ ! -f "$source" ]; then
+    printf 'template: source file not found: %s\n' "$source" >&2
+    return 2
+  fi
+
+  local in_conditional=0      # 0 outside, 1 inside (active), 2 inside (skipped)
+  local conditional_lineno=0  # for error diagnostics on unclosed `if`
+  local lineno=0
+  local line
+  # IFS= + -r preserves leading whitespace and backslashes. The trailing
+  # `|| [ -n "$line" ]` catches a file without a final newline.
+  while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+
+    # `<<<` close marker?
+    if template_substitution::_is_close "$line"; then
+      if [ "$in_conditional" = "0" ]; then
+        printf 'template: %s:%d: unexpected `<<<` (no open `>>> if`)\n' \
+          "$source" "$lineno" >&2
+        return 1
+      fi
+      in_conditional=0
+      continue
+    fi
+
+    # `>>> if ...` open marker?
+    local expr
+    if expr=$(template_substitution::_is_if_open "$line"); then
+      if [ "$in_conditional" != "0" ]; then
+        printf 'template: %s:%d: nested `>>> if` is not supported in v1 (open at line %d)\n' \
+          "$source" "$lineno" "$conditional_lineno" >&2
+        return 1
+      fi
+      conditional_lineno=$lineno
+      local rc=0
+      template_substitution::eval_expr "$expr" || rc=$?
+      case $rc in
+        0) in_conditional=1 ;;
+        1) in_conditional=2 ;;
+        2) return 1 ;;  # malformed expr → malformed template
+        3) return 3 ;;  # strict-mode fact-miss
+        *) printf 'template: eval_expr returned unexpected rc=%d\n' "$rc" >&2; return 1 ;;
+      esac
+      continue
+    fi
+
+    # Body line.
+    if [ "$in_conditional" = "2" ]; then
+      # Inside a skipped block — drop the line.
+      continue
+    fi
+
+    local rendered
+    local rc=0
+    rendered=$(template_substitution::_substitute_vars "$line") || rc=$?
+    case "$rc" in
+      0) ;;
+      2) return 1 ;;  # malformed fact key in template body → malformed template
+      3) return 3 ;;  # strict-mode unset fact
+      *) return $rc ;;
+    esac
+    printf '%s\n' "$rendered"
+  done < "$source"
+
+  if [ "$in_conditional" != "0" ]; then
+    printf 'template: %s: unclosed `>>> if` (opened at line %d)\n' \
+      "$source" "$conditional_lineno" >&2
+    return 1
+  fi
+}
+
+# Render to a destination file atomically.
+#
+# Atomicity contract: the destination either contains the fully-
+# rendered output OR is unchanged from its prior state — never a
+# partial write. Implemented by rendering into a sibling temp file
+# and `mv`-renaming it over the destination. The temp file lives in
+# `$(dirname "$dest")` (NOT $TMPDIR) so the rename is guaranteed to
+# stay on the same filesystem; a cross-filesystem mv would degrade
+# to copy+unlink, breaking atomicity under interrupt (CodeRabbit
+# Major / Codex P2 on PR #313).
+#
+# mv failure (permission, ENOSPC, racing process) is checked
+# explicitly — without that, render_to could return 0 with no
+# destination write, silently losing the rendered output.
+#
+# Mode preservation: if the destination already exists, its file
+# mode is captured before the rename and re-applied after, so a
+# pre-existing executable or world-readable file keeps its bits
+# rather than inheriting mktemp's 0600 (Codex P2 round 2 on PR
+# #313). When dest doesn't yet exist, the temp file's 0600 mode
+# stands — callers that need a specific mode on a new file set it
+# explicitly after rendering.
+template_substitution::render_to() {
+  local source=$1
+  local dest=$2
+  local dest_dir
+  dest_dir=$(dirname "$dest")
+  if [ ! -d "$dest_dir" ]; then
+    printf 'template: destination directory not found: %s\n' "$dest_dir" >&2
+    return 2
+  fi
+  # Capture existing dest mode (if any) before render — we need it
+  # before the rename clobbers the dest inode. `stat -c` is GNU/
+  # Linux; `stat -f` is BSD/macOS. Try GNU first because that's the
+  # CI runner — and crucially because GNU `stat -f` means "filesystem
+  # status" (not "format"), so a BSD-first fallback chain writes
+  # filesystem text to stdout on Linux before failing, contaminating
+  # dest_mode with multi-line garbage (Codex P1 round 3 on PR #313).
+  # GNU `stat -c '%a'` and BSD `stat -f '%Mp%Lp'` both yield the
+  # mode in a chmod-acceptable form (e.g. "644" or "0644").
+  local dest_mode=""
+  if [ -e "$dest" ]; then
+    dest_mode=$(stat -c '%a' "$dest" 2>/dev/null \
+                || stat -f '%Mp%Lp' "$dest" 2>/dev/null \
+                || printf '')
+  fi
+  local tmp
+  tmp=$(mktemp "$dest_dir/.template-render.XXXXXX")
+  local rc=0
+  template_substitution::render "$source" >"$tmp" || rc=$?
+  if [ "$rc" != "0" ]; then
+    rm -f "$tmp"
+    return $rc
+  fi
+  if ! mv -f "$tmp" "$dest"; then
+    rm -f "$tmp"
+    printf 'template: mv failed writing %s\n' "$dest" >&2
+    return 1
+  fi
+  # Re-apply captured mode. chmod failure is non-fatal — the content
+  # is already correctly written, and a mode-preservation failure is
+  # less bad than reporting a render failure when the render itself
+  # succeeded. Surfaced via stderr only.
+  if [ -n "$dest_mode" ]; then
+    chmod "$dest_mode" "$dest" 2>/dev/null \
+      || printf 'template: warning: failed to restore mode %s on %s\n' \
+           "$dest_mode" "$dest" >&2
+  fi
+}
+
+# Inline self-check: if invoked directly as a script (not sourced),
+# enable strict mode (safe because nothing else is sourcing us) and
+# emit a usage hint. Matches the convention used by other lib files
+# under scripts/lib/. Strict mode is intentionally NOT enabled at
+# file scope; see the comment near the top of this file.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  set -euo pipefail
+  cat >&2 <<EOF
+$(basename "$0") is a library. Source it from another bash script:
+
+  source "scripts/lib/template-substitution.sh"
+  template_substitution::render path/to/source.template
+
+See docs/agents/templated-propagation.md for the syntax reference.
+EOF
+  exit 2
+fi

--- a/scripts/merge-clearance-gate.sh
+++ b/scripts/merge-clearance-gate.sh
@@ -169,8 +169,14 @@ nested_field() {  # <top_block> <sub_block> <field>
     in_sub && /^[[:space:]]{0,3}[^[:space:]#]/ { in_sub=0 }
     in_sub && $1 == fldkey":" {
       sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", $0)
-      gsub(/^"/, "", $0)
-      gsub(/"[[:space:]]*(#.*)?$/, "", $0)
+      # Strip BOTH single and double quotes (#536): a single-quoted
+      # scalar like `enabled: '"'"'true'"'"'` previously kept its quotes
+      # and tripped the true|false validator (exit 2). \047 is the octal
+      # escape for a single quote inside the awk character class, mirroring
+      # codex-p1-gate.sh codex_field and the policy parsers in
+      # check_workflow_parsers.
+      gsub(/^["\047]/, "", $0)
+      gsub(/["\047][[:space:]]*(#.*)?$/, "", $0)
       gsub(/[[:space:]]*#.*$/, "", $0)
       sub(/[[:space:]]+$/, "", $0)
       print

--- a/scripts/op-preflight.sh
+++ b/scripts/op-preflight.sh
@@ -156,12 +156,20 @@ ssh_host_for() {
 }
 
 # ── Cache layout ──────────────────────────────────────────────────────
-# Cache directory is intentionally shared across all consumer repos:
-#   - The session file is keyed by --agent (see SESSION_FILE below).
-#   - PATs are agent-keyed and currently uniform across the Phase 4
-#     propagation set, so a shared cache is functionally correct.
-# Re-evaluate if per-repo PATs ever diverge — at that point, namespace
-# the cache path per consumer repo (e.g. $HOME/.cache/mergepath/$REPO).
+# Cache directory is intentionally shared across all consumer repos and is
+# NOT namespaced per repo. The session file is keyed by --agent (see
+# SESSION_FILE below), and each agent's credentials are per-identity and
+# machine-wide: one reviewer PAT per agent, not per-repo (see CLAUDE.md /
+# REVIEW_POLICY.md PAT lookup table). So the same agent's cached token is
+# identical regardless of which repo invoked preflight — a shared,
+# agent-keyed cache is correct today and a per-repo cache would only
+# duplicate identical material.
+#
+# Per-repo namespacing (e.g. $HOME/.cache/mergepath/$REPO) is a DEFERRED
+# fleet-wide architecture decision (mergepath#532), to revisit only if any
+# consumer ever needs a repo-scoped PAT for the same agent. Until then, do
+# NOT namespace this path — it would fragment the cache and multiply the
+# biometric burst across repos for no security gain.
 DEFAULT_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/mergepath"
 CACHE_DIR="${OP_PREFLIGHT_CACHE_DIR:-$DEFAULT_CACHE_DIR}"
 DEFAULT_TTL_SECONDS=14400  # 4 hours
@@ -237,8 +245,16 @@ if $PURGE_ALL; then
   exit 0
 fi
 
-if [[ "$MODE" == "review" || "$MODE" == "all" || "$PURGE" == "true" || "$CHECK" == "true" ]] && [[ -z "$AGENT" ]]; then
-  echo "Error: --agent is required for review, all, --purge, or --check mode." >&2
+# --agent is required for every mode except --purge-all (handled above).
+# `deploy` MUST stay in this gate: cache paths are unconditionally
+# $AGENT-interpolated (op-preflight-$AGENT.env / -adc.json /
+# -firebase-sa.json), so `--mode deploy` with no --agent writes a shared
+# anonymous ("") bucket that `--purge --agent <name>` can never reclaim and
+# that concurrent agent sessions clobber. This was added in #259, silently
+# dropped by a bulk sync, and restored in #534 — the regression test
+# test_deploy_mode_requires_agent guards against another drop.
+if [[ "$MODE" == "review" || "$MODE" == "all" || "$MODE" == "deploy" || "$PURGE" == "true" || "$CHECK" == "true" ]] && [[ -z "$AGENT" ]]; then
+  echo "Error: --agent is required for review, deploy, all, --purge, or --check mode." >&2
   echo "Usage: eval \"\$(scripts/op-preflight.sh --agent claude --mode review)\"" >&2
   exit 1
 fi
@@ -787,6 +803,12 @@ emit_from_session_file() (
   fi
   printf 'export OP_PREFLIGHT_DONE=1\n'
   printf 'export OP_PREFLIGHT_AGENT=%q\n' "$AGENT"
+  # Keep exporting the preflight mode on the cache-hit path (#521): a
+  # consumer that evals this output (e.g. a deploy wrapper that took the
+  # fast path and skipped a fresh fetch) can read OP_PREFLIGHT_MODE to see
+  # which mode actually ran. $MODE is this invocation's mode, which the
+  # cross-mode validation above already proved the cache satisfies.
+  printf 'export OP_PREFLIGHT_MODE=%q\n' "$MODE"
   exit 0
 )
 
@@ -1143,7 +1165,13 @@ if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
     chmod 600 "$ADC_TMPFILE"
 
     log_deploy_biometric_once
-    if op read "$DEFAULT_ADC_OP_URI" > "$ADC_TMPFILE" 2>/dev/null && [[ -s "$ADC_TMPFILE" ]]; then
+    # Capture op's stderr so the could-not-read warning can say WHY (vault
+    # locked / item not found / sign-in expired) instead of a bare "not
+    # available" (#534.3). Routed through scrub_op_error so a service-account
+    # token can never leak into the diagnostic, mirroring the Phase 1 reader.
+    ADC_OP_ERR="$(mktemp "${TMPDIR:-/tmp}/op-preflight-adc-err.XXXXXX")"
+    if op read "$DEFAULT_ADC_OP_URI" > "$ADC_TMPFILE" 2>"$ADC_OP_ERR" && [[ -s "$ADC_TMPFILE" ]]; then
+      rm -f "$ADC_OP_ERR"
       if adc_is_usable "$ADC_TMPFILE"; then
         EXPORTS+=("export GOOGLE_APPLICATION_CREDENTIALS=$(printf '%q' "$ADC_TMPFILE")")
         EXPORTS+=("export OP_PREFLIGHT_ADC_TMPFILE=$(printf '%q' "$ADC_TMPFILE")")
@@ -1154,11 +1182,25 @@ if [[ "$MODE" == "deploy" || "$MODE" == "all" ]]; then
         rm -f "$ADC_TMPFILE"
         log_stale_adc_guidance
         SUMMARY+=("GCP ADC: STALE (refresh_token rejected — see warning above)")
+        # Fail closed (#534.2): under `--mode deploy` a deploy script needs a
+        # real credential. Degrading in place (continuing to OP_PREFLIGHT_DONE=1
+        # with no GOOGLE_APPLICATION_CREDENTIALS) is the cache-hit path's
+        # `exit 2` failure mode replayed on the full-fetch path — symmetric to
+        # the line-696 cache-hit guard. `--mode all` deliberately keeps
+        # degrading (callers still want the PATs), so scope this to deploy.
+        if [[ "$MODE" == "deploy" ]]; then exit 1; fi
       fi
     else
-      rm -f "$ADC_TMPFILE"
-      echo "# Warning: could not read GCP ADC. Deploy credentials not cached." >&2
+      adc_op_reason="$(scrub_op_error "$ADC_OP_ERR")"
+      rm -f "$ADC_TMPFILE" "$ADC_OP_ERR"
+      if [[ -n "$adc_op_reason" ]]; then
+        echo "# Warning: could not read GCP ADC. Deploy credentials not cached. (op: ${adc_op_reason})" >&2
+      else
+        echo "# Warning: could not read GCP ADC. Deploy credentials not cached." >&2
+      fi
       SUMMARY+=("GCP ADC: SKIPPED (not available)")
+      # Fail closed (#534.2): see STALE branch above.
+      if [[ "$MODE" == "deploy" ]]; then exit 1; fi
     fi
   fi
 
@@ -1206,6 +1248,10 @@ chmod 600 "$SESSION_FILE"
 # ── Output ────────────────────────────────────────────────────────────
 EXPORTS+=("export OP_PREFLIGHT_DONE=1")
 EXPORTS+=("export OP_PREFLIGHT_AGENT=$(printf '%q' "$AGENT")")
+# Export the mode on the full-fetch path too (#521), symmetric to the
+# cache-hit path above, so consumers can read which mode ran regardless of
+# whether the fetch was fresh or a cache hit.
+EXPORTS+=("export OP_PREFLIGHT_MODE=$(printf '%q' "$MODE")")
 
 # Print export statements to stdout (caller evals them)
 for exp in "${EXPORTS[@]}"; do

--- a/scripts/phase-4b-classifier.sh
+++ b/scripts/phase-4b-classifier.sh
@@ -47,6 +47,21 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 2
 fi
 
+# --- preflight auto-source (#282) ------------------------------------------
+# When the live `gh api .../pulls/{pr}/files` path runs (no --fixture), it
+# must authenticate as the reviewer identity, not under a bare ambient
+# GH_TOKEN. Mirror codex-review-check.sh: if GH_TOKEN is unset and a fresh
+# op-preflight cache exists for this agent, source it so the reviewer PAT is
+# available. The classifier is read-only, so reviewer scope is correct.
+# Guarded by existence — a hand-built install without the helper still runs
+# (it just won't auto-source).
+__P4B_CLASSIFIER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -r "$__P4B_CLASSIFIER_DIR/lib/preflight-helpers.sh" ]; then
+  # shellcheck source=lib/preflight-helpers.sh
+  . "$__P4B_CLASSIFIER_DIR/lib/preflight-helpers.sh"
+  preflight_require_token reviewer || true
+fi
+
 # ── Argument parsing ─────────────────────────────────────────────────────────
 
 PR_NUM=""
@@ -224,7 +239,13 @@ else
     echo "Error: GH_TOKEN required for live API call (or use --fixture)." >&2
     exit 2
   fi
-  FILES_JSON=$(gh api --paginate "repos/$REPO/pulls/$PR_NUM/files" 2>&1) || {
+  # Pin the reviewer PAT on the live call (#533). Prefer the cached reviewer
+  # PAT (set above by preflight_require_token, or already exported by an
+  # op-preflight session) over a bare ambient GH_TOKEN, mirroring the sibling
+  # agent-session helpers. Falls back to the ambient GH_TOKEN when no reviewer
+  # PAT is present (the empty-token guard above already required one or the
+  # other to be set).
+  FILES_JSON=$(GH_TOKEN="${OP_PREFLIGHT_REVIEWER_PAT:-${GH_TOKEN:-}}" gh api --paginate "repos/$REPO/pulls/$PR_NUM/files" 2>&1) || {
     echo "Error: failed to fetch PR files: $FILES_JSON" >&2; exit 2
   }
   # gh --paginate emits a stream of arrays; flatten into one. Normalize
@@ -246,7 +267,9 @@ else
   # "invariant" body mention). Hard-fail with exit 2 instead of
   # falling through with PR_BODY="" — codex r1 Phase 4b on PR #190
   # caught the prior `|| echo ""` swallow + reproduced with stubbed gh.
-  PR_BODY=$(gh api "repos/$REPO/pulls/$PR_NUM" --jq '.body // ""' 2>&1) || {
+  # Same reviewer-PAT pin as the files fetch above (#533): both live agent
+  # calls authenticate as the reviewer identity, not under a bare GH_TOKEN.
+  PR_BODY=$(GH_TOKEN="${OP_PREFLIGHT_REVIEWER_PAT:-${GH_TOKEN:-}}" gh api "repos/$REPO/pulls/$PR_NUM" --jq '.body // ""' 2>&1) || {
     echo "Error: failed to fetch PR body for $REPO#$PR_NUM: $PR_BODY" >&2
     echo "       Body-only triggers (state-machine / invariant body mention) require this fetch to succeed." >&2
     exit 2

--- a/scripts/post-phase-4b-handoff.sh
+++ b/scripts/post-phase-4b-handoff.sh
@@ -306,11 +306,6 @@ fi
 echo '```'
 echo 'PRs ready for external review (Phase 4b):'
 echo
-while IFS=$'\t' read -r _repo _num url _head_short_unused base_short _content _unresolved; do
-  [[ -n "$_repo" ]] || continue
-  # Re-read to get head_short in the right column.
-  :
-done <<<"$ROWS_TSV"
 # Print one URL line per row, with head + base shorts.
 while IFS=$'\t' read -r _repo _num url head_short base_short _content _unresolved; do
   [[ -n "$_repo" ]] || continue

--- a/scripts/request-label-removal.sh
+++ b/scripts/request-label-removal.sh
@@ -43,7 +43,10 @@
 #   1 = bad arguments / unsupported label
 #   2 = gh failure (auth, missing PR, network)
 
-set -eo pipefail
+set -euo pipefail
+# `-u` added (#536): every optional is already guarded with `${VAR:-}`,
+# so unset-variable strictness surfaces genuine typos without breaking the
+# documented optional-arg paths.
 
 # --- preflight auto-source (#282) ------------------------------------------
 # If OP_PREFLIGHT_REVIEWER_PAT is unset and a fresh op-preflight cache
@@ -107,8 +110,13 @@ REPO=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --reason) REASON="$2"; shift 2 ;;
-    --repo)   REPO="$2"; shift 2 ;;
+    # Validate the value is present BEFORE shift 2 (#536): under
+    # `set -eo pipefail` a trailing `--reason` / `--repo` with no value
+    # made `shift 2` abort the script (shifting past the end) instead of
+    # routing to the usage handler. `[ -n "${2:-}" ] || usage` makes the
+    # missing-value case a clean usage exit.
+    --reason) [ -n "${2:-}" ] || usage; REASON="$2"; shift 2 ;;
+    --repo)   [ -n "${2:-}" ] || usage; REPO="$2"; shift 2 ;;
     -h|--help) usage ;;
     -*) echo "Unknown flag: $1" >&2; usage ;;
     *)
@@ -141,6 +149,11 @@ if [ -n "$REPO" ]; then
   REPO_FLAG=(--repo "$REPO")
   REPO_HINT_FOR_BODY=" --repo $REPO"
 fi
+# NOTE: the two `"${REPO_FLAG[@]}"` expansions below use the
+# `${REPO_FLAG[@]+...}` guard form. macOS's default /bin/bash 3.2 raises
+# "unbound variable" on a bare `"${REPO_FLAG[@]}"` when the array is empty
+# (the no-`--repo` common case) under the `-u` added above; the guard
+# expands to nothing when unset and to the elements otherwise.
 # Plain string (set -e safe). The previous form embedded
 # `$([ -n "$REPO" ] && echo "--repo $REPO")` directly inside the BODY
 # heredoc. In the default no-`--repo` case the inline `[` returns 1,
@@ -167,7 +180,7 @@ if ! gh_resolve_token_for_identity "$REVIEWER_IDENTITY" "OP_PREFLIGHT_REVIEWER_P
 fi
 REVIEWER_TOKEN="$GH_RESOLVED_TOKEN"
 
-PR_URL=$(GH_TOKEN="$REVIEWER_TOKEN" gh pr view "$PR_NUM" "${REPO_FLAG[@]}" --json url --jq .url 2>/dev/null) || {
+PR_URL=$(GH_TOKEN="$REVIEWER_TOKEN" gh pr view "$PR_NUM" ${REPO_FLAG[@]+"${REPO_FLAG[@]}"} --json url --jq .url 2>/dev/null) || {
   echo "Could not resolve PR #$PR_NUM. Check --repo and gh auth." >&2
   exit 2
 }
@@ -204,7 +217,7 @@ if [ ! -x "$AS_REVIEWER" ]; then
 fi
 
 if ! GH_AS_REVIEWER_IDENTITY="$REVIEWER_IDENTITY" OP_PREFLIGHT_REVIEWER_PAT="$REVIEWER_TOKEN" \
-  "$AS_REVIEWER" -- gh pr comment "$PR_NUM" "${REPO_FLAG[@]}" --body "$BODY" >/dev/null; then
+  "$AS_REVIEWER" -- gh pr comment "$PR_NUM" ${REPO_FLAG[@]+"${REPO_FLAG[@]}"} --body "$BODY" >/dev/null; then
   echo "Failed to post comment on PR #$PR_NUM" >&2
   exit 2
 fi

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -93,7 +93,12 @@
 #   matchline #181, #190, #192 — observed cases of conversation-
 #                                resolution blocker
 
-set -eo pipefail
+set -euo pipefail
+# `-u` added (#536): optionals are already defaulted (MODE/DRY_RUN/
+# RATIONALE_OVERRIDE/etc. at module top, env vars via `${VAR:-}` and the
+# `:=` default for MERGEPATH_AGENT_AUTHORS), and the arg parser guards
+# `$2` behind a `$# -lt 2` short-circuit, so strict unset-variable
+# handling surfaces genuine typos without breaking documented paths.
 
 # --- preflight auto-source (#282) ------------------------------------------
 # If OP_PREFLIGHT_REVIEWER_PAT is unset and a fresh op-preflight cache
@@ -612,7 +617,10 @@ fetch_manifest_paths() {
   # Fall back to a grep-based extraction so the helper still functions
   # in environments without yq (the rollup-classifier-side reading is
   # the same shape).
-  if command -v yq >/dev/null 2>&1; then
+  # RESOLVE_PR_THREADS_FORCE_NO_YQ=1 forces the grep/awk fallback — a test
+  # hook for the #521 no-yq path (CI installs yq, so PATH curation is not
+  # portable). Inert in production. Mirrors RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK.
+  if [ -z "${RESOLVE_PR_THREADS_FORCE_NO_YQ:-}" ] && command -v yq >/dev/null 2>&1; then
     MANIFEST_PATHS_CACHE=$(yq -r '.paths[].path' "$manifest" 2>/dev/null || true)
   else
     # Best-effort: read `- path: VALUE` lines. Tolerates surrounding
@@ -666,7 +674,10 @@ fetch_manifest_templated_dests() {
   MANIFEST_TEMPLATED_FETCHED=true
   local manifest="$REPO_ROOT_FOR_MANIFEST/.mergepath-sync.yml"
   [ -f "$manifest" ] || return 0
-  if command -v yq >/dev/null 2>&1; then
+  # RESOLVE_PR_THREADS_FORCE_NO_YQ=1 forces the grep/awk fallback — a test
+  # hook for the #521 no-yq path (CI installs yq, so PATH curation is not
+  # portable). Inert in production. Mirrors RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK.
+  if [ -z "${RESOLVE_PR_THREADS_FORCE_NO_YQ:-}" ] && command -v yq >/dev/null 2>&1; then
     # #467: a path entry's `consumers` is EITHER a sequence of names OR
     # the scalar literal `all`. The prior single-pass expression did
     # `.consumers // [] | map(...)`, which on the scalar `all` tried to
@@ -728,12 +739,28 @@ fetch_manifest_templated_dests() {
     #    cautious failure mode: under-classify rather than over-
     #    classify; templated-render is a skip-class, and a missed
     #    skip just falls back to the rollup's general heuristics).
+    #
+    # 3. `consumers: all` parity with the yq path (#521). The yq pass-1
+    #    resolves a scalar `consumers: all` to EVERY consumer's repo slug,
+    #    i.e. match-any-consumer. The awk fallback previously could not
+    #    distinguish `all` from a name list (it never parsed `consumers:`),
+    #    so an `all` templated entry was under-classified along with every
+    #    other entry. We now detect the scalar `consumers: all` per entry
+    #    and emit a dedicated `__AWK_CONSUMERS_ALL__` sentinel, which
+    #    path_matches_templated_dest treats as "match any repo" — mirroring
+    #    the yq semantics. A `consumers:` followed by a name SEQUENCE stays
+    #    the cautious no-scope sentinel (awk can't reliably resolve
+    #    name→repo cross-references), matching the prior behavior for lists.
     MANIFEST_TEMPLATED_DESTS_CACHE=$(awk '
       function emit() {
         if (cur_type == "templated") {
           out = (cur_dest != "" ? cur_dest : cur_path)
           if (out != "") {
-            printf "%s\t__AWK_NO_CONSUMER_SCOPE__\n", out
+            if (cur_consumers_all) {
+              printf "%s\t__AWK_CONSUMERS_ALL__\n", out
+            } else {
+              printf "%s\t__AWK_NO_CONSUMER_SCOPE__\n", out
+            }
           }
         }
       }
@@ -746,7 +773,7 @@ fetch_manifest_templated_dests() {
         sub(/^[[:space:]]*-[[:space:]]*path:[[:space:]]*/, "", cur_path)
         sub(/[[:space:]]*#.*$/, "", cur_path)
         gsub(/^[[:space:]]+|[[:space:]]+$|^"|"$/, "", cur_path)
-        cur_dest = ""; cur_type = ""
+        cur_dest = ""; cur_type = ""; cur_consumers_all = 0
       }
       /^[[:space:]]*dest:/ {
         cur_dest = $0
@@ -756,6 +783,12 @@ fetch_manifest_templated_dests() {
       }
       /^[[:space:]]*type:[[:space:]]*templated/ {
         cur_type = "templated"
+      }
+      # Scalar `consumers: all` (optionally quoted / trailing comment).
+      # A sequence form (`consumers:` then `- name` lines) does NOT match
+      # this pattern, so it correctly falls through to the no-scope sentinel.
+      /^[[:space:]]*consumers:[[:space:]]*["\047]?all["\047]?[[:space:]]*(#.*)?$/ {
+        cur_consumers_all = 1
       }
       END { emit() }
     ' "$manifest")
@@ -780,6 +813,13 @@ path_matches_templated_dest() {
     dest="${line%%$'\t'*}"
     consumers="${line#*$'\t'}"
     [ "$file_path" = "$dest" ] || continue
+    # The awk fallback emits a scalar-`consumers: all` sentinel (#521).
+    # `all` means every consumer is in scope, so the current repo always
+    # qualifies — match unconditionally, mirroring the yq path which
+    # expands `all` to every consumer's repo slug.
+    if [ "$consumers" = "__AWK_CONSUMERS_ALL__" ]; then
+      return 0
+    fi
     # The awk fallback emits this sentinel when it can't resolve
     # consumer-name → repo-slug (cross-references in awk are
     # brittle). Treat sentinel as "no scope information available"

--- a/scripts/workflow/parse_policy_list.sh
+++ b/scripts/workflow/parse_policy_list.sh
@@ -51,11 +51,17 @@ awk -v key="$KEY" '
   in_block && /^ *-/ {
     line = $0
     sub(/^ *- */, "", line)
-    if (line ~ /^"/) {
-      # Quoted entry: strip the leading `"`, then the closing `"`
-      # plus any trailing whitespace and inline comment.
-      sub(/^"/, "", line)
-      sub(/"[[:space:]]*(#.*)?$/, "", line)
+    if (line ~ /^["\047]/) {
+      # Quoted entry (single OR double, #536): strip the leading quote,
+      # then the matching closing quote plus any trailing whitespace and
+      # inline comment. \047 is the octal escape for a single quote.
+      # Single-quoted entries like `- '"'"'.github/**'"'"'` previously kept
+      # their quotes, so policy matching silently missed them. Capture the
+      # opening quote char and strip the SAME char at the close so a value
+      # legitimately containing the other quote style is preserved.
+      q = substr(line, 1, 1)
+      sub(/^["\047]/, "", line)
+      sub(q "[[:space:]]*(#.*)?$", "", line)
     } else {
       # Unquoted entry: strip only the trailing whitespace + comment.
       sub(/[[:space:]]+#.*$/, "", line)

--- a/scripts/workflow/verify-propagation-pr.sh
+++ b/scripts/workflow/verify-propagation-pr.sh
@@ -13,10 +13,25 @@ set -euo pipefail
 #
 # This script is the teeth. It byte-compares every file the PR
 # changes against the SAME path in a checkout of mergepath at the
-# sync's source commit. It is TRUSTED ONLY when invoked from that
-# mergepath checkout (the immutable, public commit the PR's branch
-# name points at) — never from the PR's own checkout, which the PR
-# could have tampered with.
+# sync's source commit (<mergepath_dir>, used as a DATA source only).
+# It is TRUSTED when invoked from a tamper-proof in-repo location:
+# pr-review-policy.yml runs the consumer's OWN copy from the PR's BASE
+# commit (propagated + reviewed; the PR cannot edit its base), and this
+# script sources its helper scripts + libs from its own directory
+# (#531). It must NOT be run from the PR's own checkout (the PR could
+# tamper with it) nor executed out of the runtime-cloned mergepath@<sha>
+# (a `pull-requests: write` workflow running runtime-fetched shell is an
+# RCE surface).
+#
+# mergepath-verifier-contract: self-sourced-helpers-v1
+#   pr-review-policy.yml greps the BASE-commit copy of this file for the
+#   exact tag above BEFORE running it. A base verifier without the tag
+#   predates the #531 self-sourcing hardening (it sources its helpers
+#   from the runtime-cloned mergepath, i.e. fetched shell), so the review
+#   workflow fails closed and falls through to normal review instead of
+#   executing it. Keep this tag in lockstep with the self-sourcing block
+#   below — if you ever revert to sourcing from the runtime clone, drop
+#   the tag so no consumer treats the old shape as trusted.
 #
 # Two verification surfaces:
 #
@@ -91,13 +106,20 @@ if [ ! -f "$MANIFEST" ]; then
   exit 2
 fi
 
-# The parser is taken from the mergepath checkout too — TRUSTED,
-# same provenance as the manifest and the canonical content.
-PARSE_MANIFEST="$MERGEPATH_DIR/scripts/workflow/parse_manifest_paths.sh"
-MATCH_PATHS="$MERGEPATH_DIR/scripts/workflow/match_protected_paths.sh"
+# #531: the parser + match helpers run from THIS verifier's own
+# directory (the consumer's in-repo, propagated, reviewed copy — invoked
+# from the PR's BASE commit by pr-review-policy.yml, which the PR cannot
+# tamper with), NOT from $MERGEPATH_DIR. $MERGEPATH_DIR is a DATA source
+# ONLY (manifest text + canonical content via git ls-tree / git show +
+# template sources), so no shell is ever executed out of the
+# runtime-cloned mergepath@<sha> — the RCE surface a `pull-requests:
+# write` workflow must not have.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARSE_MANIFEST="$SCRIPT_DIR/parse_manifest_paths.sh"
+MATCH_PATHS="$SCRIPT_DIR/match_protected_paths.sh"
 for h in "$PARSE_MANIFEST" "$MATCH_PATHS"; do
   if [ ! -f "$h" ]; then
-    echo "verify-propagation-pr.sh: missing trusted helper in mergepath checkout: $h" >&2
+    echo "verify-propagation-pr.sh: missing trusted in-repo helper alongside the verifier: $h" >&2
     exit 2
   fi
 done
@@ -114,7 +136,22 @@ fi
 
 # Files the PR changes (three-dot: changes since the merge-base, the
 # same range the External Review Check uses).
-CHANGED_FILES=$(git -C "$CONSUMER_DIR" diff --name-only "$BASE_SHA...$HEAD_SHA")
+#
+# #536: the lane is intentionally DIFF-SCOPED — it verifies that THIS
+# PR's changed files are a faithful mirror. Standing drift on already-
+# merged manifest paths OUTSIDE this PR's diff is the weekly drift
+# audit's job (scripts/audit-propagation-lane.sh checks every consumer's
+# live default branch), not the per-PR lane's. Re-verifying the full
+# canonical surface here would also false-fail consumers carrying a
+# legitimate .sync-overrides.yml exception on an unrelated path.
+#
+# #536: capture git's failure explicitly so an unresolved base/head (or
+# a non-work-tree CONSUMER_DIR) returns the documented exit 2 instead of
+# git's raw 128 escaping through `set -e`.
+if ! CHANGED_FILES=$(git -C "$CONSUMER_DIR" diff --name-only "$BASE_SHA...$HEAD_SHA" 2>/dev/null); then
+  echo "verify-propagation-pr.sh: could not compute the PR diff ($BASE_SHA...$HEAD_SHA in $CONSUMER_DIR) — unresolved base/head or not a git work tree" >&2
+  exit 2
+fi
 if [ -z "$CHANGED_FILES" ]; then
   echo "verify-propagation-pr.sh: PR has no changed files — nothing to verify" >&2
   exit 1
@@ -220,11 +257,13 @@ infer_consumer_from_pr_context() {
   return 1
 }
 
-# Source the template lib and facts helper from the TRUSTED mergepath
-# checkout. Same provenance rule as the parser helpers above — never
-# from the PR's working tree.
-TEMPLATE_LIB="$MERGEPATH_DIR/scripts/lib/template-substitution.sh"
-FACTS_HELPER="$MERGEPATH_DIR/scripts/lib/manifest-fact-helpers.sh"
+# #531: source the template lib + facts helper from THIS verifier's own
+# tree (the trusted in-repo copy alongside SCRIPT_DIR), NOT from the
+# runtime-cloned $MERGEPATH_DIR. The clone supplies only the template
+# SOURCE files (data, rendered by this trusted code) and the consumer
+# facts (read from the manifest text) — never executable shell.
+TEMPLATE_LIB="$SCRIPT_DIR/../lib/template-substitution.sh"
+FACTS_HELPER="$SCRIPT_DIR/../lib/manifest-fact-helpers.sh"
 
 # Only attempt the templated surface if both trusted helpers are
 # present in mergepath@<sha>. Missing helpers → fall through to the

--- a/tests/test_465_fail_closed.sh
+++ b/tests/test_465_fail_closed.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Structural regression guards for the #465 fail-open / early-clear fixes.
+# Structural regression guards for the #465 fail-open / early-clear fixes,
+# plus the #530 non-idempotent comment-POST and #548 checkout-hardening
+# invariants (cross-workflow, source-level assertions; propagation-safe via
+# the assert_grep/refute_grep SKIP-if-absent contract).
 #
 # The six defects span four YAML workflows and two shell scripts; the
 # workflow ones cannot be unit-executed without a full Actions runner, so
@@ -55,6 +58,13 @@ assert_grep "D3: auto-clear verifies label end-state (still_present)" \
   "$W/auto-clear-blocking-labels.yml" 'still_present'
 refute_grep "D3: auto-clear no longer retries the --remove-label write" \
   "$W/auto-clear-blocking-labels.yml" 'with_gh_retry gh pr edit "$PR" --repo "$REPO" --remove-label needs-external-review'
+# #530: the attribution-comment POST is non-idempotent (a retry after a
+# timeout-after-accept duplicates the comment), so it must NOT be retried;
+# the idempotent (name,head_sha) check-run POSTs stay wrapped.
+refute_grep "D3: auto-clear no longer retries the non-idempotent comment POST (#530)" \
+  "$W/auto-clear-blocking-labels.yml" 'with_gh_retry gh pr comment "$PR" --repo "$REPO" --body "$comment_body"'
+assert_grep "D3: auto-clear keeps check-run POSTs retried (idempotent name,head_sha) (#530)" \
+  "$W/auto-clear-blocking-labels.yml" 'with_gh_retry gh api "repos/$REPO/check-runs"'
 
 # Defect 4: codex-review-request re-scans at the deadline before emitting.
 assert_grep "D4: codex-review-request final scan at deadline" \
@@ -73,6 +83,73 @@ assert_grep "D6: codex-review-check tells 404 apart via HTTP status" \
   scripts/codex-review-check.sh 'HTTP 404'
 refute_grep "D6: codex-review-check dropped the unconditional skip-all-checks fail-open" \
   scripts/codex-review-check.sh 'Skipping required-check filter — all checks treated as passing this gate.'
+
+# Defect 7 (#548): every dispatchable-privileged checkout pins the trusted
+# default branch (blocks a manually-dispatched branch from running tampered
+# repo code under a privileged PAT), and checkouts with no authenticated-git
+# path drop the persisted checkout token (defense-in-depth).
+assert_grep "D7: weekly-feedback-sweep pins checkout ref (#548 Major)" \
+  "$W/weekly-feedback-sweep.yml" 'ref: ${{ github.event.repository.default_branch }}'
+assert_grep "D7: weekly-feedback-sweep drops the persisted checkout token (#548)" \
+  "$W/weekly-feedback-sweep.yml" 'persist-credentials: false'
+# Both checkouts (main sweep + the notify-on-failure job) must drop the token,
+# so the #548 invariant holds for the WHOLE file (Codex #550 P2 caught that the
+# failure-notify checkout was initially missed). Propagation-safe: skip if absent.
+if [ -f "$W/weekly-feedback-sweep.yml" ]; then
+  _wfs_pc=$(grep -c 'persist-credentials: false' "$W/weekly-feedback-sweep.yml")
+  if [ "$_wfs_pc" -ge 2 ]; then
+    pass "D7: weekly-feedback-sweep hardens BOTH checkouts (#548 / Codex #550)"
+  else
+    fail "D7: weekly-feedback-sweep both checkouts (#548): $_wfs_pc persist-credentials, expected >= 2"
+  fi
+else
+  echo "SKIP: D7 weekly-feedback-sweep both checkouts (absent)"; SKIP=$((SKIP + 1))
+fi
+assert_grep "D7: weekly-drift-audit pins checkout ref (#548)" \
+  "$W/weekly-drift-audit.yml" 'ref: ${{ github.event.repository.default_branch }}'
+assert_grep "D7: weekly-drift-audit drops the persisted checkout token (#548)" \
+  "$W/weekly-drift-audit.yml" 'persist-credentials: false'
+assert_grep "D7: pr-audit pins checkout ref (#548)" \
+  "$W/pr-audit.yml" 'ref: ${{ github.event.repository.default_branch }}'
+assert_grep "D7: onepassword-headless-proof pins checkout ref (#548)" \
+  "$W/onepassword-headless-proof.yml" 'ref: ${{ github.event.repository.default_branch }}'
+assert_grep "D7: pr-review-policy drops the persisted checkout token (#548)" \
+  "$W/pr-review-policy.yml" 'persist-credentials: false'
+# NB: repo_lint.yml is NOT a propagated path (it is consumer-local — each repo
+# runs its own lint), so this PROPAGATED suite must not assert its contents:
+# consumers have repo_lint.yml present-but-unsynced, which fails (not skips) the
+# grep. The canonical repo_lint persist-credentials (#548) stays in the file; it
+# just is not a fleet-wide invariant. Caught by the swipewatch sync canary #78.
+assert_grep "D7: pr-audit drops the persisted checkout token (#548)" \
+  "$W/pr-audit.yml" 'persist-credentials: false'
+assert_grep "D7: daily-feedback-rollup drops the persisted checkout token (#548 / Codex #550)" \
+  "$W/daily-feedback-rollup.yml" 'persist-credentials: false'
+# Completeness sweep (Codex #550): every cross-repo-PAT workflow drops the
+# persisted token on ALL its checkouts (gh-with-explicit-token only, no authed
+# git). Count-based so a regression of any one checkout is caught.
+if [ -f "$W/agent-review.yml" ]; then
+  _ar=$(grep -c 'persist-credentials: false' "$W/agent-review.yml")
+  if [ "$_ar" -ge 4 ]; then pass "D7: agent-review hardens all 4 checkouts (#550)"; else fail "D7: agent-review checkouts (#550): $_ar persist-credentials, expected >= 4"; fi
+else echo "SKIP: D7 agent-review (absent)"; SKIP=$((SKIP + 1)); fi
+if [ -f "$W/auto-clear-blocking-labels.yml" ]; then
+  _ac=$(grep -c 'persist-credentials: false' "$W/auto-clear-blocking-labels.yml")
+  if [ "$_ac" -ge 2 ]; then pass "D7: auto-clear hardens both checkouts (#550)"; else fail "D7: auto-clear checkouts (#550): $_ac persist-credentials, expected >= 2"; fi
+else echo "SKIP: D7 auto-clear (absent)"; SKIP=$((SKIP + 1)); fi
+
+# Defect 8 (#550 Codex P1): secret-bearing dispatchable workflows guard the JOB
+# on the default branch, so a non-default workflow_dispatch — which runs the
+# chosen ref's workflow DEFINITION, beyond the checkout pin's reach — cannot
+# leak the secret via a step added ahead of the pinned checkout.
+assert_grep "D8: onepassword-headless-proof guards dispatch to the default branch (#550)" \
+  "$W/onepassword-headless-proof.yml" 'if: github.ref_name == github.event.repository.default_branch'
+assert_grep "D8: weekly-feedback-sweep guards dispatch to the default branch (#550)" \
+  "$W/weekly-feedback-sweep.yml" 'if: github.ref_name == github.event.repository.default_branch'
+assert_grep "D8: weekly-drift-audit guards dispatch to the default branch (#550)" \
+  "$W/weekly-drift-audit.yml" 'if: github.ref_name == github.event.repository.default_branch'
+assert_grep "D8: pr-audit guards dispatch to the default branch (#550)" \
+  "$W/pr-audit.yml" 'if: github.ref_name == github.event.repository.default_branch'
+assert_grep "D8: daily-feedback-rollup guards dispatch to the default branch (#550 Codex)" \
+  "$W/daily-feedback-rollup.yml" 'if: github.ref_name == github.event.repository.default_branch'
 
 echo ""
 echo "test_465_fail_closed: $PASS passed, $FAIL failed, $SKIP skipped"

--- a/tests/test_audit_propagation_lane.sh
+++ b/tests/test_audit_propagation_lane.sh
@@ -196,6 +196,30 @@ else
   fail "#454: live mode should fail closed w/o a token; got rc=$RC, out: $OUT"
 fi
 
+# --- #521: token check ordered BEFORE manifest/yq prerequisites -----------
+# Run live mode from a directory with NO .mergepath-sync.yml and NO yq on
+# PATH, with no token. Pre-#521 the yq/manifest checks ran first and the
+# script exited 2 ("yq is required" / "manifest not found") — the WRONG
+# diagnostic when the real blocker is the absent reviewer token. After the
+# reorder, the token-presence check fires first → exit 3 + "reviewer token".
+NO_MANIFEST_DIR="$WORKDIR/no-manifest"; mkdir -p "$NO_MANIFEST_DIR"
+# Minimal PATH WITHOUT yq (and without the stub yq), so if the yq check ran
+# first it would exit 2. jq/coreutils from /usr/bin keep the script runnable
+# up to the token gate.
+NOYQ_PATH_521="/usr/bin:/bin:/usr/sbin:/sbin"
+set +e
+OUT=$( cd "$NO_MANIFEST_DIR" && PATH="$NOYQ_PATH_521" OP_PREFLIGHT_CACHE_DIR="$EMPTY_CACHE" \
+  MERGEPATH_AGENT="nobody-xyz" env -u GH_TOKEN "$SCRIPT" --repos __none__ 2>&1 )
+RC=$?
+set -e
+if [ "$RC" = "3" ] && echo "$OUT" | grep -qi "reviewer token" \
+   && ! echo "$OUT" | grep -qi "yq is required" \
+   && ! echo "$OUT" | grep -qi "not found"; then
+  pass "#521: missing token fails fast (exit 3) BEFORE the yq/manifest checks"
+else
+  fail "#521: token check should precede manifest/yq prereqs; got rc=$RC, out: $OUT"
+fi
+
 echo ""
 echo "test_audit_propagation_lane: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tests/test_check_no_bare_gh_writes.sh
+++ b/tests/test_check_no_bare_gh_writes.sh
@@ -62,6 +62,37 @@ assert_clean   "gh api GET not flagged"       'gh api repos/o/r/pulls/1 --jq .st
 assert_flagged "bare exemption marker rejected" 'gh pr merge 1 --squash  # NO_BARE_GH_WRITE_EXEMPT:'
 assert_clean   "exemption WITH reason honored"  'gh pr merge 1 --squash  # NO_BARE_GH_WRITE_EXEMPT: covered by gh-as-author in caller'
 
+# echo/printf substitution masking — the #533 gap. A gh WRITE hidden in an
+# echo/printf command substitution must still be CAUGHT (the prior exemption
+# only negative-checked gh pr|issue|api, so non-pr/issue/api write verbs and
+# gh api -X POST slipped through). Read-only / non-gh substitutions stay EXEMPT.
+assert_flagged "echo \$(gh repo create) caught"      'echo "$(gh repo create x)"'
+assert_flagged "printf \$(gh secret set) caught"     "printf '%s' \"\$(gh secret set X)\""
+assert_flagged "echo \$(gh variable set) caught"     'echo "$(gh variable set X)"'
+assert_flagged "echo backtick gh repo delete caught" 'echo `gh repo delete z`'
+assert_flagged "echo \$(gh api -X POST) caught"      'echo "$(gh api -X POST repos/o/r/x)"'
+# Regression (#540): a ) inside '...' or "..." within $() must NOT end
+# command-substitution extraction early — a gh write AFTER the quoted
+# paren is still caught (the prior walk closed the span on the quoted )).
+assert_flagged "quoted-paren in cmdsub before gh write caught" "echo \"\$(printf '%s' ')'; gh repo create x)\""
+# A bare gh label create (not inside echo) is — and stays — caught.
+assert_flagged "bare gh label create caught"         'gh label create urgent --color FF0000'
+# Controls: a read inside a substitution, and a non-gh substitution, stay exempt.
+assert_clean   "echo \$(gh pr view) stays exempt"    'echo "$(gh pr view 1)"'
+assert_clean   "echo \$(date) stays exempt"          'echo "$(date)"'
+# Control for the #540 regression: a quoted ) inside $() with NO gh write
+# stays exempt (the quote-aware walk must not over-flag).
+assert_clean   "quoted-paren in cmdsub, no gh write, exempt"  "echo \"\$(printf '%s' ')')\""
+# #540 P2 (4a review): a $( inside SINGLE quotes, or an escaped \$( in
+# double quotes, is a literal — bash runs no substitution — so an echo of
+# such help/example text must NOT be flagged as a write.
+assert_clean   "single-quoted dollar-paren literal exempt"   "echo '\$(gh repo create x)'"
+assert_clean   "escaped dollar-paren in dquotes exempt"      'echo "\$(gh repo create x)"'
+# Regression: a gh write spelled in echo TEXT but OUTSIDE the substitution
+# (e.g. a log line whose only substitution is $(date)) must stay exempt —
+# the masking fix must not over-match plain documentation text.
+assert_clean   "gh write text outside subst exempt"  'echo "$(date -u) create Project v2: gh project create --owner o --title t"'
+
 echo ""
 echo "test_check_no_bare_gh_writes: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/tests/test_check_propagation_closure.sh
+++ b/tests/test_check_propagation_closure.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# tests/test_check_propagation_closure.sh
+#
+# Unit tests for scripts/ci/check_propagation_closure — the INVERSE of
+# check_sync_manifest (the #519/#521 closure-completeness guard). The
+# live invocation in PR CI smoke-tests the real tree; this file targets
+# the detection logic against synthetic fixtures.
+#
+# Pattern matches tests/test_check_sync_manifest.sh — a fixture repo
+# tree (manifest + a propagated scripts/ci/check_* file + the
+# referenced files) written to a scratch dir, run via env override,
+# assert on exit code + diagnostic substring.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK="$ROOT/scripts/ci/check_propagation_closure"
+
+[[ -x "$CHECK" ]] || { echo "missing or non-executable $CHECK" >&2; exit 1; }
+command -v yq >/dev/null 2>&1 || { echo "SKIP: yq not available" >&2; exit 0; }
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/check-propagation-closure-test.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# Helper: build a fixture repo tree and run the check against it.
+#
+# Args:
+#   $1 = manifest YAML content (written to manifest.yml; pass "" to omit
+#        the manifest entirely, exercising the SKIP/FAIL marker logic)
+#   $2 = newline-separated repo-relative paths to materialize (files for
+#        non-trailing-slash entries, dirs for trailing-slash entries)
+#   $3 = OPTIONAL: "no-marker" to SKIP creating scripts/sync-to-downstream.sh
+#        (so a missing manifest reads as a consumer checkout). Default
+#        creates the marker (mergepath checkout).
+#
+# Every fixture gets scripts/sync-to-downstream.sh (the mergepath marker)
+# unless $3 == "no-marker", so the manifest-absent branch can be steered
+# to either SKIP (consumer) or FAIL (mergepath).
+run_with_fixture() {
+  local manifest_content="$1" paths="$2" marker_mode="${3:-marker}"
+  local fix
+  fix="$(mktemp -d "$WORKDIR/fix.XXXXXX")"
+
+  if [ "$marker_mode" != "no-marker" ]; then
+    mkdir -p "$fix/scripts"
+    : > "$fix/scripts/sync-to-downstream.sh"
+  fi
+
+  local manifest_arg=""
+  if [ -n "$manifest_content" ]; then
+    printf '%s' "$manifest_content" > "$fix/manifest.yml"
+    manifest_arg="$fix/manifest.yml"
+  else
+    # Point at a path that does not exist so the check's manifest-absent
+    # branch fires.
+    manifest_arg="$fix/does-not-exist.yml"
+  fi
+
+  while IFS= read -r p; do
+    [ -z "$p" ] && continue
+    case "$p" in
+      */) mkdir -p "$fix/$p" ;;
+      *)  mkdir -p "$(dirname "$fix/$p")"; : > "$fix/$p" ;;
+    esac
+  done <<< "$paths"
+
+  MERGEPATH_MANIFEST_PATH="$manifest_arg" MERGEPATH_REPO_ROOT="$fix" bash "$CHECK" 2>&1
+}
+
+# Baseline manifest header. scripts/ci/ is a kit (so the fixture's
+# check_* file is is_covered → scanned), and scripts/sync-to-downstream.sh
+# is declared so the marker file doesn't get flagged as an undeclared
+# self-... (it's the marker, not a scan target).
+MIN_HEADER='version: 1
+consumers:
+  - name: example
+    repo: example-org/example
+    visibility: public
+paths:
+  - path: scripts/ci/
+    type: kit
+    consumers: all'
+
+# A minimal propagated check_* body that references one test file. The
+# referenced path is parameterized per-case by writing the file content
+# inline in each case (run_with_fixture only touches empty stub files, so
+# we overwrite the check_* stub with real content after).
+#
+# To keep run_with_fixture simple, each case writes its own
+# scripts/ci/check_fixture file into the fixture AFTER the helper builds
+# the tree. We therefore use a lower-level driver for the ref cases.
+run_raw() {
+  # $1 = manifest content, $2 = paths to materialize, $3 = check_* body,
+  # $4 = relative path of the check file (default scripts/ci/check_fixture)
+  local manifest_content="$1" paths="$2" check_body="$3"
+  local check_rel="${4:-scripts/ci/check_fixture}"
+  local fix
+  fix="$(mktemp -d "$WORKDIR/fix.XXXXXX")"
+  mkdir -p "$fix/scripts"
+  : > "$fix/scripts/sync-to-downstream.sh"
+  printf '%s' "$manifest_content" > "$fix/manifest.yml"
+  while IFS= read -r p; do
+    [ -z "$p" ] && continue
+    case "$p" in
+      */) mkdir -p "$fix/$p" ;;
+      *)  mkdir -p "$(dirname "$fix/$p")"; : > "$fix/$p" ;;
+    esac
+  done <<< "$paths"
+  mkdir -p "$(dirname "$fix/$check_rel")"
+  printf '%s' "$check_body" > "$fix/$check_rel"
+  chmod +x "$fix/$check_rel"
+  MERGEPATH_MANIFEST_PATH="$fix/manifest.yml" MERGEPATH_REPO_ROOT="$fix" bash "$CHECK" 2>&1
+}
+
+CHECK_BODY_REFS_TEST='#!/usr/bin/env bash
+# fixture check that hard-runs a paired test
+bash tests/test_widget.sh
+'
+
+# --- Case (a): undeclared, on-disk, propagated ref → FAIL naming it ---
+# check_fixture (under the scripts/ci/ kit → propagated) references
+# tests/test_widget.sh, which exists on disk but is NOT in the manifest.
+MANIFEST_A="$MIN_HEADER"
+PATHS_A="scripts/ci/
+tests/test_widget.sh"
+set +e
+out=$(run_raw "$MANIFEST_A" "$PATHS_A" "$CHECK_BODY_REFS_TEST"); rc=$?
+set -e
+if [ "$rc" = "1" ] && echo "$out" | grep -q "references 'tests/test_widget.sh' but that path is NOT covered"; then
+  pass "Case (a): undeclared on-disk propagated ref fails closed naming the missing ref"
+else
+  fail "Case (a) unexpected (rc=$rc): $out"
+fi
+
+# --- Case (b): same ref but added to a requires: → PASS ---------------
+MANIFEST_B='version: 1
+consumers:
+  - name: example
+    repo: example-org/example
+    visibility: public
+paths:
+  - path: scripts/ci/
+    type: kit
+    consumers: all
+    requires:
+      - "tests/test_widget.sh"
+  - path: tests/test_widget.sh
+    type: canonical
+    consumers: all'
+PATHS_B="scripts/ci/
+tests/test_widget.sh"
+set +e
+out=$(run_raw "$MANIFEST_B" "$PATHS_B" "$CHECK_BODY_REFS_TEST"); rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "check_propagation_closure: PASS"; then
+  pass "Case (b): declaring the ref in requires: makes the check pass"
+else
+  fail "Case (b) unexpected (rc=$rc): $out"
+fi
+
+# --- Case (c): allow-listed ref (scripts/bootstrap/foo.sh) → PASS -----
+# The fixture check references an allow-listed orchestrator path that is
+# on disk but undeclared. The allow-list must exempt it.
+CHECK_BODY_BOOTSTRAP='#!/usr/bin/env bash
+bash scripts/bootstrap/foo.sh
+'
+MANIFEST_C="$MIN_HEADER"
+PATHS_C="scripts/ci/
+scripts/bootstrap/foo.sh"
+set +e
+out=$(run_raw "$MANIFEST_C" "$PATHS_C" "$CHECK_BODY_BOOTSTRAP"); rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "check_propagation_closure: PASS"; then
+  pass "Case (c): allow-listed orchestrator ref (scripts/bootstrap/foo.sh) is exempt and passes"
+else
+  fail "Case (c) unexpected (rc=$rc): $out"
+fi
+
+# --- Case (d): consumer checkout (no manifest, no marker) → SKIP ------
+set +e
+out=$(run_with_fixture "" "" "no-marker"); rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "check_propagation_closure: SKIP"; then
+  pass "Case (d): consumer checkout (no manifest, no marker) SKIPs with exit 0"
+else
+  fail "Case (d) unexpected (rc=$rc): $out"
+fi
+
+# --- Case (e): manifest absent but marker present → FAIL (mergepath) --
+# Guards against a blanket SKIP fail-open: a deleted/renamed manifest in
+# a mergepath checkout (marker present) must FAIL.
+set +e
+out=$(run_with_fixture "" "" "marker"); rc=$?
+set -e
+if [ "$rc" = "1" ] && echo "$out" | grep -q "manifest must not be deleted/renamed"; then
+  pass "Case (e): manifest-absent + marker-present (mergepath) fails closed"
+else
+  fail "Case (e) unexpected (rc=$rc): $out"
+fi
+
+# --- Case (f): undeclared ref that does NOT exist on disk → PASS ------
+# A reference to a path that is not a real file (fixture string, doc
+# example, assertion literal) is not a propagation dependency and must
+# NOT be flagged.
+CHECK_BODY_GHOST='#!/usr/bin/env bash
+# This is a doc example, not a real dependency:
+#   bash scripts/cinema/ghost.sh
+echo "ok"
+'
+MANIFEST_F="$MIN_HEADER"
+PATHS_F="scripts/ci/"
+set +e
+out=$(run_raw "$MANIFEST_F" "$PATHS_F" "$CHECK_BODY_GHOST"); rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "check_propagation_closure: PASS"; then
+  pass "Case (f): undeclared ref that does not exist on disk is not flagged (exists-on-disk filter)"
+else
+  fail "Case (f) unexpected (rc=$rc): $out"
+fi
+
+# --- Case (g): self-reference is skipped, not flagged -----------------
+# A propagated check that names its OWN .sh path must not flag itself:
+# the self-ref skip (`[ "$ref" = "$rel" ] && continue`) fires before the
+# coverage test. The body references its own rel path WITH a .sh
+# extension so the extractor actually emits it as a candidate — an
+# extensionless name is never emitted by the scripts/*.{sh,cjs,js}
+# matcher, so the earlier fixture exercised nothing. The scripts/ci/ kit
+# covers the file, so it is scanned and the self-ref branch is hit.
+# (The skip is belt-and-suspenders: a scan file is always is_covered, so
+# its self-ref would be covered anyway — but we want the branch
+# exercised and guarded against a future matcher that emits a file's own
+# path.)
+CHECK_BODY_SELF='#!/usr/bin/env bash
+# scripts/ci/check_selfref.sh enumerates ... (names its own path)
+echo "scripts/ci/check_selfref.sh"
+'
+MANIFEST_G="$MIN_HEADER"
+PATHS_G="scripts/ci/"
+set +e
+out=$(run_raw "$MANIFEST_G" "$PATHS_G" "$CHECK_BODY_SELF" "scripts/ci/check_selfref.sh"); rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "check_propagation_closure: PASS"; then
+  pass "Case (g): a propagated check naming its own .sh path is self-ref-skipped (no false positive)"
+else
+  fail "Case (g) unexpected (rc=$rc): $out"
+fi
+
+# --- Case (h): a NON-propagated check_* (not under a kit) is NOT ------
+# scanned. If check_fixture is NOT covered by the manifest, its
+# undeclared on-disk ref must not be flagged (only propagated files are
+# scanned — an unpropagated check can't leak a dependency to a consumer).
+MANIFEST_H='version: 1
+consumers:
+  - name: example
+    repo: example-org/example
+    visibility: public
+paths:
+  - path: scripts/op-preflight.sh
+    type: canonical
+    consumers: all'
+# No scripts/ci/ kit → check_fixture is not covered → not scanned.
+PATHS_H="scripts/op-preflight.sh
+tests/test_widget.sh"
+set +e
+out=$(run_raw "$MANIFEST_H" "$PATHS_H" "$CHECK_BODY_REFS_TEST"); rc=$?
+set -e
+if [ "$rc" = "0" ] && echo "$out" | grep -q "check_propagation_closure: PASS"; then
+  pass "Case (h): a non-propagated check_* is not scanned (no false positive on its refs)"
+else
+  fail "Case (h) unexpected (rc=$rc): $out"
+fi
+
+# --- Case (i): an EXACT-manifest workflow with an undeclared on-disk --
+# script ref → FAIL. Workflows are scanned when they are exact manifest
+# entries (canonical propagation).
+WORKFLOW_BODY='name: fixture
+on: [push]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - run: bash scripts/helper.sh
+'
+MANIFEST_I='version: 1
+consumers:
+  - name: example
+    repo: example-org/example
+    visibility: public
+paths:
+  - path: .github/workflows/fixture.yml
+    type: canonical
+    consumers: all'
+PATHS_I=".github/workflows/fixture.yml
+scripts/helper.sh"
+# Write the workflow as the "check body" at the workflow path.
+set +e
+out=$(run_raw "$MANIFEST_I" "$PATHS_I" "$WORKFLOW_BODY" ".github/workflows/fixture.yml"); rc=$?
+set -e
+if [ "$rc" = "1" ] && echo "$out" | grep -q "references 'scripts/helper.sh' but that path is NOT covered"; then
+  pass "Case (i): exact-manifest workflow with undeclared on-disk script ref fails closed"
+else
+  fail "Case (i) unexpected (rc=$rc): $out"
+fi
+
+# --- Case (j): a propagated workflow referencing an UNDECLARED ---------
+# scripts/workflow/ helper must FAIL. The previously-broad
+# `scripts/workflow/*` allow-list masked exactly this gap
+# (nathanpayne-codex Phase-4b finding on #543): scripts/workflow/ is a
+# kit, so a helper that genuinely travels is covered by is_covered; an
+# undeclared one is the closure gap this check exists to catch.
+WORKFLOW_BODY_J='name: fixture
+on: [pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: bash scripts/workflow/parse_policy_list.sh .github/review-policy.yml available_reviewers
+'
+MANIFEST_J='version: 1
+consumers:
+  - name: example
+    repo: example-org/example
+    visibility: public
+paths:
+  - path: .github/workflows/pr-review-policy.yml
+    type: canonical
+    consumers: all'
+PATHS_J=".github/workflows/pr-review-policy.yml
+scripts/workflow/parse_policy_list.sh"
+set +e
+out=$(run_raw "$MANIFEST_J" "$PATHS_J" "$WORKFLOW_BODY_J" ".github/workflows/pr-review-policy.yml"); rc=$?
+set -e
+if [ "$rc" = "1" ] && echo "$out" | grep -q "references 'scripts/workflow/parse_policy_list.sh' but that path is NOT covered"; then
+  pass "Case (j): undeclared scripts/workflow/ helper ref in a propagated workflow fails closed (#543)"
+else
+  fail "Case (j) unexpected (rc=$rc): $out"
+fi
+
+echo
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -gt 0 ]; then
+  echo "test_check_propagation_closure: FAIL ($FAIL/$TOTAL failed)"
+  exit 1
+fi
+echo "test_check_propagation_closure: PASS ($TOTAL tests)"
+exit 0

--- a/tests/test_coderabbit_automerge_rate_limit_gate.sh
+++ b/tests/test_coderabbit_automerge_rate_limit_gate.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Regression coverage for scripts/coderabbit-automerge-rate-limit-gate.sh (#489)
+# — the auto-merge workflow's decision on whether a CodeRabbit rate-limit stall
+# (coderabbit-wait.sh exit 5) blocks or proceeds. PROCEED requires BOTH the
+# Codex failover engaged AND the PR being above the external-review threshold
+# (where merge-clearance gates Codex). Under-threshold stalls keep blocking
+# (Codex P2 on #512 r3). Verifies the engaged×threshold matrix + fail-closed
+# edges the Phase-4b reviewer asked for.
+#
+# Bash 3.2 portable.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GATE="$ROOT/scripts/coderabbit-automerge-rate-limit-gate.sh"
+
+[ -x "$GATE" ] || { echo "missing or non-executable $GATE" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq not available" >&2; exit 0; }
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# assert_rc <desc> <expected-rc> <gate-args...>
+assert_rc() {
+  local desc=$1 want=$2; shift 2
+  local rc=0
+  bash "$GATE" "$@" >/dev/null 2>&1 || rc=$?
+  if [ "$rc" -eq "$want" ]; then pass "$desc"; else fail "$desc (expected rc $want, got $rc)"; fi
+}
+
+ENGAGED='{"status":"rate_limit_stalled","codex_failover_requested":true}'
+NOT_ENGAGED='{"status":"rate_limit_stalled","codex_failover_requested":false}'
+
+# --- the core engaged × threshold matrix ---
+assert_rc "engaged + above-threshold → proceed" 0 "$ENGAGED" true
+assert_rc "engaged + under-threshold → block (#512 r3: no downstream Codex gate)" 1 "$ENGAGED" false
+assert_rc "not engaged + above-threshold → block" 1 "$NOT_ENGAGED" true
+assert_rc "not engaged + under-threshold → block" 1 "$NOT_ENGAGED" false
+
+# --- fail-closed edges ---
+assert_rc "engaged + missing threshold arg → block (fail-closed)" 1 "$ENGAGED"
+assert_rc "missing codex_failover_requested + above-threshold → block (fail-closed)" 1 \
+  '{"status":"rate_limit_stalled"}' true
+assert_rc "unparseable JSON + above-threshold → block (fail-closed)" 1 'not json at all' true
+assert_rc "empty JSON arg + above-threshold → block (fail-closed)" 1 '' true
+assert_rc "no arguments → block (fail-closed)" 1
+
+# --- a realistic full payload ---
+assert_rc "full rate_limit_stalled payload, engaged + above-threshold → proceed" 0 \
+  '{"pr_number":1,"status":"rate_limit_stalled","rate_limit_retries":2,"codex_failover_requested":true,"waited_seconds":120}' true
+assert_rc "full payload, engaged + under-threshold → block" 1 \
+  '{"pr_number":1,"status":"rate_limit_stalled","rate_limit_retries":2,"codex_failover_requested":true,"waited_seconds":120}' false
+
+echo "----"
+echo "test_coderabbit_automerge_rate_limit_gate: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/test_coderabbit_wait_codex_failover.sh
+++ b/tests/test_coderabbit_wait_codex_failover.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# Regression coverage for coderabbit-wait.sh's CodeRabbit→Codex rate-limit
+# failover (#489).
+#
+# Runs the real helper from a temp repo with stubbed gh/date/sleep and a stub
+# codex-review-request.sh (wired via CODERABBIT_WAIT_CODEX_REQUEST_CMD), so the
+# rate-limit path is deterministic and makes no GitHub writes. Verifies:
+#   - On a rate-limit notice with the knob ON, the helper invokes the Codex
+#     request helper ONCE in --trigger-only mode with MERGEPATH_PHASE_4A_GATED
+#     and surfaces codex_failover_requested:true in the JSON.
+#   - With the knob OFF (codex_failover_on_rate_limit: false), it does NOT.
+#   - When the Codex helper no-ops (exit 5, e.g. codex.enabled:false), the
+#     failover stays unrecorded (codex_failover_requested:false).
+#   - The failover is idempotent across a multi-retry run (FIRED latch): a
+#     single trigger even when the loop keeps polling the same rate-limit NOTE.
+#
+# Bash 3.2 portable. Mirrors the harness shape of
+# tests/test_coderabbit_wait_status_probe.sh.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/coderabbit-wait-codex-failover.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# make_case <name> <max_wait> <max_retries> <failover>
+make_case() {
+  local name=$1 max_wait=$2 max_retries=$3 failover=$4
+  local dir="$WORKDIR/$name"
+
+  mkdir -p "$dir/scripts/lib" "$dir/.github" "$dir/bin" "$dir/state"
+  cp "$ROOT/scripts/coderabbit-wait.sh" "$dir/scripts/coderabbit-wait.sh"
+  cp "$ROOT/scripts/lib/gh-token-resolver.sh" "$dir/scripts/lib/gh-token-resolver.sh"
+  cp "$ROOT/scripts/lib/reviewers-helpers.sh" "$dir/scripts/lib/reviewers-helpers.sh"
+  chmod +x "$dir/scripts/coderabbit-wait.sh"
+
+  cat >"$dir/.github/review-policy.yml" <<EOF
+coderabbit:
+  bot_login: "coderabbitai[bot]"
+  max_wait_seconds: $max_wait
+  status_probe_enabled: false
+  status_probe_wait_seconds: 0
+  max_rate_limit_retries: $max_retries
+  codex_failover_on_rate_limit: $failover
+  wallclock_freshness_window_seconds: 999999999
+  trust_status_context_for_clearance: false
+EOF
+
+  cat >"$dir/bin/date" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+state_dir=${CODERABBIT_TEST_STATE_DIR:?}
+clock_file="$state_dir/fake-time"
+[ -f "$clock_file" ] || printf '2000000000\n' >"$clock_file"
+if [ "$#" -eq 1 ] && [ "$1" = "+%s" ]; then cat "$clock_file"; exit 0; fi
+exec /bin/date "$@"
+EOF
+  chmod +x "$dir/bin/date"
+
+  cat >"$dir/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+state_dir=${CODERABBIT_TEST_STATE_DIR:?}
+clock_file="$state_dir/fake-time"
+[ -f "$clock_file" ] || printf '2000000000\n' >"$clock_file"
+duration=${1:-0}
+case "$duration" in *.*) duration=${duration%%.*} ;; esac
+current=$(cat "$clock_file")
+printf '%s\n' $((current + duration)) >"$clock_file"
+EOF
+  chmod +x "$dir/bin/sleep"
+
+  # gh stub: serves the endpoints coderabbit-wait.sh hits on the rate-limit
+  # path. issues/999/comments returns a persistent "Rate limit exceeded" NOTE
+  # (same id 7701 every call), so a multi-retry run loops on the same NOTE
+  # after the first detection — exactly the shape that must fire the failover
+  # only once. POST to issues/999/comments (the `@coderabbitai, try again.`
+  # retry trigger) is accepted and ignored.
+  cat >"$dir/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+bot='coderabbitai[bot]'
+head_time='2026-06-04T00:00:00Z'
+[ "${1:-}" = "api" ] || { echo "unexpected gh command: $*" >&2; exit 99; }
+shift
+method="GET"
+if [ "${1:-}" = "--method" ]; then method=${2:-}; shift 2; fi
+if [ "${1:-}" = "--paginate" ]; then shift; fi
+endpoint=${1:-}; shift || true
+if [ "$method" = "POST" ]; then
+  case "$endpoint" in
+    repos/owner/repo/issues/999/comments)
+      printf '{"id":9001,"created_at":"%s","body":"ack"}\n' "$head_time" ;;
+    *) echo "unexpected gh api POST endpoint: $endpoint" >&2; exit 99 ;;
+  esac
+  exit 0
+fi
+case "$endpoint" in
+  repos/owner/repo/pulls/999) printf '{"head":{"sha":"head-sha"}}\n' ;;
+  repos/owner/repo/commits/head-sha)
+    if [ "${1:-}" = "--jq" ]; then printf '%s\n' "$head_time"
+    else printf '{"commit":{"committer":{"date":"%s"}}}\n' "$head_time"; fi ;;
+  repos/owner/repo/issues/999/timeline) printf '[]\n' ;;
+  repos/owner/repo/pulls/999/reviews) printf '[]\n' ;;
+  repos/owner/repo/pulls/999/comments) printf '[]\n' ;;
+  repos/owner/repo/issues/999/comments)
+    printf '[{"id":7701,"user":{"login":"%s"},"created_at":"%s","updated_at":"%s","body":"Rate limit exceeded. Please wait 10 seconds before requesting another review."}]\n' "$bot" "$head_time" "$head_time" ;;
+  *) echo "unexpected gh api endpoint: $endpoint" >&2; exit 99 ;;
+esac
+EOF
+  chmod +x "$dir/bin/gh"
+
+  # Stub Codex request helper. Records each invocation (args + the
+  # MERGEPATH_PHASE_4A_GATED env it was called with) to a log, emits the
+  # documented trigger-only JSON, and exits CODEX_STUB_EXIT (0 = posted,
+  # 5 = NO_TRIGGER_REQUESTED, i.e. Codex disabled / opted out).
+  cat >"$dir/bin/codex-request-stub.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'phase4a=%s args=[%s]\n' "${MERGEPATH_PHASE_4A_GATED:-unset}" "$*" >>"${CODEX_STUB_LOG:?}"
+echo '{"trigger_only":true,"trigger_posted":true,"trigger_requested":true}'
+exit "${CODEX_STUB_EXIT:-0}"
+EOF
+  chmod +x "$dir/bin/codex-request-stub.sh"
+
+  printf '%s\n' "$dir"
+}
+
+# run_case <dir> <stub_exit>
+run_case() {
+  local dir=$1 stub_exit=${2:-0} rc=0
+  (
+    cd "$dir"
+    PATH="$dir/bin:$PATH" \
+      GH_TOKEN=test-token \
+      CODERABBIT_WAIT_SKIP_IDENTITY_CHECK=1 \
+      CODERABBIT_TEST_STATE_DIR="$dir/state" \
+      CODERABBIT_WAIT_CODEX_REQUEST_CMD="$dir/bin/codex-request-stub.sh" \
+      CODEX_STUB_LOG="$dir/state/codex-stub.log" \
+      CODEX_STUB_EXIT="$stub_exit" \
+      ./scripts/coderabbit-wait.sh 999 owner/repo \
+      >"$dir/out.json" 2>"$dir/err.log"
+  ) || rc=$?
+  printf '%s\n' "$rc"
+}
+
+stub_calls() {
+  local dir=$1
+  if [ -f "$dir/state/codex-stub.log" ]; then wc -l <"$dir/state/codex-stub.log" | tr -d ' '
+  else printf '0\n'; fi
+}
+
+jqf() { jq -r "$2" "$1/out.json"; }
+
+# --- Test A: knob ON → failover fires once, exit 5, requested:true ----------
+test_failover_fires() {
+  local dir rc before=$FAIL
+  dir=$(make_case "fires" 300 0 true)
+  rc=$(run_case "$dir" 0)
+  [ "$rc" = "5" ] || fail "A: expected exit 5 (rate_limit_stalled), got $rc; err=$(cat "$dir/err.log")"
+  [ "$(jqf "$dir" '.status')" = "rate_limit_stalled" ] || fail "A: status=$(jqf "$dir" '.status'), expected rate_limit_stalled"
+  [ "$(jqf "$dir" '.codex_failover_requested')" = "true" ] || fail "A: codex_failover_requested=$(jqf "$dir" '.codex_failover_requested'), expected true"
+  [ "$(stub_calls "$dir")" = "1" ] || fail "A: Codex helper invoked $(stub_calls "$dir") time(s), expected 1"
+  grep -q -- '--trigger-only' "$dir/state/codex-stub.log" || fail "A: Codex helper not called with --trigger-only; log=$(cat "$dir/state/codex-stub.log")"
+  grep -q 'phase4a=true' "$dir/state/codex-stub.log" || fail "A: MERGEPATH_PHASE_4A_GATED not set true; log=$(cat "$dir/state/codex-stub.log")"
+  grep -q '999' "$dir/state/codex-stub.log" || fail "A: PR number not forwarded; log=$(cat "$dir/state/codex-stub.log")"
+  [ "$FAIL" -ne "$before" ] || pass "A: rate-limit fires Codex failover once (--trigger-only, phase4a, PR#) → exit 5, requested:true"
+}
+
+# --- Test B: knob OFF → no failover, requested:false ------------------------
+test_failover_opt_out() {
+  local dir rc before=$FAIL
+  dir=$(make_case "optout" 300 0 false)
+  rc=$(run_case "$dir" 0)
+  [ "$rc" = "5" ] || fail "B: expected exit 5, got $rc; err=$(cat "$dir/err.log")"
+  [ "$(jqf "$dir" '.codex_failover_requested')" = "false" ] || fail "B: codex_failover_requested=$(jqf "$dir" '.codex_failover_requested'), expected false"
+  [ "$(stub_calls "$dir")" = "0" ] || fail "B: Codex helper invoked $(stub_calls "$dir") time(s) with knob off, expected 0"
+  [ "$FAIL" -ne "$before" ] || pass "B: codex_failover_on_rate_limit:false suppresses the failover"
+}
+
+# --- Test C: Codex helper no-ops (exit 5) → requested:false -----------------
+test_failover_codex_disabled() {
+  local dir rc before=$FAIL
+  dir=$(make_case "codexoff" 300 0 true)
+  rc=$(run_case "$dir" 5)   # stub exits 5 = NO_TRIGGER_REQUESTED
+  [ "$rc" = "5" ] || fail "C: expected exit 5, got $rc; err=$(cat "$dir/err.log")"
+  [ "$(stub_calls "$dir")" = "1" ] || fail "C: Codex helper invoked $(stub_calls "$dir") time(s), expected 1 (attempted)"
+  [ "$(jqf "$dir" '.codex_failover_requested')" = "false" ] || fail "C: codex_failover_requested=$(jqf "$dir" '.codex_failover_requested'), expected false (helper no-op)"
+  [ "$FAIL" -ne "$before" ] || pass "C: helper exit 5 (Codex disabled) leaves codex_failover_requested:false"
+}
+
+# --- Test D: idempotent across a multi-retry run (FIRED latch) --------------
+test_failover_idempotent_across_retries() {
+  local dir rc before=$FAIL
+  # max_retries=2 + a persistent same-id rate-limit NOTE: iteration 1 detects
+  # the NOTE (fires the failover, posts a retry trigger, sleeps the window via
+  # the fake clock), later iterations see the SAME comment id and just poll
+  # until the max_wait budget elapses (exit 4). The failover must fire once.
+  dir=$(make_case "idempotent" 300 2 true)
+  rc=$(run_case "$dir" 0)
+  [ "$rc" = "4" ] || fail "D: expected exit 4 (timeout on persistent NOTE), got $rc; err=$(tail -3 "$dir/err.log")"
+  [ "$(stub_calls "$dir")" = "1" ] || fail "D: Codex helper invoked $(stub_calls "$dir") time(s) across the run, expected exactly 1 (latch)"
+  [ "$(jqf "$dir" '.codex_failover_requested')" = "true" ] || fail "D: codex_failover_requested=$(jqf "$dir" '.codex_failover_requested'), expected true"
+  [ "$FAIL" -ne "$before" ] || pass "D: failover fires exactly once across a multi-poll run (idempotent FIRED latch)"
+}
+
+test_failover_fires
+test_failover_opt_out
+test_failover_codex_disabled
+test_failover_idempotent_across_retries
+
+echo "----"
+echo "test_coderabbit_wait_codex_failover: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/test_coderabbit_wait_status_probe.sh
+++ b/tests/test_coderabbit_wait_status_probe.sh
@@ -182,10 +182,22 @@ case "$endpoint" in
           count=$(cat "$state_dir/probe-count")
         fi
         if [ "$count" -gt 0 ] && [ "$(fake_now)" -ge 2000000006 ]; then
-          printf '[{"id":9901,"user":{"login":"%s"},"submitted_at":"%s"}]\n' "$bot" "$reply_time"
+          printf '[{"id":9901,"user":{"login":"%s"},"submitted_at":"%s","commit_id":"head-sha"}]\n' "$bot" "$reply_time"
         else
           printf '[]\n'
         fi
+        ;;
+      summary_marker_only)
+        # #535.1: one CodeRabbit review on HEAD, no inline findings, but the
+        # PR-level summary body carries a Potential issue marker.
+        printf '[{"id":9921,"user":{"login":"%s"},"submitted_at":"%s","commit_id":"head-sha"}]\n' "$bot" "$head_time"
+        ;;
+      intermediate_review_head_pin)
+        # #535.2: a NEWER review (later submitted_at) references an
+        # intermediate commit, while the HEAD review is older. The
+        # HEAD-pinned selection must pick the HEAD review (9931), not the
+        # newer intermediate one (9932).
+        printf '[{"id":9931,"user":{"login":"%s"},"submitted_at":"%s","commit_id":"head-sha"},{"id":9932,"user":{"login":"%s"},"submitted_at":"%s","commit_id":"intermediate-sha"}]\n' "$bot" "$head_time" "$bot" "$reply_time"
         ;;
       *)
         printf '[]\n'
@@ -204,6 +216,17 @@ case "$endpoint" in
         else
           printf '[]\n'
         fi
+        ;;
+      summary_marker_only)
+        # #535.1: no inline findings at all — the marker lives only in the
+        # PR-level summary body (issues endpoint below).
+        printf '[]\n'
+        ;;
+      intermediate_review_head_pin)
+        # #535.2: the ⚠️ inline finding is tied to the HEAD review (9931).
+        # The newer intermediate review (9932) has no inline findings, so
+        # selecting it (the pre-fix freshness-only behavior) would clear.
+        printf '[{"id":9933,"user":{"login":"%s"},"created_at":"%s","updated_at":"%s","commit_id":"head-sha","pull_request_review_id":9931,"in_reply_to_id":null,"body":"_⚠️ Potential issue_ | _🟠 Major_\\n\\nFinding on the HEAD review."}]\n' "$bot" "$head_time" "$head_time"
         ;;
       *)
         printf '[]\n'
@@ -239,6 +262,19 @@ case "$endpoint" in
         else
           printf '[]\n'
         fi
+        ;;
+      summary_marker_only)
+        # #535.1: latest PR-level summary classifies as a review (not a
+        # rate-limit/paused/in-progress/status-probe narration) and carries a
+        # Potential issue marker in its body. The inline count is 0, so the
+        # gate must rely on this summary-body marker to emit findings.
+        printf '[{"id":8821,"user":{"login":"%s"},"created_at":"%s","updated_at":"%s","body":"**Actionable comments posted: 1**\\n\\n<details>\\n<summary>foo.sh (1)</summary>\\n\\n_⚠️ Potential issue_\\n\\nThis only appears in the summary body."}]\n' "$bot" "$head_time" "$head_time"
+        ;;
+      intermediate_review_head_pin)
+        # #535.2: a plain review-completed summary with NO Potential issue
+        # marker, so clearance is decided purely by the HEAD-pinned inline
+        # count (which finds the finding on the HEAD review).
+        printf '[{"id":8831,"user":{"login":"%s"},"created_at":"%s","updated_at":"%s","body":"**Actionable comments posted: 1**\\n\\nSee inline findings on the latest HEAD review."}]\n' "$bot" "$head_time" "$head_time"
         ;;
       reply_poll_failure)
         count=0
@@ -462,6 +498,66 @@ test_review_during_probe_wait_emits_findings() {
   fi
 }
 
+# #535.1: the findings gate must also honor a PR-level summary-body marker.
+# A CodeRabbit review on HEAD with ZERO inline findings but a "Potential
+# issue"/⚠️ marker in its PR-level summary body must emit findings (exit 2),
+# not false-clear. Pre-fix this cleared (exit 0) because count_potential_
+# issues scans only the inline pulls/{pr}/comments list. max_wait is large
+# so the first poll reaches the in-loop `review)` arm before any timeout.
+test_535_1_summary_body_marker_emits_findings() {
+  local dir rc status potential review_endpoint
+  dir=$(make_case "summary-marker-only" 600 false 0 2)
+  rc=$(run_case "$dir" summary_marker_only)
+  if [ "$rc" != "2" ]; then
+    fail "#535.1 summary-body marker: exit $rc, expected findings 2; stderr=$(cat "$dir/err.log")"
+    return
+  elif [ ! -s "$dir/out.json" ]; then
+    fail "#535.1 summary-body marker: missing findings JSON output; stderr=$(cat "$dir/err.log")"
+    return
+  fi
+  status=$(jq -r '.status' "$dir/out.json")
+  potential=$(jq -r '.potential_issue_count' "$dir/out.json")
+  review_endpoint=$(jq -r '.review.endpoint' "$dir/out.json")
+  if [ "$status" != "findings" ]; then
+    fail "#535.1 summary-body marker: status=$status, expected findings"
+  elif [ "$potential" != "0" ]; then
+    fail "#535.1 summary-body marker: potential_issue_count=$potential, expected 0 (marker is summary-only, inline count is 0)"
+  elif [ "$review_endpoint" != "issues" ]; then
+    fail "#535.1 summary-body marker: review.endpoint=$review_endpoint, expected issues"
+  else
+    pass "#535.1: PR-level summary-body Potential issue/⚠️ marker yields findings even with 0 inline findings"
+  fi
+}
+
+# #535.2: latest-review selection must be pinned to the HEAD commit, not just
+# freshness. A NEWER review (later submitted_at) that references an
+# intermediate commit must not be chosen over the HEAD review. Here the HEAD
+# review carries the only ⚠️ inline finding; the newer intermediate review
+# has none. Pre-fix (freshness-only `submitted_at >= anchor`) selected the
+# intermediate review and cleared (exit 0); with the commit_id == HEAD_SHA
+# pin the HEAD review is selected and the finding is counted (exit 2).
+test_535_2_head_pinned_review_selection_emits_findings() {
+  local dir rc status potential
+  dir=$(make_case "intermediate-review-head-pin" 600 false 0 2)
+  rc=$(run_case "$dir" intermediate_review_head_pin)
+  if [ "$rc" != "2" ]; then
+    fail "#535.2 head-pinned review: exit $rc, expected findings 2; stderr=$(cat "$dir/err.log")"
+    return
+  elif [ ! -s "$dir/out.json" ]; then
+    fail "#535.2 head-pinned review: missing findings JSON output; stderr=$(cat "$dir/err.log")"
+    return
+  fi
+  status=$(jq -r '.status' "$dir/out.json")
+  potential=$(jq -r '.potential_issue_count' "$dir/out.json")
+  if [ "$status" != "findings" ]; then
+    fail "#535.2 head-pinned review: status=$status, expected findings (HEAD review's inline finding must count)"
+  elif [ "$potential" != "1" ]; then
+    fail "#535.2 head-pinned review: potential_issue_count=$potential, expected 1"
+  else
+    pass "#535.2: latest-review selection pins to HEAD commit; a newer intermediate-commit review does not shadow the HEAD finding"
+  fi
+}
+
 # #446: fast-path StatusContext clearance race. A NEWER rate-limit/
 # in-progress comment than the StatusContext success must suppress the
 # fast-path EVEN WHEN it does not reference the current HEAD — otherwise the
@@ -516,6 +612,8 @@ test_rate_limit_stalled_does_not_probe
 test_probe_post_failure_stays_timeout_advisory
 test_probe_reply_poll_failure_stays_timeout_advisory
 test_review_during_probe_wait_emits_findings
+test_535_1_summary_body_marker_emits_findings
+test_535_2_head_pinned_review_selection_emits_findings
 
 echo
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/test_gh_as_reviewer.sh
+++ b/tests/test_gh_as_reviewer.sh
@@ -74,9 +74,11 @@ reset_log() {
 }
 
 reset_log
+set +e
 OP_PREFLIGHT_REVIEWER_PAT="reviewer-token" GITHUB_TOKEN="ambient-token" \
   run_wrapper -- gh pr review 123 --comment --body "ok" >/dev/null 2>&1
 rc=$?
+set -e
 if [ "$rc" -ne 0 ]; then
   fail "review happy path: rc=$rc"
 elif grep -q $'gh\tauth\tswitch' "$WORKDIR/calls.log"; then
@@ -89,9 +91,11 @@ else
 fi
 
 reset_log
+set +e
 MERGEPATH_AGENT=codex OP_PREFLIGHT_REVIEWER_PAT="codex-token" \
   run_wrapper -- gh issue comment 7 --body "thanks" >/dev/null 2>&1
 rc=$?
+set -e
 if [ "$rc" -ne 0 ]; then
   fail "MERGEPATH_AGENT fallback: rc=$rc"
 elif ! grep -q $'GH_TOKEN=codex-token GITHUB_TOKEN= gh\tissue\tcomment\t7' "$WORKDIR/calls.log"; then
@@ -102,9 +106,11 @@ else
 fi
 
 reset_log
+set +e
 OP_PREFLIGHT_AGENT=codex OP_PREFLIGHT_REVIEWER_PAT="codex-token" \
   run_wrapper -- gh issue comment 8 --body "thanks" >/dev/null 2>&1
 rc=$?
+set -e
 if [ "$rc" -ne 0 ]; then
   fail "OP_PREFLIGHT_AGENT fallback: rc=$rc"
 elif ! grep -q $'GH_TOKEN=codex-token GITHUB_TOKEN= gh\tissue\tcomment\t8' "$WORKDIR/calls.log"; then
@@ -115,9 +121,11 @@ else
 fi
 
 reset_log
+set +e
 GH_AS_REVIEWER_IDENTITY=nathanpayne-codex OP_PREFLIGHT_REVIEWER_PAT="codex-token" \
   run_wrapper -- gh pr comment 123 --body "ping" >/dev/null 2>&1
 rc=$?
+set -e
 if [ "$rc" -ne 0 ]; then
   fail "explicit identity: rc=$rc"
 elif ! grep -q $'GH_TOKEN=codex-token GITHUB_TOKEN= gh\tpr\tcomment\t123' "$WORKDIR/calls.log"; then
@@ -129,8 +137,10 @@ fi
 
 reset_log
 unset OP_PREFLIGHT_REVIEWER_PAT
+set +e
 run_wrapper -- gh pr review 123 --comment --body "ok" >/dev/null 2>&1
 rc=$?
+set -e
 if [ "$rc" -ne 0 ]; then
   fail "fallback token: rc=$rc"
 elif ! grep -q $'GH_TOKEN=fallback-claude-token GITHUB_TOKEN= gh\tpr\treview' "$WORKDIR/calls.log"; then
@@ -153,6 +163,62 @@ elif grep -q $'gh\tpr\treview' "$WORKDIR/calls.log"; then
 else
   pass "wrong preferred token: fails before wrapped write"
 fi
+
+# --- ambient GH_TOKEN candidate (#533) --------------------------------
+# A verified ambient GH_TOKEN (no OP_PREFLIGHT_*, picked up before the
+# keyring fallback) must be used directly. reviewer-token verifies as
+# nathanpayne-claude (the default reviewer). We assert the wrapped write
+# ran with the AMBIENT token value, NOT the keyring's fallback-claude-token
+# — proving candidate 2 won, not candidate 3.
+reset_log
+unset OP_PREFLIGHT_REVIEWER_PAT
+set +e
+GH_TOKEN="reviewer-token" run_wrapper -- gh pr review 123 --comment --body "ok" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -ne 0 ]; then
+  fail "ambient token verified: rc=$rc"
+elif grep -q $'gh\tauth\tswitch' "$WORKDIR/calls.log"; then
+  fail "ambient token verified: called gh auth switch"
+elif ! grep -q $'GH_TOKEN=reviewer-token GITHUB_TOKEN= gh\tpr\treview\t123\t--comment' "$WORKDIR/calls.log"; then
+  fail "ambient token verified: wrapped write did not run with the ambient token"
+  cat "$WORKDIR/calls.log" >&2
+elif grep -q "fallback-claude-token" "$WORKDIR/calls.log"; then
+  fail "ambient token verified: fell through to keyring despite a usable ambient token"
+  cat "$WORKDIR/calls.log" >&2
+else
+  pass "ambient token verified: a usable ambient GH_TOKEN is used before the keyring fallback"
+fi
+
+# An ambient GH_TOKEN that verifies to the WRONG identity must be rejected
+# and fall through to the keyring fallback — never blindly trusted.
+# author-token verifies as nathanjohnpayne (wrong for reviewer
+# nathanpayne-claude); the keyring then yields fallback-claude-token.
+reset_log
+unset OP_PREFLIGHT_REVIEWER_PAT
+set +e
+err=$(GH_TOKEN="author-token" run_wrapper -- gh pr review 123 --comment --body "ok" 2>&1 >/dev/null)
+rc=$?
+set -e
+# The wrapped write (gh pr review) must run under the keyring token, never
+# under the wrong ambient token. (The verification probe `gh api user` does
+# run under author-token — that's expected; we only forbid the wrapped
+# pr-review line under it.)
+if [ "$rc" -ne 0 ]; then
+  fail "ambient token wrong identity: rc=$rc (expected fallthrough success)"
+elif ! grep -q $'GH_TOKEN=fallback-claude-token GITHUB_TOKEN= gh\tpr\treview' "$WORKDIR/calls.log"; then
+  fail "ambient token wrong identity: did not fall through to the keyring fallback"
+  cat "$WORKDIR/calls.log" >&2
+elif grep -q $'GH_TOKEN=author-token GITHUB_TOKEN= gh\tpr\treview' "$WORKDIR/calls.log"; then
+  fail "ambient token wrong identity: wrong ambient token reached the wrapped write"
+  cat "$WORKDIR/calls.log" >&2
+elif ! echo "$err" | grep -q "ambient GH_TOKEN did not verify"; then
+  fail "ambient token wrong identity: missing fallthrough diagnostic"
+  echo "$err" >&2
+else
+  pass "ambient token wrong identity: rejected and falls through to the keyring fallback"
+fi
+unset GH_TOKEN
 
 reset_log
 set +e

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -55,6 +55,8 @@ case "${1:-} ${2:-}" in
         ;;
       *)
         echo "${STUB_MERGE_STATE:-CLEAN}"
+        echo "${STUB_MERGEABLE:-MERGEABLE}"
+        echo "${STUB_ROLLUP_NONGREEN:-0}"
         if [ -n "${STUB_LABELS:-}" ]; then
           echo "$STUB_LABELS" | tr ';' '\n'
         fi
@@ -83,6 +85,8 @@ run_hook() {
   payload=$(jq -n --arg c "$cmd" '{tool_input: {command: $c}}')
   PATH="$STUB_DIR:$PATH" \
   STUB_MERGE_STATE="$merge_state" \
+  STUB_MERGEABLE="${STUB_MERGEABLE:-MERGEABLE}" \
+  STUB_ROLLUP_NONGREEN="${STUB_ROLLUP_NONGREEN:-0}" \
   STUB_LABELS="$labels" \
   STUB_PR_BODY="$pr_body" \
   STUB_PR_ADDITIONS="$additions" \
@@ -190,6 +194,28 @@ assert_rc_contains "direct pr merge blocked" 2 "token-verifying wrapper" \
 assert_rc_contains "author wrapper pr merge blocked state" 2 "mergeStateStatus is BLOCKED" \
   'scripts/gh-as-author.sh -- gh pr merge 123 --squash' "BLOCKED" ""
 
+# #547: UNSTABLE is a non-passing commit status. It is allowed ONLY when
+# the check ROLLUP confirms every check name's LATEST run is green
+# (ROLLUP_NONGREEN=0 — a stale failure superseded by a later pass) AND
+# mergeable=MERGEABLE. A genuinely-red check (rollup non-green > 0) is NOT
+# trusted as benign just because mergeable is MERGEABLE: mergeable is
+# conflict-only, so trusting it would reopen the #170/#171 red-CI bypass.
+assert_rc_contains "UNSTABLE + green rollup + MERGEABLE allowed (#547)" 0 "" \
+  'scripts/gh-as-author.sh -- gh pr merge 123 --squash' "UNSTABLE" ""
+STUB_ROLLUP_NONGREEN=1 \
+  assert_rc_contains "UNSTABLE + a red latest check fails closed (#547)" 2 "latest run is not green" \
+  'scripts/gh-as-author.sh -- gh pr merge 123 --squash' "UNSTABLE" ""
+STUB_MERGEABLE=UNKNOWN \
+  assert_rc_contains "UNSTABLE + green rollup but mergeable=UNKNOWN fails closed (#547)" 2 "fail-closed" \
+  'scripts/gh-as-author.sh -- gh pr merge 123 --squash' "UNSTABLE" ""
+STUB_ROLLUP_NONGREEN=1 \
+  assert_rc_contains "UNSTABLE + red rollup + break-glass allowed (#547)" 0 "BREAK-GLASS" \
+  'BREAK_GLASS_MERGE_STATE=1 scripts/gh-as-author.sh -- gh pr merge 123 --squash' "UNSTABLE" ""
+# DIRTY (merge conflict) stays blocked regardless — the UNSTABLE allowance
+# must not leak to the other non-CLEAN states.
+assert_rc_contains "DIRTY stays blocked (#547 split)" 2 "mergeStateStatus is DIRTY" \
+  'scripts/gh-as-author.sh -- gh pr merge 123 --squash' "DIRTY" ""
+
 assert_rc_contains "author wrapper pr merge human-hold blocks" 2 "human-hold" \
   'CODEX_CLEARED=1 BREAK_GLASS_ADMIN=1 BREAK_GLASS_MERGE_STATE=1 scripts/gh-as-author.sh -- gh pr merge 123 --admin --squash' "DIRTY" "human-hold"
 
@@ -248,8 +274,158 @@ assert_rc_contains "same-agent under-threshold approve allowed" 0 "" \
   'scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "small"' "CLEAN" "" "nathanpayne-claude" "Authoring-Agent: claude" "10" "5"
 cd "$ORIG_DIR"
 
+# --- #533 item 2: propagation lane bypass honors propagation_prs.enabled
+# A mergepath-sync/* PR authored by the author identity skips the
+# same-agent self-approve guard even when over-threshold — but ONLY when
+# the lane is enabled. DEFAULT-ON: an absent propagation_prs block counts
+# as enabled; an explicit `enabled: false` must re-impose the guard, and
+# per #540 any other present non-`true` value (e.g. `yes`, a typo) also
+# re-imposes it (fail-closed exact-match).
+mkdir -p "$WORKDIR/repo-lane-default/.github"
+cat >"$WORKDIR/repo-lane-default/.github/review-policy.yml" <<'YML'
+external_review_threshold: 300
+YML
+cd "$WORKDIR/repo-lane-default"
+assert_rc_contains "lane bypass allowed (default-on absent block)" 0 "" \
+  'scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "sync"' "CLEAN" "" "nathanpayne-claude" "Authoring-Agent: claude" "5000" "0" "mergepath-sync/abc123" "nathanjohnpayne"
+cd "$ORIG_DIR"
+
+mkdir -p "$WORKDIR/repo-lane-off/.github"
+cat >"$WORKDIR/repo-lane-off/.github/review-policy.yml" <<'YML'
+external_review_threshold: 300
+propagation_prs:
+  enabled: false
+YML
+cd "$WORKDIR/repo-lane-off"
+assert_rc_contains "lane bypass denied when propagation_prs.enabled false (#533)" 2 "self-approve detected" \
+  'scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "sync"' "CLEAN" "" "nathanpayne-claude" "Authoring-Agent: claude" "5000" "0" "mergepath-sync/abc123" "nathanjohnpayne"
+cd "$ORIG_DIR"
+
+mkdir -p "$WORKDIR/repo-lane-typo/.github"
+cat >"$WORKDIR/repo-lane-typo/.github/review-policy.yml" <<'YML'
+external_review_threshold: 300
+propagation_prs:
+  enabled: yes
+YML
+cd "$WORKDIR/repo-lane-typo"
+assert_rc_contains "lane bypass denied when propagation_prs.enabled is a present non-true value (#540)" 2 "self-approve detected" \
+  'scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "sync"' "CLEAN" "" "nathanpayne-claude" "Authoring-Agent: claude" "5000" "0" "mergepath-sync/abc123" "nathanjohnpayne"
+cd "$ORIG_DIR"
+
+# #540 P2 (4a review): a trailing comment on the propagation_prs header
+# (propagation_prs: # opt-out) must still be parsed, so enabled:false
+# disables the lane. The prior exact-EOL header match missed it and the
+# lane failed open.
+mkdir -p "$WORKDIR/repo-lane-comment/.github"
+cat >"$WORKDIR/repo-lane-comment/.github/review-policy.yml" <<'YML'
+external_review_threshold: 300
+propagation_prs:  # this repo opted out of the self-approve lane
+  enabled: false
+YML
+cd "$WORKDIR/repo-lane-comment"
+assert_rc_contains "lane bypass denied when propagation_prs header has a trailing comment (#540 P2)" 2 "self-approve detected" \
+  'scripts/gh-as-reviewer.sh -- gh pr review 123 --approve --body "sync"' "CLEAN" "" "nathanpayne-claude" "Authoring-Agent: claude" "5000" "0" "mergepath-sync/abc123" "nathanjohnpayne"
+cd "$ORIG_DIR"
+
 assert_rc_contains "compound direct guarded write blocked" 2 "#348" \
   'gh issue close 7 && gh pr merge --admin 123'
+
+# --- #533 item 1: eval / sh -c / bash -c admin-merge bypass -----------
+# Each of these returned rc=0 (BYPASS) before the python tokenizer
+# re-tokenized eval/shell -c payloads: shlex kept the inner command as
+# one opaque token, so SAW_GH stayed 0 and the guard exited early. They
+# must now surface the inner guarded gh write and BLOCK (rc=2).
+assert_rc_contains "eval-wrapped gh pr merge --admin blocked (#533)" 2 "token-verifying wrapper" \
+  'eval "gh pr merge 123 --admin"'
+
+assert_rc_contains "eval split-arg gh pr merge --admin blocked (#533)" 2 "token-verifying wrapper" \
+  'eval "gh pr" "merge 123 --admin"'
+
+assert_rc_contains "bash -lc gh pr merge --admin blocked (#533)" 2 "token-verifying wrapper" \
+  'bash -lc "gh pr merge 123 --admin"'
+
+assert_rc_contains "bash -c gh pr merge --admin blocked (#533)" 2 "token-verifying wrapper" \
+  'bash -c "gh pr merge 123 --admin"'
+
+assert_rc_contains "sh -c gh pr merge --admin blocked (#533)" 2 "token-verifying wrapper" \
+  'sh -c "gh pr merge 123 --admin"'
+
+# Recursion: a shell wrapper nesting eval (bash -c -> eval -> gh) must
+# expand all the way down.
+assert_rc_contains "bash -c eval gh pr merge blocked (#533 recursion)" 2 "token-verifying wrapper" \
+  'bash -c "eval gh pr merge 123 --admin"'
+
+# A guarded write hidden inside a shell -c compound must still trip #348.
+assert_rc_contains "shell -c compound guarded write blocked (#533/#348)" 2 "#348" \
+  'sh -c "gh issue close 1 && gh pr merge 123 --admin"'
+
+# No false positives: a wrapped command with no command-position gh
+# write stays allowed (the walk re-establishes command position on the
+# expanded stream, so a gh token that is mere data is not a write).
+assert_rc_contains "eval echo allowed (no gh)" 0 "" \
+  'eval "echo hello world"'
+
+assert_rc_contains "bash -c echo of gh text allowed (gh not in cmd position)" 0 "" \
+  'bash -c "echo gh pr merge --admin"'
+
+# --- #540 Phase-4b: nathanpayne-codex found two more guard bypasses ----
+# (1) bash --noprofile --norc -c "<payload>": the option scan matched any
+#     flag containing a 'c', so --norc consumed the real -c and dropped the
+#     command string. Long (--) options are now skipped so the real -c is
+#     found.
+assert_rc_contains "bash --norc -c gh pr merge --admin blocked (#540)" 2 "" \
+  'bash --noprofile --norc -c "gh pr merge 1 --admin"'
+assert_rc_contains "bash --rcfile -c still finds the real -c (#540)" 2 "" \
+  'bash --rcfile /dev/null -c "gh pr merge 1 --admin"'
+
+# (3) <prefix> [opts] bash -c "<payload>": a prefix command with its OWN
+#     options (env -i, sudo -u USER, nice -n N) must consume those options
+#     so the wrapped bash -c is still found. Previously a prefix option
+#     fell through and flipped command-position off, hiding the bash -c
+#     gh-write (#540 P1, 4a review).
+assert_rc_contains "env -i bash -c gh pr merge blocked (#540 P1)" 2 "" \
+  'env -i bash -c "gh pr merge 1 --admin"'
+assert_rc_contains "sudo -u USER bash -c gh pr merge blocked (#540 P1)" 2 "" \
+  'sudo -u nobody bash -c "gh pr merge 1 --admin"'
+assert_rc_contains "nice -n N bash -c gh pr merge blocked (#540 P1)" 2 "" \
+  'nice -n 5 bash -c "gh pr merge 1 --admin"'
+# sudo -n is a no-value FLAG (unlike nice -n), so bash stays in command
+# position and is still expanded (per-prefix value-option table).
+assert_rc_contains "sudo -n bash -c gh pr merge blocked (#540 P1)" 2 "" \
+  'sudo -n bash -c "gh pr merge 1 --admin"'
+# An env NAME=VALUE assignment before the shell is skipped, not mistaken
+# for the wrapped command.
+assert_rc_contains "env VAR=x bash -c gh pr merge blocked (#540 P1)" 2 "" \
+  'env FOO=bar bash -c "gh pr merge 1 --admin"'
+# Control: a prefix wrapping a benign echo of gh text stays allowed (gh is
+# not in command position inside the echo).
+assert_rc_contains "sudo -u x bash -c echo gh text allowed (#540 P1)" 0 "" \
+  'sudo -u nobody bash -c "echo gh pr merge --admin"'
+
+# (2) a command substitution with a quoted ) desynced shlex quote tracking
+#     and glued a top-level "; gh ..." into a data token. The python
+#     preprocessor is now command-substitution aware: it pads unquoted
+#     separators and surfaces commands inside $(...) / backticks.
+assert_rc_contains "cmd-sub quoted-paren hides top-level gh merge blocked (#540)" 2 "" \
+  'echo "$(printf %s ")")"; gh pr merge 1 --admin'
+
+# Related command-substitution / subshell vectors the same fix closes: a
+# gh write that EXECUTES inside $(...), a backtick, a subshell, or an
+# assignment substitution is surfaced and blocked (also required the
+# fast-path pre-filter boundary to count ( / $ / ; / backtick, not only
+# whitespace, so the hook does not early-exit before tokenizing).
+assert_rc_contains "gh write inside command substitution blocked (#540)" 2 "" \
+  'echo "$(gh pr merge 1 --admin)"'
+assert_rc_contains "gh write in subshell blocked (#540)" 2 "" \
+  '(gh pr merge 1 --admin)'
+assert_rc_contains "gh write in assignment substitution blocked (#540)" 2 "" \
+  'X=$(gh pr merge 1 --admin)'
+assert_rc_contains "gh write in backtick substitution blocked (#540)" 2 "" \
+  'echo `gh pr merge 1 --admin`'
+
+# Control: a READ inside a substitution is not a guarded write -> allowed.
+assert_rc_contains "gh read inside command substitution allowed (#540)" 0 "" \
+  'echo "$(gh pr view 1)"'
 
 # --- author-wrapper identity pin (#438) -------------------------------
 
@@ -530,6 +706,83 @@ if [ "$rc" -eq 2 ] && echo "$out" | grep -qi "author identity"; then
 else
   fail "author wrapper unset identity under custom expected author fails closed: rc=$rc; output: $out"
 fi
+
+# --- #546: parser-completeness hardening (gap 1 + gap 2) --------------
+# Gap 1 — a blessed wrapper must not hide a shell-c payload. Before #546 the
+# wrappers were not prefix-like in expand_wrappers, so a "<wrapper> -- bash
+# -c <gh write>" left the inner write opaque and it ran under the verified
+# token WITHOUT the merge-state / admin / CODEX gate. The inner write must
+# now surface and face the same checks as a visible "<wrapper> -- gh ...".
+assert_rc_contains "author wrapper hides bash -c merge: state still checked (#546 gap 1)" 2 "mergeStateStatus is BLOCKED" \
+  'scripts/gh-as-author.sh -- bash -c "gh pr merge 123 --squash"' "BLOCKED" ""
+assert_rc_contains "author wrapper bash -c clean merge still allowed (#546 gap 1, no false block)" 0 "" \
+  'scripts/gh-as-author.sh -- bash -c "gh pr merge 123 --squash"' "CLEAN" ""
+assert_rc_contains "author wrapper hides eval admin merge: surfaced + blocked (#546 gap 1)" 2 "" \
+  'scripts/gh-as-author.sh -- eval "gh pr merge 123 --admin"' "CLEAN" ""
+assert_rc_contains "reviewer wrapper hides bash -c admin merge: surfaced + blocked (#546 gap 1)" 2 "" \
+  'scripts/gh-as-reviewer.sh -- bash -c "gh pr merge 123 --admin"' "CLEAN" ""
+assert_rc_contains "wrapper bash -c echo of gh text is not a write (#546 gap 1, no false positive)" 0 "" \
+  'scripts/gh-as-author.sh -- bash -c "echo gh pr merge --admin"' "CLEAN" ""
+
+# Gap 2 — the python pre-pass and the bash walk read ONE shared
+# PREFIX_VALUE_OPTS_SPEC, so a long-form prefix value-option no longer
+# mis-skips. Before #546 python expanded "sudo --user X bash -c <gh write>"
+# but the bash compound scan (short-forms only) mis-read X as the command
+# and never saw the surfaced gh, so a guarded write passed rc=0.
+assert_rc_contains "sudo --user long form bash -c gh write surfaced (#546 gap 2)" 2 "token-verifying wrapper" \
+  'sudo --user root bash -c "gh pr merge 123 --admin"'
+assert_rc_contains "nice --adjustment long form bash -c gh write surfaced (#546 gap 2)" 2 "token-verifying wrapper" \
+  'nice --adjustment 10 bash -c "gh pr merge 123 --admin"'
+assert_rc_contains "time -f value option bash -c gh write surfaced (#546 gap 2)" 2 "token-verifying wrapper" \
+  'time -f FMT bash -c "gh pr merge 123 --admin"'
+# Bogus sudo:-s / sudo:-c removed from the shared spec: -s is a no-value
+# flag, so the FOLLOWING token is the command, not -s's value. Before #546
+# the bash table wrongly skipped it and lost the gh write.
+assert_rc_contains "sudo -s no-value flag does not swallow the gh write (#546 gap 2)" 2 "token-verifying wrapper" \
+  'sudo -s gh pr merge 123 --admin'
+
+# --- #546 follow-on (CodeRabbit #551): spec correctness for ionice/env ----
+# ionice -t/--ignore is a no-value FLAG, so it must not consume the next
+# token; before this it swallowed the bash that followed and hid the write.
+assert_rc_contains "ionice -t flag does not swallow bash -c gh write (#551)" 2 "token-verifying wrapper" \
+  'ionice -t bash -c "gh pr merge 123 --admin"'
+# ionice -c is still a real value option (regression: must skip its value).
+assert_rc_contains "ionice -c value option still skips its value, then surfaces gh (#551)" 2 "token-verifying wrapper" \
+  'ionice -c 2 bash -c "gh pr merge 123 --admin"'
+# env -S / --split-string FAILS CLOSED (#551, Codex r1-r4). GNU env -S has
+# exotic dynamic semantics — whitespace splitting, $VAR expansion,
+# $(...)/backtick substitution, AND appending the remaining argv after the
+# split string — that the guard cannot safely + completely model (each partial
+# model surfaced a new bypass). env -S on a command line is an exotic shebang
+# feature no gh workflow needs, so ANY env -S is blocked rather than risk a
+# hidden write.
+assert_rc_contains "env -S gh write fails closed (#551)" 2 "tokenize" \
+  'env -S "gh pr merge 123 --admin"'
+assert_rc_contains "env --split-string gh write fails closed (#551)" 2 "tokenize" \
+  'env --split-string "gh pr merge 123 --admin"'
+assert_rc_contains "env --split-string=STR gh write fails closed (#551)" 2 "tokenize" \
+  'env --split-string="gh pr merge 123 --admin"'
+assert_rc_contains "env -S variable-expansion payload fails closed (#551 Codex)" 2 "tokenize" \
+  'G=gh env -S "${G} pr merge 123 --admin"'
+assert_rc_contains "env -S command-substitution payload fails closed (#551 Codex)" 2 "tokenize" \
+  'env -S "$(printf gh) pr merge 123 --admin"'
+assert_rc_contains "env -S following-argv payload fails closed (#551 Codex)" 2 "tokenize" \
+  'env -S "bash -c" "gh pr merge 123 --admin"'
+# No literal "gh" in the raw command (gh synthesized via octal printf), so the
+# no-gh fast-path would skip the tokenizer — but env -S forces tokenization and
+# then fails closed (Codex #551 r5: tokenize env -S even without a literal gh).
+assert_rc_contains "env -S without a literal gh still fails closed (#551 Codex)" 2 "tokenize" \
+  'G=$(printf "\147\150") env -S "${G} pr merge 123 --admin"'
+# Clustered env split-string flag (-vS), not just a leading -S (CodeRabbit #551).
+assert_rc_contains "env clustered -vS fails closed (#551)" 2 "tokenize" \
+  'env -vS "gh pr merge 123 --admin"'
+# Quoted `env` (the shell strips the quotes and runs env) with no literal gh:
+# the fast-path quote-strips before probing, then env -S fails closed (Codex #551).
+assert_rc_contains "quoted env -S without a literal gh fails closed (#551 Codex)" 2 "tokenize" \
+  'G=$(printf "\147\150") "env" -S "${G} pr merge 123 --admin"'
+# A plain env prefix (no -S) is unaffected — it still surfaces the wrapped write.
+assert_rc_contains "plain env prefix still surfaces the gh write (#551 regression)" 2 "token-verifying wrapper" \
+  'env FOO=bar gh pr merge 123 --admin'
 
 echo ""
 echo "test_gh_pr_guard: $PASS passed, $FAIL failed"

--- a/tests/test_merge_clearance_gate.sh
+++ b/tests/test_merge_clearance_gate.sh
@@ -656,6 +656,159 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 19 (#536): a SINGLE-QUOTED boolean — `enabled: 'true'` — must be
+# parsed as the bare `true`, not the literal `'true'` that trips the
+# true|false validator (exit 2). Before the nested_field quote-strip fix,
+# this aborted with rc=2; now it reads `true` and the gate evaluates
+# normally (APPROVED on HEAD → exit 0 PASS).
+# ---------------------------------------------------------------------------
+echo; echo "--- Test 19: single-quoted enabled: 'true' parses (no validator trip) (#536)"
+SCRATCH=$(mktemp -d "$WORKDIR/scratch.XXXXXX"); mkdir -p "$SCRATCH/.github"
+cat >"$SCRATCH/.github/review-policy.yml" <<EOF
+external_review_threshold: 300
+external_review_paths:
+  - ".github/**"
+
+available_reviewers:
+  - nathanpayne-claude
+
+codex:
+  external_review_gate:
+    enabled: 'false'
+
+dependabot:
+  reviewer_gate:
+    enabled: 'true'
+EOF
+FIXTURE_PR=$(make_pr_fixture "$HEAD_SHA" "$DEPENDABOT")
+FIXTURE_REVIEWS=$(make_reviews_fixture "$(jq -n --arg sha "$HEAD_SHA" '
+  [{ user:{login:"nathanpayne-claude"}, state:"APPROVED", commit_id:$sha, submitted_at:"2026-06-01T10:00:00Z" }]
+')")
+set +e
+OUT=$(FIXTURE_PR="$FIXTURE_PR" FIXTURE_REVIEWS="$FIXTURE_REVIEWS" run_gate "$SCRATCH" 99 owner/repo 2>&1)
+RC=$?
+set -e
+if [ "$RC" = 0 ] && echo "$OUT" | grep -q "PASS"; then
+  pass "single-quoted enabled: 'true' parsed as true → gate evaluates (exit 0)"
+else
+  fail "expected rc=0 PASS (single-quote stripped); got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 20 (#533): the check_merge_clearance_gate workflow-shape pre-flight
+# must require the required-check name to be a JOB name, not just any
+# indented name:. A step-level `name: Merge clearance gate` under a
+# differently-named job MUST fail the check — otherwise a coincidentally
+# named step could satisfy the branch-protection required-check contract
+# while the actual job name silently drifted and de-wired the gate.
+#
+# These point the check's WORKFLOW at a fixture via MERGE_CLEARANCE_WORKFLOW.
+# A failing workflow-shape pre-flight exits 1 BEFORE the check runs its
+# fixture test suite, so this stays cheap (no recursion into this file).
+# ---------------------------------------------------------------------------
+# Re-entrancy guard: Case C below invokes check_merge_clearance_gate, which
+# (on a clean pre-flight) runs THIS test file as its fixture suite. Skip the
+# Test 20 block in that nested run to avoid infinite recursion — the nested
+# run still exercises Tests 1-18.
+if [ -z "${MCG_SKIP_FIX3_SELFTEST:-}" ]; then
+echo; echo "--- Test 20: check_merge_clearance_gate job-name scope (#533)"
+CHECK_BIN="$ROOT/scripts/ci/check_merge_clearance_gate"
+
+# A minimal workflow that is otherwise shape-valid (all required triggers +
+# a schedule cron) so ONLY the job-name assertion is under test.
+write_wf_header() {
+  cat <<'WF'
+name: Merge Clearance Gate
+on:
+  pull_request:
+    types: [opened, synchronize]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+  schedule:
+    - cron: "*/15 * * * *"
+permissions:
+  contents: read
+jobs:
+WF
+}
+
+# Case A (negative): the required name appears ONLY as a non-first step key
+# (deeper indent, no leading dash) under a differently-named job. Must FAIL.
+WF_STEP_NAME="$WORKDIR/wf-step-name.yml"
+{
+  write_wf_header
+  cat <<'WF'
+  some-other-job:
+    name: A completely different job
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        name: Merge clearance gate
+WF
+} > "$WF_STEP_NAME"
+set +e
+OUT=$(MERGE_CLEARANCE_WORKFLOW="$WF_STEP_NAME" "$CHECK_BIN" 2>&1)
+RC=$?
+set -e
+if [ "$RC" -ne 0 ] && echo "$OUT" | grep -q "must define a JOB named"; then
+  pass "step-level name: Merge clearance gate under a differently-named job → check FAILS (#533)"
+else
+  fail "expected check FAIL on step-level name (#533); got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# Case B (negative): job name DRIFTED, but a step is named like the required
+# check. The drifted job + correctly-named step must still FAIL.
+WF_DRIFT="$WORKDIR/wf-job-drift.yml"
+{
+  write_wf_header
+  cat <<'WF'
+  merge-clearance-gate:
+    name: Merge clearance gate DRIFTED
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge clearance gate
+        run: echo step named like the required check
+WF
+} > "$WF_DRIFT"
+set +e
+OUT=$(MERGE_CLEARANCE_WORKFLOW="$WF_DRIFT" "$CHECK_BIN" 2>&1)
+RC=$?
+set -e
+if [ "$RC" -ne 0 ] && echo "$OUT" | grep -q "must define a JOB named"; then
+  pass "drifted job name + correctly-named step → check FAILS (#533)"
+else
+  fail "expected check FAIL on drifted job name (#533); got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+
+# Case C (positive control): a correctly-named JOB satisfies the assertion.
+# The check proceeds past the workflow-shape pre-flight (and runs its own
+# fixture suite). We only assert the job-name assertion does NOT fire — i.e.
+# the check does not emit the job-name FAIL line and exits clean.
+WF_OK="$WORKDIR/wf-ok.yml"
+{
+  write_wf_header
+  cat <<'WF'
+  merge-clearance-gate:
+    name: Merge clearance gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run gate
+        run: echo ok
+WF
+} > "$WF_OK"
+set +e
+OUT=$(MCG_SKIP_FIX3_SELFTEST=1 MERGE_CLEARANCE_WORKFLOW="$WF_OK" "$CHECK_BIN" 2>&1)
+RC=$?
+set -e
+if [ "$RC" -eq 0 ] && ! echo "$OUT" | grep -q "must define a JOB named"; then
+  pass "correctly-named JOB → job-name assertion passes (#533)"
+else
+  fail "expected job-name assertion to pass on a correct job name (#533); got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
+fi
+fi  # end re-entrancy guard (MCG_SKIP_FIX3_SELFTEST)
+# ---------------------------------------------------------------------------
 echo
 echo "============================================"
 echo "test_merge_clearance_gate.sh: $PASS passed, $FAIL failed"

--- a/tests/test_op_preflight_check.sh
+++ b/tests/test_op_preflight_check.sh
@@ -571,7 +571,7 @@ EOF
     PATH="$bin_dir:$STUB_DIR:$PATH" \
       OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
       GCP_ADC_OP_URI="$shared_adc_uri" \
-      "$SCRIPT" --mode deploy >"$case_dir/out" 2>"$case_dir/err"
+      "$SCRIPT" --agent claude --mode deploy >"$case_dir/out" 2>"$case_dir/err"
   ) || rc=$?
   out="$(cat "$case_dir/out")"
   err="$(cat "$case_dir/err")"
@@ -626,17 +626,17 @@ JSON
 
   local epoch
   epoch=$(date +%s)
-  cat > "$cache_dir/op-preflight-.env" <<EOF
+  cat > "$cache_dir/op-preflight-claude.env" <<EOF
 OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
 OP_PREFLIGHT_TTL_SECONDS=14400
-OP_PREFLIGHT_AGENT=''
+OP_PREFLIGHT_AGENT=claude
 OP_PREFLIGHT_MODE=deploy
 OP_PREFLIGHT_DONE=1
 GOOGLE_APPLICATION_CREDENTIALS=$bad_sa_file
 OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$bad_sa_file
 OP_PREFLIGHT_FIREBASE_PROJECT=$project
 EOF
-  chmod 600 "$cache_dir/op-preflight-.env"
+  chmod 600 "$cache_dir/op-preflight-claude.env"
 
   cat > "$bin_dir/op" <<EOF
 #!/usr/bin/env bash
@@ -693,7 +693,7 @@ EOF
     PATH="$bin_dir:$STUB_DIR:$PATH" \
       OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
       GCP_ADC_OP_URI="$shared_adc_uri" \
-      "$SCRIPT" --mode deploy >"$case_dir/out" 2>"$case_dir/err"
+      "$SCRIPT" --agent claude --mode deploy >"$case_dir/out" 2>"$case_dir/err"
   ) || rc=$?
   out="$(cat "$case_dir/out")"
   err="$(cat "$case_dir/err")"
@@ -755,17 +755,17 @@ JSON
 
   local epoch
   epoch=$(date +%s)
-  cat > "$cache_dir/op-preflight-.env" <<EOF
+  cat > "$cache_dir/op-preflight-claude.env" <<EOF
 OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
 OP_PREFLIGHT_TTL_SECONDS=14400
-OP_PREFLIGHT_AGENT=''
+OP_PREFLIGHT_AGENT=claude
 OP_PREFLIGHT_MODE=deploy
 OP_PREFLIGHT_DONE=1
 GOOGLE_APPLICATION_CREDENTIALS=$cached_sa_file
 OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$cached_sa_file
 OP_PREFLIGHT_FIREBASE_PROJECT=$cached_project
 EOF
-  chmod 600 "$cache_dir/op-preflight-.env"
+  chmod 600 "$cache_dir/op-preflight-claude.env"
 
   cat > "$bin_dir/op" <<EOF
 #!/usr/bin/env bash
@@ -822,7 +822,7 @@ EOF
     PATH="$bin_dir:$STUB_DIR:$PATH" \
       OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
       GCP_ADC_OP_URI="$shared_adc_uri" \
-      "$SCRIPT" --mode deploy >"$case_dir/out" 2>"$case_dir/err"
+      "$SCRIPT" --agent claude --mode deploy >"$case_dir/out" 2>"$case_dir/err"
   ) || rc=$?
   out="$(cat "$case_dir/out")"
   err="$(cat "$case_dir/err")"
@@ -865,7 +865,7 @@ test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch() {
   local shared_adc_uri="op://Private/test-shared-adc-file-mismatch/credential"
   local op_log="$case_dir/op.log"
   mkdir -p "$case_dir" "$cache_dir" "$bin_dir"
-  local cached_sa_file="$cache_dir/op-preflight--firebase-sa.json"
+  local cached_sa_file="$cache_dir/op-preflight-claude-firebase-sa.json"
 
   cat > "$case_dir/.firebaserc" <<JSON
 { "projects": { "default": "$current_project" } }
@@ -885,17 +885,17 @@ JSON
 
   local epoch
   epoch=$(date +%s)
-  cat > "$cache_dir/op-preflight-.env" <<EOF
+  cat > "$cache_dir/op-preflight-claude.env" <<EOF
 OP_PREFLIGHT_CREATED_AT_EPOCH=$epoch
 OP_PREFLIGHT_TTL_SECONDS=14400
-OP_PREFLIGHT_AGENT=''
+OP_PREFLIGHT_AGENT=claude
 OP_PREFLIGHT_MODE=deploy
 OP_PREFLIGHT_DONE=1
 GOOGLE_APPLICATION_CREDENTIALS=$cached_sa_file
 OP_PREFLIGHT_FIREBASE_SA_TMPFILE=$cached_sa_file
 OP_PREFLIGHT_FIREBASE_PROJECT=$current_project
 EOF
-  chmod 600 "$cache_dir/op-preflight-.env"
+  chmod 600 "$cache_dir/op-preflight-claude.env"
 
   cat > "$bin_dir/op" <<EOF
 #!/usr/bin/env bash
@@ -956,7 +956,7 @@ EOF
     PATH="$bin_dir:$STUB_DIR:$PATH" \
       OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
       GCP_ADC_OP_URI="$shared_adc_uri" \
-      "$SCRIPT" --mode deploy >"$case_dir/out" 2>"$case_dir/err"
+      "$SCRIPT" --agent claude --mode deploy >"$case_dir/out" 2>"$case_dir/err"
   ) || rc=$?
   out="$(cat "$case_dir/out")"
   err="$(cat "$case_dir/err")"
@@ -1053,6 +1053,177 @@ test_source_gcp_adc_stale_forces_refresh() {
   fi
 }
 
+# ---------------------------------------------------------------------------
+# test_deploy_mode_requires_agent (#534.1): `deploy` must stay in the
+# --agent-required gate. Cache paths are unconditionally $AGENT-interpolated,
+# so `--mode deploy` with no --agent writes a shared anonymous ("") bucket
+# that `--purge --agent <name>` can never reclaim and concurrent sessions
+# clobber. This was added in #259, dropped by a bulk sync, and restored in
+# #534. Behavioral + structural guards so another drop fails CI.
+# ---------------------------------------------------------------------------
+test_deploy_mode_requires_agent() {
+  # Behavioral: --mode deploy with no --agent must fail before doing any work.
+  local rc=0
+  PATH="$STUB_DIR:$PATH" OP_PREFLIGHT_CACHE_DIR="$WORKDIR/deploy-no-agent" \
+    "$SCRIPT" --mode deploy >"$WORKDIR/deploy-no-agent.out" 2>"$WORKDIR/deploy-no-agent.err" || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    fail "test_deploy_mode_requires_agent: --mode deploy without --agent unexpectedly succeeded"
+    return
+  fi
+  if ! grep -q "agent is required" "$WORKDIR/deploy-no-agent.err"; then
+    fail "test_deploy_mode_requires_agent: missing 'agent is required' diagnostic; stderr=$(cat "$WORKDIR/deploy-no-agent.err")"
+    return
+  fi
+  # The error message itself must enumerate deploy, and no anonymous cache
+  # file may have been written.
+  if ! grep -qi "deploy" "$WORKDIR/deploy-no-agent.err"; then
+    fail "test_deploy_mode_requires_agent: agent-required error does not mention deploy mode"
+    return
+  fi
+  if [ -e "$WORKDIR/deploy-no-agent/op-preflight-.env" ]; then
+    fail "test_deploy_mode_requires_agent: anonymous (empty-agent) cache file was written"
+    return
+  fi
+  # Structural: the gate line that requires --agent (the one testing
+  # `-z "$AGENT"`) must also include the `deploy` mode token. Guards against
+  # a bulk-sync re-dropping deploy even if a future refactor changes the
+  # error string. The gate is the only line carrying both tokens.
+  if ! awk '
+    /-z "\$AGENT" \]\]/ && /"\$MODE" == "deploy"/ { ok = 1 }
+    END { exit (ok ? 0 : 1) }
+  ' "$SCRIPT"; then
+    fail "test_deploy_mode_requires_agent: 'deploy' missing from the --agent-required gate (#534.1 regression)"
+    return
+  fi
+  pass "test_deploy_mode_requires_agent: --mode deploy requires --agent (gate retains deploy)"
+}
+
+# ---------------------------------------------------------------------------
+# test_deploy_full_fetch_fails_closed_on_unreadable_adc (#534.2 / #534.3):
+# on the full-fetch path, when the GCP ADC read fails (op error) under
+# `--mode deploy`, preflight must fail closed (exit non-zero) rather than
+# emitting OP_PREFLIGHT_DONE=1 with no GOOGLE_APPLICATION_CREDENTIALS — the
+# cache-hit path already exit 2's for this. The could-not-read warning must
+# also surface op's stderr reason (#534.3).
+# ---------------------------------------------------------------------------
+test_deploy_full_fetch_fails_closed_on_unreadable_adc() {
+  local case_dir="$WORKDIR/deploy-fail-closed"
+  local cache_dir="$case_dir/cache"
+  local bin_dir="$case_dir/bin"
+  local shared_adc_uri="op://Private/test-unreadable-adc/credential"
+  mkdir -p "$case_dir" "$cache_dir" "$bin_dir"
+  # No .firebaserc → falls through to the GCP ADC branch (not Firebase SA).
+
+  # op stub: every `op read` fails with a recognizable stderr reason; op
+  # inject (Phase 1) is not reached in --mode deploy.
+  cat > "$bin_dir/op" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  read)
+    echo "[ERROR] could not read secret: vault is locked" >&2
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$bin_dir/op"
+
+  local out err rc=0
+  (
+    cd "$case_dir"
+    PATH="$bin_dir:$STUB_DIR:$PATH" \
+      OP_PREFLIGHT_CACHE_DIR="$cache_dir" \
+      GCP_ADC_OP_URI="$shared_adc_uri" \
+      "$SCRIPT" --agent claude --mode deploy >"$case_dir/out" 2>"$case_dir/err"
+  ) || rc=$?
+  out="$(cat "$case_dir/out")"
+  err="$(cat "$case_dir/err")"
+
+  if [ "$rc" -eq 0 ]; then
+    fail "test_deploy_full_fetch_fails_closed_on_unreadable_adc: --mode deploy with unreadable ADC unexpectedly succeeded (rc=0); out=$out"
+    return
+  fi
+  if echo "$out" | grep -q "export GOOGLE_APPLICATION_CREDENTIALS"; then
+    fail "test_deploy_full_fetch_fails_closed_on_unreadable_adc: exported GOOGLE_APPLICATION_CREDENTIALS despite unreadable ADC; out=$out"
+    return
+  fi
+  if echo "$out" | grep -q "export OP_PREFLIGHT_DONE=1"; then
+    fail "test_deploy_full_fetch_fails_closed_on_unreadable_adc: emitted OP_PREFLIGHT_DONE=1 on a failed deploy; out=$out"
+    return
+  fi
+  # #534.3: the warning must include op's stderr reason.
+  if ! echo "$err" | grep -q "could not read GCP ADC"; then
+    fail "test_deploy_full_fetch_fails_closed_on_unreadable_adc: missing could-not-read warning; stderr=$err"
+    return
+  fi
+  if ! echo "$err" | grep -q "vault is locked"; then
+    fail "test_deploy_full_fetch_fails_closed_on_unreadable_adc: warning did not surface op stderr reason (#534.3); stderr=$err"
+    return
+  fi
+  pass "test_deploy_full_fetch_fails_closed_on_unreadable_adc: deploy fails closed on unreadable ADC and surfaces op stderr"
+}
+
+# ---------------------------------------------------------------------------
+# test_deploy_full_fetch_fail_closed_structural (#534.2): structural guard
+# that BOTH the STALE branch and the could-not-read branch of the full-fetch
+# ADC path carry a deploy-scoped `exit 1`, symmetric to
+# test_source_gcp_adc_stale_forces_refresh's exit-2 guard. A behavioral test
+# covers the could-not-read branch; the STALE branch needs a usable-then-
+# rejected ADC + python3 oauth round-trip that is impractical to fixture
+# hermetically, so assert its fail-closed structurally.
+# ---------------------------------------------------------------------------
+test_deploy_full_fetch_fail_closed_structural() {
+  # STALE branch: a 'GCP ADC: STALE' SUMMARY line must be followed by a
+  # deploy-scoped `exit 1` before the branch's closing `fi`.
+  if ! awk '
+    /GCP ADC: STALE/ { found = 1; next }
+    found && /MODE" == "deploy".*exit 1/ { ok = 1 }
+    found && /^[[:space:]]*fi[[:space:]]*$/ { exit (ok ? 0 : 1) }
+    END { exit (ok ? 0 : 1) }
+  ' "$SCRIPT"; then
+    fail "test_deploy_full_fetch_fail_closed_structural: STALE ADC branch missing deploy-scoped exit 1 (#534.2)"
+    return
+  fi
+  # Could-not-read branch: a 'GCP ADC: SKIPPED' SUMMARY line must be followed
+  # by a deploy-scoped `exit 1` before the branch's closing `fi`.
+  if ! awk '
+    /GCP ADC: SKIPPED/ { found = 1; next }
+    found && /MODE" == "deploy".*exit 1/ { ok = 1 }
+    found && /^[[:space:]]*fi[[:space:]]*$/ { exit (ok ? 0 : 1) }
+    END { exit (ok ? 0 : 1) }
+  ' "$SCRIPT"; then
+    fail "test_deploy_full_fetch_fail_closed_structural: could-not-read ADC branch missing deploy-scoped exit 1 (#534.2)"
+    return
+  fi
+  pass "test_deploy_full_fetch_fail_closed_structural: both full-fetch ADC failure branches fail closed under deploy"
+}
+
+# ---------------------------------------------------------------------------
+# test_preflight_mode_is_exported (#521): the preflight mode must be exported
+# on BOTH the cache-hit path and the full-fetch path so a consumer that evals
+# the output (e.g. a deploy wrapper that took the fast path / skipped deploy)
+# can read which mode ran.
+# ---------------------------------------------------------------------------
+test_preflight_mode_is_exported() {
+  # Cache-hit path: a fresh review cache must emit `export OP_PREFLIGHT_MODE`.
+  local case_dir="$WORKDIR/mode-export-cachehit"
+  make_fresh_cache "$case_dir" claude "rev-pat-m" "author-pat-m"
+  local out rc=0
+  out=$(PATH="$STUB_DIR:$PATH" OP_PREFLIGHT_CACHE_DIR="$case_dir" \
+    "$SCRIPT" --agent claude --check 2>/dev/null) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "test_preflight_mode_is_exported: cache-hit --check rc=$rc"
+    return
+  fi
+  if ! echo "$out" | grep -q "export OP_PREFLIGHT_MODE=review"; then
+    fail "test_preflight_mode_is_exported: cache-hit path did not export OP_PREFLIGHT_MODE; out=$out"
+    return
+  fi
+  pass "test_preflight_mode_is_exported: OP_PREFLIGHT_MODE exported on cache-hit path (#521)"
+}
+
 test_check_fresh_cache
 test_check_missing_cache
 test_check_stale_cache
@@ -1069,6 +1240,10 @@ test_deploy_mode_refreshes_mismatched_cached_firebase_sa
 test_deploy_mode_refreshes_cached_firebase_sa_file_mismatch
 test_check_review_mode_omits_deploy_creds
 test_source_gcp_adc_stale_forces_refresh
+test_deploy_mode_requires_agent
+test_deploy_full_fetch_fails_closed_on_unreadable_adc
+test_deploy_full_fetch_fail_closed_structural
+test_preflight_mode_is_exported
 
 echo
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/test_op_preflight_token_mode.sh
+++ b/tests/test_op_preflight_token_mode.sh
@@ -61,7 +61,7 @@ case "\${1:-}" in
       op://Mergepath\ CI\ Headless/nathanpayne-claude\ reviewer\ PAT/token) printf '%s\n' "reviewer-pat-claude" ;;
       op://Mergepath\ CI\ Headless/nathanpayne-cursor\ reviewer\ PAT/token) printf '%s\n' "reviewer-pat-cursor" ;;
       op://Mergepath\ CI\ Headless/nathanpayne-codex\ reviewer\ PAT/token) printf '%s\n' "reviewer-pat-codex" ;;
-      op://Private/sm5kopwk6t6p3xmu2igesndzhe/token)
+      op://Private/FAKEAUTHORITEMID00000000000/token)
         echo "FATAL: token mode attempted author PAT read" >&2
         exit 66
         ;;
@@ -236,7 +236,7 @@ test_token_mode_agents() {
       fail "test_token_mode_agents($agent): token mode used op inject"
       return
     fi
-    if grep -q "sm5kopwk6t6p3xmu2igesndzhe\\|c2v6emkwppjzjjaq2bdqk3wnlm\\|4x6wslp3f6pal5t6h3jhhe63ie" "$OP_LOG"; then
+    if grep -q "FAKEAUTHORITEMID00000000000\\|c2v6emkwppjzjjaq2bdqk3wnlm\\|4x6wslp3f6pal5t6h3jhhe63ie" "$OP_LOG"; then
       fail "test_token_mode_agents($agent): token mode attempted out-of-scope op item"
       return
     fi
@@ -277,7 +277,7 @@ test_token_mode_reviewer_ref_override() {
     fail "test_token_mode_reviewer_ref_override: op did not read override ref"
     return
   fi
-  if grep -q "op://Private/o6ekjxjjl5gq6rmcneomrjahpu/token" "$OP_LOG"; then
+  if grep -q "op://Private/FAKECODEXITEMID000000000000/token" "$OP_LOG"; then
     fail "test_token_mode_reviewer_ref_override: fallback Private ref was read despite override"
     return
   fi
@@ -383,7 +383,7 @@ test_token_mode_reviewer_ref_override() {
   fi
 
   local blocked_ref
-  for blocked_ref in "op://Private/o6ekjxjjl5gq6rmcneomrjahpu/token" "op://Personal/nathanpayne-codex reviewer PAT/token"; do
+  for blocked_ref in "op://Private/FAKECODEXITEMID000000000000/token" "op://Personal/nathanpayne-codex reviewer PAT/token"; do
     reset_logs
     rc=0
     PATH="$STUB_DIR:$PATH" \

--- a/tests/test_resolve_pr_threads_rationale_tag.sh
+++ b/tests/test_resolve_pr_threads_rationale_tag.sh
@@ -625,6 +625,58 @@ else
   echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
 fi
 
+# ─────────────────────────────────────────────────────────────────────
+# Test 8b (#521): the same scalar `consumers: all` templated dest must
+# ALSO classify as templated-render on the NO-YQ fallback path. We force
+# that path by running with a PATH that excludes yq (and keeps only the
+# stub gh + minimal coreutils). The awk fallback now emits a dedicated
+# `__AWK_CONSUMERS_ALL__` sentinel that path_matches_templated_dest treats
+# as match-any — before this fix the awk path emitted the cautious
+# no-scope sentinel for EVERY templated entry, so a `consumers: all` dest
+# never classified as templated-render without yq.
+# Reuses the Test 8 fixture manifest (still on disk) + the same threads.
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 8b: templated-render on consumers: all dest via NO-YQ awk fallback (#521)"
+
+# Sanity: confirm the fixture manifest still carries the consumers: all
+# templated entry (Test 8 wrote it; we depend on it here).
+if ! grep -q 'consumers: all' "$FIXTURE_ROOT/.mergepath-sync.yml"; then
+  fail=$((fail + 1))
+  echo "  FAIL: Test 8b precondition — fixture manifest missing consumers: all entry" >&2
+fi
+
+GH_ARGV_LOG_B="$SCRATCH/t8b.log"; : > "$GH_ARGV_LOG_B"
+# Stub gh in its own dir. Force the no-yq fallback via the script's test
+# hook (RESOLVE_PR_THREADS_FORCE_NO_YQ=1) rather than curating yq out of
+# PATH: CI installs yq into /usr/bin, so a fixed-PATH exclusion is not
+# portable (it false-failed the setup on the runner). The hook exercises
+# the exact grep/awk branch regardless of where yq is installed.
+T8B_BIN="$SCRATCH/t8b-bin"; mkdir -p "$T8B_BIN"
+make_gh_stub "$T8B_BIN/gh-real" "$THREADS_T8" "$FILES_T8" "$COMMITS_T8"
+make_gh_wrapper "$T8B_BIN/gh" "$T8B_BIN/gh-real"
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG_B" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  RESOLVE_PR_THREADS_FORCE_NO_YQ=1 \
+  PATH="$T8B_BIN:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --auto-resolve-bots 2>&1
+)
+rc=$?
+set -e
+if [ "$rc" -eq 0 ] && tag_before_resolve "$GH_ARGV_LOG_B" && grep -q 'FIELD: body=\[mergepath-resolve: templated-render\]' "$GH_ARGV_LOG_B"; then
+  pass=$((pass + 1))
+  echo "  PASS: no-yq awk fallback classifies consumers: all dest as templated-render (#521)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: no-yq fallback did not emit templated-render for consumers: all dest (rc=$rc)" >&2
+  echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG_B" | sed 's/^/      /' >&2
+fi
+
 echo
 if [ "$fail" -eq 0 ]; then
   echo "test_resolve_pr_threads_rationale_tag: PASS ($pass tests)"


### PR DESCRIPTION
Bulk sync to [mergepath@b17c998](https://github.com/nathanjohnpayne/mergepath/commit/b17c998cdc88d5b1383ffa86e5a678cf2a0ac270) — verbatim canonical/kit mirror per `.mergepath-sync.yml`.

Opened by `scripts/sync-to-downstream.sh --sync-all` (v0.4.0-layer3-sync-all, see [#168](https://github.com/nathanjohnpayne/mergepath/issues/168)). Unlike a per-commit propagation PR, this replays the **current HEAD state of every canonical + kit path** so a consumer that has fallen behind reaches a clean steady state in one shot.

## Canonical paths synced
  - scripts/op-preflight.sh
  - scripts/lib/preflight-helpers.sh
  - scripts/lib/gh-retry-helpers.sh
  - scripts/lib/gh-token-resolver.sh
  - scripts/lib/manifest-fact-helpers.sh
  - scripts/lib/template-substitution.sh
  - scripts/lib/reviewers-helpers.sh
  - scripts/coderabbit-wait.sh
  - scripts/coderabbit-automerge-rate-limit-gate.sh
  - scripts/codex-review-request.sh
  - scripts/codex-review-check.sh
  - scripts/codex-record-feedback.sh
  - scripts/phase-4b-classifier.sh
  - scripts/post-phase-4b-handoff.sh
  - scripts/codex-p1-gate.sh
  - scripts/audit-propagation-lane.sh
  - tests/test_audit_propagation_lane.sh
  - scripts/merge-clearance-gate.sh
  - scripts/daily-feedback-rollup.sh
  - scripts/lib/daily-feedback-rollup-helpers.sh
  - scripts/disagreement-detector.cjs
  - scripts/resolve-pr-threads.sh
  - scripts/request-label-removal.sh
  - scripts/gh-as-author.sh
  - scripts/gh-as-reviewer.sh
  - scripts/identity-check.sh
  - scripts/hooks/gh-pr-guard.sh
  - scripts/hooks/label-removal-guard.sh
  - tests/test_gh_pr_guard.sh
  - tests/test_gh_as_author.sh
  - tests/test_gh_as_reviewer.sh
  - tests/test_gh_wrapper_parallel.sh
  - tests/test_check_no_bare_gh_writes.sh
  - tests/test_identity_check.sh
  - tests/test_coderabbit_wait_identity_derivation.sh
  - tests/test_coderabbit_wait_status_probe.sh
  - tests/test_coderabbit_wait_paused.sh
  - tests/test_coderabbit_wait_codex_failover.sh
  - tests/test_coderabbit_automerge_rate_limit_gate.sh
  - tests/test_verify_propagation_pr.sh
  - tests/test_match_protected_paths.sh
  - tests/test_codex_p1_gate.sh
  - tests/test_codex_review_request_ack.sh
  - tests/test_codex_review_request_trigger_only.sh
  - tests/test_codex_review_request_entry.sh
  - tests/test_codex_review_check_resolution.sh
  - tests/test_465_fail_closed.sh
  - tests/test_codex_record_feedback.sh
  - tests/test_merge_clearance_gate.sh
  - tests/test_disagreement_detector.sh
  - tests/test_post_phase_4b_handoff.sh
  - tests/test_op_preflight_check.sh
  - tests/test_op_preflight_token_mode.sh
  - tests/test_helper_autosource.sh
  - tests/test_preflight_agent_name.sh
  - tests/test_resolve_pr_threads_rationale_tag.sh
  - tests/test_daily_feedback_rollup.sh
  - tests/test_template_substitution.sh
  - tests/test_export_consumer_facts.sh
  - tests/test_check_coderabbit_config.sh
  - tests/test_check_propagation_closure.sh
  - .github/pull_request_template.md
  - .github/workflows/agent-review.yml
  - .github/workflows/pr-review-policy.yml
  - .github/workflows/dependabot-auto-merge.yml
  - .github/workflows/auto-clear-blocking-labels.yml
  - .github/workflows/pr-audit.yml
  - .github/workflows/codex-p1-gate.yml
  - .github/workflows/merge-clearance-gate.yml
  - .github/workflows/daily-feedback-rollup.yml

## Kit paths synced
  - .github/ISSUE_TEMPLATE/ (kit, allow-extras)
  - scripts/ci/ (kit, allow-extras)
  - scripts/gh-projects/ (kit, allow-extras)
  - scripts/workflow/ (kit, allow-extras)

## Templated paths rendered (per-consumer facts applied)
  - eslint.config.js (templated, rendered from examples/eslint.config.js)


Authoring-Agent: claude

## Self-Review
- Correctness: mirrors mergepath@b17c998 HEAD state verbatim per the manifest. Each path was already reviewed in its upstream PR.
- Regression risk: low. Verbatim mirror; kit paths use allow-extras semantics so consumer-only files are kept.
- Style: N/A (mirror).
- Test coverage: relies on the consumer repo CI. No test changes shipped.
- Security: no new attack surface; `.sync-overrides.yml` was honored per-consumer so documented divergences are untouched.