### PR TITLE
sync: bulk reconcile to mergepath@75eae1c

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -43,12 +43,23 @@ jobs:
     # stays scoped to opened/ready/labeled. See #59 for the
     # SKIPPED-as-SUCCESS miss this
     # closes and Codex's P2 on PR #131 for why labeled is excluded.
+    # #557: ALSO run on approved pull_request_review events. The
+    # auto-merge-on-approval registered-reviewer gate (require_approval)
+    # reads needs.load-config.outputs.reviewers on the direct-approval
+    # path; if load-config is skipped on review events that list is empty,
+    # the gate defaults REVIEWERS_JSON to [], rejects every approver as
+    # "not a registered reviewer", and never arms auto-merge (the merge
+    # still backstops via merge-clearance-gate, but the convenience #544
+    # added — and the one-shot-arming gap #495 closed — regress). This job
+    # only reads the static review-policy.yml, so it is event-shape-agnostic.
     if: >
-      github.event_name == 'pull_request' &&
-      (github.event.action == 'opened' ||
-       github.event.action == 'ready_for_review' ||
-       github.event.action == 'synchronize' ||
-       github.event.action == 'reopened')
+      (github.event_name == 'pull_request' &&
+       (github.event.action == 'opened' ||
+        github.event.action == 'ready_for_review' ||
+        github.event.action == 'synchronize' ||
+        github.event.action == 'reopened')) ||
+      (github.event_name == 'pull_request_review' &&
+       github.event.review.state == 'approved')
     runs-on: ubuntu-latest
     outputs:
       threshold: ${{ steps.config.outputs.threshold }}

--- a/scripts/ci/check_no_bare_gh_writes
+++ b/scripts/ci/check_no_bare_gh_writes
@@ -69,7 +69,10 @@ function cmdsub_interiors(line,   i, c, n, depth, out, inbt, prev, q, oq, esc) {
   for (i = 1; i <= n; i++) {
     c = substr(line, i, 1)
     if (inbt) {
-      if (c == "`") { inbt = 0; out = out " " }
+      # #553 (Minor): honor a backslash-escaped backtick — bash treats `\`` as a
+      # literal backtick, not a span terminator, so a later gh write in the same
+      # legacy substitution is not split off and missed.
+      if (c == "`" && prev != "\\") { inbt = 0; out = out " " }
       else { out = out c }
       prev = c
       continue
@@ -128,7 +131,49 @@ function gh_write_in_cmdsub(line) {
   if (line !~ /\$\(/ && line !~ /`/) return 0
   return gh_write_class(cmdsub_interiors(line))
 }
-function bare_write(line) {
+# Return the substring of `line` AFTER the first TOP-LEVEL command separator
+# (`;`, `&&`, `||`, `|`, `&`) — a separator that is NOT inside single/double
+# quotes, a $(...) substitution, or a backtick span. Returns "" when the line is
+# a single top-level command. Used to stop the echo/printf exemption from
+# covering a SECOND command chained after the echo (#553). Bash-3.2-safe POSIX
+# awk: manual char walk mirroring the cmdsub_interiors quote/substitution walk.
+function tail_after_top_sep(line,   i, c, n, depth, inbt, oq, q, esc, prev) {
+  n = length(line); depth = 0; inbt = 0; oq = ""; q = ""; esc = 0; prev = ""
+  for (i = 1; i <= n; i++) {
+    c = substr(line, i, 1)
+    if (inbt) { if (c == "`" && prev != "\\") inbt = 0; prev = c; continue }
+    if (depth > 0) {
+      if (q != "") {
+        if (q == sq) { if (c == sq) q = "" }
+        else if (c == "\"" && prev != "\\") q = ""
+        prev = c; continue
+      }
+      if (c == sq) { q = sq; prev = c; continue }
+      if (c == "\"") { q = "\""; prev = c; continue }
+      if (c == "(" && prev == "$") depth++
+      else if (c == ")") depth--
+      prev = c; continue
+    }
+    if (esc) { esc = 0; prev = "x"; continue }
+    if (oq == sq) { if (c == sq) oq = ""; prev = c; continue }
+    if (c == "\\") { esc = 1; prev = c; continue }
+    if (oq == "\"") {
+      if (c == "\"") oq = ""
+      else if (c == "(" && prev == "$") depth = 1
+      else if (c == "`") inbt = 1
+      prev = c; continue
+    }
+    if (c == sq) { oq = sq; prev = c; continue }
+    if (c == "\"") { oq = "\""; prev = c; continue }
+    if (c == "(" && prev == "$") { depth = 1; prev = c; continue }
+    if (c == "`") { inbt = 1; prev = c; continue }
+    if (substr(line, i, 2) == "&&" || substr(line, i, 2) == "||") return substr(line, i + 2)
+    if (c == ";" || c == "|" || c == "&") return substr(line, i + 1)
+    prev = c
+  }
+  return ""
+}
+function bare_write(line,   rest) {
   if (line ~ /^[[:space:]]*($|#)/) return 0
   # Exemption requires a documented reason after the colon (#466): a bare
   # NO_BARE_GH_WRITE_EXEMPT: marker with no justification is too weak a
@@ -150,6 +195,13 @@ function bare_write(line) {
   # substitution contents before granting the exemption.
   if (line ~ /^[[:space:]]*(echo|printf)[[:space:]]/) {
     if (gh_write_in_cmdsub(line)) return 1
+    # #553 (Major): the echo/printf exemption must cover ONLY the echo/printf
+    # command itself, not a SECOND command chained after a top-level separator.
+    # `echo ok; gh pr merge 1` previously passed clean because this branch
+    # returned 0 without scanning past the `;`. Re-check the tail after the first
+    # top-level (unquoted, non-substitution) separator.
+    rest = tail_after_top_sep(line)
+    if (rest != "") return bare_write(rest)
     return 0
   }
   return gh_write_class(line)

--- a/scripts/ci/check_propagation_closure
+++ b/scripts/ci/check_propagation_closure
@@ -317,7 +317,7 @@ while IFS= read -r f; do
 
   # Extract candidate references: tests/test_<name>.sh and
   # scripts/<path>.{sh,cjs,js}. sort -u dedupes within a file.
-  refs=$(grep -oE '(tests/test_[A-Za-z0-9_-]+\.sh|scripts/[A-Za-z0-9_./-]+\.(sh|cjs|js))' "$f" | sort -u || true)
+  refs=$(grep -oE '(tests/[A-Za-z0-9_./-]+\.(sh|cjs|js)|scripts/[A-Za-z0-9_./-]+\.(sh|cjs|js))' "$f" | sort -u || true)
 
   while IFS= read -r ref; do
     [ -z "$ref" ] && continue

--- a/scripts/coderabbit-automerge-rate-limit-gate.sh
+++ b/scripts/coderabbit-automerge-rate-limit-gate.sh
@@ -45,17 +45,27 @@ if [ -z "$WAIT_JSON" ]; then
   exit 1
 fi
 
-failover=$(printf '%s' "$WAIT_JSON" | jq -r '.codex_failover_requested // false' 2>/dev/null || echo "false")
+# Gate 0: only downgrade an actual rate_limit_stalled status. A cleared or
+# timeout status with codex_failover_requested: true must NOT proceed —
+# the gate is exclusively for the exit-5 rate-limit-stalled path.
+status=$(printf '%s' "$WAIT_JSON" | jq -r '.status // ""' 2>/dev/null || echo "")
+if [ "$status" != "rate_limit_stalled" ]; then
+  echo "rate-limit-gate: status=${status} (expected rate_limit_stalled) — block (fail-closed)" >&2
+  exit 1
+fi
 
-if [ "$failover" != "true" ]; then
-  echo "rate-limit-gate: codex_failover_requested=${failover} — no failover engaged; block" >&2
+# Gate 1: require a real JSON boolean true (not a string "true"). jq -e exits
+# non-zero when the selected value is false or null, so a string "true" or an
+# absent field produces a non-zero exit and we block.
+if ! printf '%s' "$WAIT_JSON" | jq -e '.codex_failover_requested == true' >/dev/null 2>&1; then
+  echo "rate-limit-gate: codex_failover_requested is not JSON boolean true — no failover engaged; block" >&2
   exit 1
 fi
 
 if [ "$EXTERNAL_REVIEW_REQUIRED" != "true" ]; then
-  echo "rate-limit-gate: failover engaged but PR is under-threshold (external_review_required=${EXTERNAL_REVIEW_REQUIRED}) — no downstream Codex gate; block (#512 r3)" >&2
+  echo "rate-limit-gate: rate-limit stall + failover engaged but PR is under-threshold (external_review_required=${EXTERNAL_REVIEW_REQUIRED}) — no downstream Codex gate; block (#512 r3)" >&2
   exit 1
 fi
 
-echo "rate-limit-gate: failover engaged + external review required — merge-clearance gates Codex; proceed" >&2
+echo "rate-limit-gate: rate-limit stall + failover engaged + external review required — merge-clearance gates Codex; proceed" >&2
 exit 0

--- a/scripts/coderabbit-wait.sh
+++ b/scripts/coderabbit-wait.sh
@@ -827,11 +827,17 @@ count_potential_issues() {
 summary_body_has_potential_issue_marker() {
   local issue_comments latest_body
   issue_comments=$(fetch_api_array "repos/$REPO/issues/$PR_NUMBER/comments" "issue comments")
+  # Mirror latest_comment_from_issue_comments: exclude status-probe narration
+  # replies so a newer probe comment doesn't mask an earlier real summary that
+  # contains a "Potential issue" marker (false-clear of the #535 gate).
   latest_body=$(echo "$issue_comments" | jq -r --arg bot "$BOT_LOGIN" --arg after "$HEAD_ANCHOR" '
+    def status_probe_reply:
+      ((.body // "") | test("CodeRabbit review command invocation|Here.s a summary of where things stand|CodeRabbit is an incremental review system|does not re-review already reviewed commits"; "i"));
     [ .[]
       | select(.user.login == $bot)
       | . + {fresh_at: ([.created_at, (.updated_at // .created_at)] | max)}
       | select(.fresh_at >= $after)
+      | select(status_probe_reply | not)
     ]
     | sort_by(.fresh_at)
     | last

--- a/scripts/daily-feedback-rollup.sh
+++ b/scripts/daily-feedback-rollup.sh
@@ -357,20 +357,18 @@ while [ "$i" -lt "$pr_count" ]; do
     done
 
     if [ -n "$tag_class" ]; then
-      case "$tag_class" in
-        addressed-elsewhere|canonical-coverage|rebuttal-recorded)
-          COUNT_TAGGED_SKIP=$((COUNT_TAGGED_SKIP + 1))
-          continue
-          ;;
-        nitpick-noted|deferred-to-followup)
-          COUNT_TAGGED_SURFACE=$((COUNT_TAGGED_SURFACE + 1))
-          # Fall through to severity-routing below.
-          ;;
-        *)
-          # Unknown tag class → surface as substantive per spec.
-          COUNT_TAGGED_SURFACE=$((COUNT_TAGGED_SURFACE + 1))
-          ;;
-      esac
+      # Single-source the skip/surface decision through tag_class_action
+      # (scripts/lib/daily-feedback-rollup-helpers.sh) so this path cannot
+      # drift from the canonical taxonomy — the drift that previously omitted
+      # templated-render here and re-filed routed templated threads as
+      # deferred (#568, Codex P2 on #565). Unknown classes map to surface.
+      if [ "$(tag_class_action "$tag_class")" = "skip" ]; then
+        COUNT_TAGGED_SKIP=$((COUNT_TAGGED_SKIP + 1))
+        continue
+      else
+        # surface (incl. unknown) → fall through to severity-routing below.
+        COUNT_TAGGED_SURFACE=$((COUNT_TAGGED_SURFACE + 1))
+      fi
     else
       # Heuristic 2: addressed-via-fix — any agent-author commit on
       # the PR with authoredDate > comment.createdAt. The spec's

--- a/scripts/hooks/gh-pr-guard.sh
+++ b/scripts/hooks/gh-pr-guard.sh
@@ -261,6 +261,20 @@ elif echo "$COMMAND" | tr -d "\"'" | grep -qE '(^|[^A-Za-z0-9_])env([[:space:]]|
   # Quote-stripped (Codex #551): a quoted `'env'` runs env but would otherwise
   # leave a quote, not whitespace, after `env` and dodge this probe.
   NEEDS_TOKENIZE=1
+elif echo "$COMMAND" | tr -d "\"'" | grep -qE '\$\(|`' \
+     && echo "$COMMAND" | tr -d "\"'" \
+        | grep -qE '(^|[^A-Za-z0-9_])(pr|issue)[[:space:]]'; then
+  # #553 / #560: a command substitution can synthesize the executable name in
+  # COMMAND position (e.g. `$(printf '\147\150')` -> gh), so the raw command
+  # carries no literal `gh` and the gh / env -S probes above miss it. This holds
+  # even after a prefix command + options (`command -p`, `env -i`), a value-taking
+  # flag (`env -u NAME`), or a quoted env assignment (`FOO="a b"`) — forms the
+  # earlier command-position-only regex could not express. Force tokenization
+  # whenever a cmdsub coexists with a gh pr/issue write noun; the command-position
+  # forward pass below then fails closed ONLY on a genuine command-position synth
+  # write and ignores benign cmdsubs and arguments. Over-matching costs one
+  # tokenizer run; a false negative is a bypass.
+  NEEDS_TOKENIZE=1
 fi
 if [ "$NEEDS_TOKENIZE" -eq 0 ]; then
   exit 0
@@ -891,6 +905,87 @@ guarded_gh_invocation_label() {
 
   return 1
 }
+
+# #553 / #560: a command substitution in COMMAND position can synthesize the
+# executable name ($(printf '\147\150') -> gh), so the flattened
+# __MERGEPATH_CMDSUB__ placeholder sits where the command name belongs and the
+# literal-`gh` detection below misses it entirely. A single forward pass tracks
+# command position exactly as the main walk does — through prefix commands and
+# their boolean / value-taking flags (`prefix_flag_takes_value`) and
+# env-assignment prefixes — so a placeholder reached AT command position AND
+# directly followed by a guarded pr/issue write fails closed, even after
+# `command -p`, `env -i`, `env -u NAME`, or a quoted assignment (`FOO="a b"`)
+# (#560). A placeholder consumed as a value-taking flag's argument, or as a bare
+# assignment's VALUE (`X=$(gh pr merge)` lifts the real write into a later
+# ;-segment, #540), is NOT flagged; the main gh walk still catches any real write
+# lifted out of the substitution. Keeping this OUT of the main walk (no SAW_GH)
+# avoids the assignment-substitution command-position ambiguity.
+_synth_cp=1
+_synth_skip_val=0
+_synth_prefix=""
+for _ci in "${!TOKENS[@]}"; do
+  _stok="${TOKENS[$_ci]}"
+  if is_guard_separator "$_stok"; then
+    _synth_cp=1
+    _synth_skip_val=0
+    _synth_prefix=""
+    continue
+  fi
+  if [ "$_synth_skip_val" -eq 1 ]; then
+    _synth_skip_val=0
+    continue
+  fi
+  if [ "$_synth_cp" -eq 0 ]; then
+    continue
+  fi
+  case "$_stok" in
+    __MERGEPATH_CMDSUB__)
+      if _synth_label=$(guarded_gh_invocation_label "$_ci"); then
+        echo "BLOCKED: command-position command substitution may synthesize a gh write ($_synth_label)." >&2
+        echo "  A \$(...) or backtick in command position can produce the executable name" >&2
+        echo "  (e.g. \$(printf '\\147\\150') -> gh), so the guard cannot verify it. Run the" >&2
+        echo "  write directly through the verifying wrapper instead:" >&2
+        echo "    scripts/gh-as-author.sh -- gh ..." >&2
+        echo "    scripts/gh-as-reviewer.sh -- gh ..." >&2
+        exit 2
+      fi
+      # In command position but NOT followed by a guarded write (e.g. `$(date)`,
+      # or `X=$(gh pr merge)` whose real write is lifted past a `;`): treat the
+      # placeholder as the command and skip its arguments.
+      _synth_cp=0
+      continue
+      ;;
+    [A-Za-z_]*=)
+      # Bare assignment `NAME=`: the NEXT token is its VALUE (e.g. `X=$(...)`),
+      # not a command — consume it so a placeholder-as-value is not mis-read.
+      _synth_skip_val=1
+      continue
+      ;;
+    [A-Za-z_]*=*)
+      # Env-assignment prefix WITH an inline value (`FOO=1`, `FOO="a b"`): the
+      # real command (which may be a synth cmdsub) follows — stay command position.
+      continue
+      ;;
+    sudo|eval|time|nohup|env|command|exec|nice|ionice)
+      _synth_prefix="$_stok"
+      continue
+      ;;
+    -*)
+      # Flag of the current prefix command. A value-taking flag (`env -u NAME`,
+      # `sudo -u USER`) consumes the NEXT token as its value; a boolean flag
+      # (`command -p`, `env -i`) does not — either way we stay command position.
+      if prefix_flag_takes_value "$_synth_prefix" "$_stok"; then
+        _synth_skip_val=1
+      fi
+      continue
+      ;;
+    *)
+      # A real (non-gh) command — its arguments are not command position.
+      _synth_cp=0
+      continue
+      ;;
+  esac
+done
 
 COMPOUND_GH_COUNT=0
 COMPOUND_GUARDED_COUNT=0
@@ -2104,7 +2199,14 @@ fi
 # protection: even if branch protection is misconfigured or
 # disabled for an emergency hotfix, the hook will still refuse
 # to dispatch the merge.
-GH_JQ='.mergeStateStatus, .mergeable, ([.statusCheckRollup[] | {n:(.name//.context//"?"), c:(.conclusion//.state//"PENDING"), t:(.completedAt//.startedAt//"")}] | group_by(.n) | map(max_by(.t).c) | map(select(. != "SUCCESS" and . != "SKIPPED" and . != "NEUTRAL")) | length), .labels[].name'
+#
+# #553 (CodeRabbit Major): a check group counts as green ONLY if no run is
+# still pending AND its latest terminal run is green. The prior `max_by(.t).c`
+# alone mis-ranked an un-timestamped PENDING re-run (t="" sorts lowest) behind a
+# timestamped SUCCESS, so an UNSTABLE PR with a check still re-running counted
+# all-green and could merge before CI finished. `if any(.[]; .c=="PENDING")`
+# treats a group with ANY in-progress run as non-green regardless of timestamps.
+GH_JQ='.mergeStateStatus, .mergeable, ([.statusCheckRollup[] | {n:(.name//.context//"?"), c:(.conclusion//.state//"PENDING"), t:(.completedAt//.startedAt//"")}] | group_by(.n) | map(if any(.[]; .c == "PENDING") then "PENDING" else max_by(.t).c end) | map(select(. != "SUCCESS" and . != "SKIPPED" and . != "NEUTRAL")) | length), .labels[].name'
 GH_ARGS=(pr view --json labels,mergeStateStatus,mergeable,statusCheckRollup --jq "$GH_JQ")
 if [ -n "$PR_SELECTOR" ]; then
   GH_ARGS=(pr view "$PR_SELECTOR" --json labels,mergeStateStatus,mergeable,statusCheckRollup --jq "$GH_JQ")

--- a/scripts/lib/preflight-helpers.sh
+++ b/scripts/lib/preflight-helpers.sh
@@ -138,6 +138,39 @@ auto_source_preflight() {
   return 0
 }
 
+# Load OP_PREFLIGHT_* env vars from the cache file unconditionally —
+# even when GH_TOKEN is already set. auto_source_preflight skips when
+# GH_TOKEN is present (to preserve caller-provided creds), but callers
+# that build a per-command token pin like
+#   GH_TOKEN="${OP_PREFLIGHT_REVIEWER_PAT:-${GH_TOKEN:-}}" gh api ...
+# need OP_PREFLIGHT_REVIEWER_PAT populated from disk even when an ambient
+# GH_TOKEN is already exported. GH_TOKEN is restored to its prior value
+# after sourcing so the caller's ambient token is not displaced.
+# Returns 0 in all cases (callers tolerate a missing cache gracefully).
+load_preflight_env_vars() {
+  local agent cache_dir session_file _saved_gh_token _r _a
+  agent="$(preflight_agent)"
+  [[ -z "$agent" ]] && return 0
+  cache_dir="$(preflight_cache_dir)"
+  session_file="$cache_dir/op-preflight-${agent}.env"
+  preflight_session_is_fresh "$session_file" || return 0
+  _saved_gh_token="${GH_TOKEN:-}"
+  # Source in a subshell and copy back only the two PAT vars. The session file
+  # can include deploy credentials (GOOGLE_APPLICATION_CREDENTIALS, CF_API_TOKEN)
+  # from a prior --mode deploy run; subshell isolation prevents those from
+  # leaking into the caller's process. (#554/#556 CodeRabbit Major)
+  # shellcheck disable=SC1090
+  _r=$(. "$session_file" 2>/dev/null && printf '%s' "${OP_PREFLIGHT_REVIEWER_PAT:-}") || true
+  # shellcheck disable=SC1090
+  _a=$(. "$session_file" 2>/dev/null && printf '%s' "${OP_PREFLIGHT_AUTHOR_PAT:-}") || true
+  [[ -n "${_r:-}" ]] && OP_PREFLIGHT_REVIEWER_PAT="$_r"
+  [[ -n "${_a:-}" ]] && OP_PREFLIGHT_AUTHOR_PAT="$_a"
+  if [[ -n "$_saved_gh_token" ]]; then
+    GH_TOKEN="$_saved_gh_token"
+  fi
+  return 0
+}
+
 # Convenience wrappers: helpers that need a reviewer-scoped token call
 # `preflight_require_token reviewer`; helpers that want author scope
 # pass `author`. The function auto-sources the cache (if needed) and

--- a/scripts/lib/template-substitution.sh
+++ b/scripts/lib/template-substitution.sh
@@ -138,8 +138,13 @@ template_substitution::eval_expr() {
     "!"*)
       local inner=${expr#!}
       inner=$(printf '%s' "$inner" | sed -e 's/^[[:space:]]*//')
-      local v
-      v=$(template_substitution::_fact_value "$inner") || return $?
+      local v rc=0
+      # Existence-check: strict mode must not abort here — an unset fact is
+      # simply false (and therefore !key is true). Suppress strict for the
+      # _fact_value call; treat rc 3 (strict-mode fact-miss) as "unset".
+      v=$(MERGEPATH_TEMPLATE_STRICT=0; template_substitution::_fact_value "$inner") || rc=$?
+      if [ "$rc" -eq 3 ]; then return 0; fi  # unset → !key is true
+      if [ "$rc" -ne 0 ]; then return "$rc"; fi
       if [ -z "$v" ]; then return 0; else return 1; fi
       ;;
     *" contains "*)
@@ -179,9 +184,12 @@ template_substitution::eval_expr() {
       return 2
       ;;
     *)
-      # Bare key — truthy iff non-empty.
-      local v
-      v=$(template_substitution::_fact_value "$expr") || return $?
+      # Bare key — truthy iff non-empty. Strict mode must not abort here —
+      # an unset fact is simply false for the existence check.
+      local v rc=0
+      v=$(MERGEPATH_TEMPLATE_STRICT=0; template_substitution::_fact_value "$expr") || rc=$?
+      if [ "$rc" -eq 3 ]; then return 1; fi  # unset → bare-key is false
+      if [ "$rc" -ne 0 ]; then return "$rc"; fi
       if [ -n "$v" ]; then return 0; else return 1; fi
       ;;
   esac

--- a/scripts/phase-4b-classifier.sh
+++ b/scripts/phase-4b-classifier.sh
@@ -60,6 +60,12 @@ if [ -r "$__P4B_CLASSIFIER_DIR/lib/preflight-helpers.sh" ]; then
   # shellcheck source=lib/preflight-helpers.sh
   . "$__P4B_CLASSIFIER_DIR/lib/preflight-helpers.sh"
   preflight_require_token reviewer || true
+  # Also load OP_PREFLIGHT_REVIEWER_PAT from disk even when an ambient
+  # GH_TOKEN is already set — preflight_require_token returns early on a
+  # pre-existing GH_TOKEN, so without this call the per-command reviewer
+  # PAT pin at the live gh api calls below would fall back to the bare
+  # ambient token instead of the cached reviewer PAT (#554 fix).
+  load_preflight_env_vars
 fi
 
 # ── Argument parsing ─────────────────────────────────────────────────────────

--- a/scripts/resolve-pr-threads.sh
+++ b/scripts/resolve-pr-threads.sh
@@ -35,7 +35,35 @@
 #                           bot-only mode. Follow REVIEW_POLICY.md's
 #                           pre-merge gate for agent-reviewer vs
 #                           real-human threads.
-#   --dry-run               With --auto-resolve-bots, print what would
+#   --resolve-actioned      Like --auto-resolve-bots (same bot-author,
+#                           current-HEAD, identity, tag-reply, and readback
+#                           handling) but resolves a thread ONLY when its
+#                           derived class proves ACTION on this PR:
+#                           addressed-elsewhere (an agent commit touching the
+#                           anchored file, after the latest re-raise) or
+#                           rebuttal-recorded (a substantive agent rebuttal
+#                           after the latest re-raise). Routing-only classes
+#                           — canonical-coverage / templated-render — are
+#                           NOT actioned here: they show WHERE a fix belongs
+#                           (upstream), not that one happened, so a fresh
+#                           finding on a canonical path must not be resolved
+#                           by routing alone (#565). The gate evaluates
+#                           action INDEPENDENTLY of routing, so a
+#                           canonical/templated thread that DOES carry action
+#                           evidence (a fix commit touching it, or a
+#                           rebuttal) is still resolved. Routing-only threads,
+#                           plus
+#                           nitpick-noted / deferred-to-followup and any
+#                           class that can't be positively determined, are
+#                           LEFT UNRESOLVED so the weekly unresolved-
+#                           feedback sweep keeps surfacing them (#564). Use
+#                           this to mark genuinely-handled feedback resolved
+#                           without the blunt "resolve everything" of
+#                           --auto-resolve-bots. To merge past a deferral on
+#                           a conversation-resolution-gated repo, fix/rebut
+#                           it (making it actioned) or defer it explicitly
+#                           via --auto-resolve-bots --rationale.
+#   --dry-run               With either resolve mode, print what would
 #                           be resolved without mutating.
 #   --rationale <text>      With --auto-resolve-bots, override the
 #                           auto-synthesized class with a free-form
@@ -83,7 +111,12 @@
 # Exit codes:
 #   0 — no unresolved threads
 #   1 — bad arguments
-#   2 — gh failure (auth, missing PR, network)
+#   2 — gh failure (auth, missing PR, network), a resolve mutation that did
+#       not return isResolved:true, OR a post-resolve readback that could
+#       not confirm isResolved:true (#564 — fail closed). After every
+#       --auto-resolve-bots run, the helper re-reads each thread it
+#       resolved via a `nodes(ids:)` readback and refuses to report success
+#       unless GitHub confirms isResolved:true for all of them.
 #   3 — unresolved threads exist (in --list mode); call again with
 #       --auto-resolve-bots after addressing findings, or resolve
 #       human-authored threads via the GitHub UI.
@@ -119,16 +152,22 @@ fi
 usage() {
   cat <<'EOF' >&2
 Usage: scripts/resolve-pr-threads.sh <PR#> [--repo owner/name] [--list]
-                                            [--auto-resolve-bots] [--dry-run]
-                                            [--rationale <text>] [--no-tag-reply]
+                                            [--auto-resolve-bots | --resolve-actioned]
+                                            [--dry-run] [--rationale <text>] [--no-tag-reply]
 
   --list                List unresolved threads (default).
-  --auto-resolve-bots   Resolve bot-authored threads on current HEAD.
-  --dry-run             With --auto-resolve-bots, print without mutating.
+  --auto-resolve-bots   Resolve ALL current-HEAD bot-authored threads
+                        (clears the conversation-resolution gate; the
+                        daily rollup re-surfaces deferrals).
+  --resolve-actioned    Resolve ONLY current-HEAD bot threads whose fix or
+                        rebuttal is demonstrable (derived class in the
+                        actioned skip-set); leave the rest unresolved so
+                        the weekly sweep keeps surfacing them.
+  --dry-run             With either resolve mode, print without mutating.
   --rationale <text>    With --auto-resolve-bots, free-form rationale
                         appended after the [mergepath-resolve: deferred-to-followup]
                         tag (overrides auto-classification).
-  --no-tag-reply        With --auto-resolve-bots, suppress the
+  --no-tag-reply        With either resolve mode, suppress the
                         [mergepath-resolve:<class>] reply emission
                         (the resolve mutation still runs).
 EOF
@@ -164,6 +203,7 @@ while [ $# -gt 0 ]; do
       REPO="$2"; shift 2 ;;
     --list) MODE="list"; shift ;;
     --auto-resolve-bots) MODE="auto-resolve-bots"; shift ;;
+    --resolve-actioned) MODE="resolve-actioned"; shift ;;
     --dry-run) DRY_RUN=true; shift ;;
     --rationale)
       # Same defensive value check as --repo (Codex r2 on PR #172):
@@ -193,6 +233,20 @@ done
 # PR_NUM must be a positive integer (no leading zeros, no other chars).
 if ! [[ "$PR_NUM" =~ ^[1-9][0-9]*$ ]]; then
   echo "Invalid PR number: '$PR_NUM' (must be a positive integer)" >&2
+  exit 1
+fi
+
+# #565: --rationale is an --auto-resolve-bots affordance (override the class
+# for a deliberate deferred resolve). It is incompatible with
+# --resolve-actioned, whose whole contract is to resolve ONLY on derived
+# action evidence — a free-form rationale override would resolve a thread
+# while mis-tagging it deferred-to-followup, so the daily rollup would treat
+# an actioned, resolved thread as deferred/unhandled. Reject the combo.
+if [ "$MODE" = "resolve-actioned" ] && $RATIONALE_FLAG_USED; then
+  echo "Error: --rationale is not valid with --resolve-actioned (it applies" >&2
+  echo "       only to --auto-resolve-bots). --resolve-actioned resolves on" >&2
+  echo "       derived action evidence; use --auto-resolve-bots --rationale" >&2
+  echo "       to deliberately resolve a deferred thread with a rationale." >&2
   exit 1
 fi
 
@@ -239,6 +293,13 @@ fi
 
 OWNER="${REPO%/*}"
 NAME="${REPO#*/}"
+
+# Per-commit file-list cache for the addressed-elsewhere check (#565). Keyed
+# by commit SHA, stored on disk so the cache survives the command-substitution
+# subshells that derive_tag_class / synth_rationale run in (a shell-var cache
+# would be lost when those subshells exit). Removed on exit.
+COMMIT_FILES_CACHE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/resolve-pr-commitfiles.XXXXXX")"
+trap 'rm -rf "$COMMIT_FILES_CACHE_DIR"' EXIT
 
 # Fetch the PR's current HEAD commit oid — used by --auto-resolve-bots
 # to verify each thread's latest comment is on the current HEAD before
@@ -329,15 +390,24 @@ QUERY='
             # and substantive rebuttal detection (≥30 chars from an
             # agent author → `rebuttal-recorded`).
             #
-            # Cap at first 50 — same conservative limit as commentsFirst.
-            # A thread deep enough to exceed 50 replies during one
-            # auto-resolve invocation is vanishingly rare and would
-            # already be a process-smell worth surfacing manually.
-            allComments: comments(first: 50) {
+            # `last: 50` (not first: 50) — the staleness checks (#565) need
+            # the MOST RECENT comments: latest_nonagent_created and the
+            # last-word marker/rebuttal logic must see a bot re-raise even on
+            # a long thread. `first: 50` truncated the newest comments, so a
+            # re-raise past comment 50 was invisible and an older fix/rebuttal
+            # looked like the latest word — resolving live feedback (Codex P2
+            # on #565). The most-recent 50 always include the latest re-raise;
+            # only very old comments (>50 back) drop off, and those never make
+            # a thread look MORE actioned, so the gate stays fail-safe.
+            allComments: comments(last: 50) {
               nodes {
                 author { login }
                 body
                 databaseId
+                # createdAt powers the addressed-elsewhere staleness guard
+                # (#565): a fix commit must post-date the LATEST bot/reviewer
+                # comment, not just the original finding, to count as actioning.
+                createdAt
               }
             }
           }
@@ -519,6 +589,63 @@ is_agent_author_local() {
   return 1
 }
 
+# latest_nonagent_created <thread_json> → ISO timestamp on stdout.
+# The createdAt of the most recent NON-agent (bot / real-reviewer) comment on
+# the thread, floored at the original finding's createdAt (`.created`). This is
+# the "bot's last word" timestamp used by the addressed-elsewhere staleness
+# guard (#565): a fix commit only counts as actioning the thread if it
+# post-dates this — otherwise a stale fix that predates a later bot re-raise
+# would falsely clear live feedback. ISO 8601 sorts lexicographically, so the
+# `\>` string comparison is chronological. Single-sourced here so
+# derive_tag_class and synth_rationale apply the identical predicate.
+latest_nonagent_created() {
+  local tj="$1"
+  local latest cnt i login created
+  latest=$(printf '%s' "$tj" | jq -r '.created // ""')
+  cnt=$(printf '%s' "$tj" | jq '.all_comments | length' 2>/dev/null || echo 0)
+  i=0
+  while [ "$i" -lt "$cnt" ]; do
+    login=$(printf '%s' "$tj" | jq -r ".all_comments[$i].author.login // \"\"")
+    if ! is_agent_author_local "$login"; then
+      created=$(printf '%s' "$tj" | jq -r ".all_comments[$i].createdAt // \"\"")
+      if [ -n "$created" ] && { [ -z "$latest" ] || [ "$created" \> "$latest" ]; }; then
+        latest="$created"
+      fi
+    fi
+    i=$((i + 1))
+  done
+  printf '%s' "$latest"
+}
+
+# commit_files <sha> → JSON array of the filenames a commit touched, on
+# stdout ("" if the per-commit fetch fails). Disk-cached under
+# COMMIT_FILES_CACHE_DIR so each sha is fetched at most once across the
+# per-thread command-substitution subshells. The PR /commits cache carries
+# no file list, so addressed-elsewhere needs this per-commit lookup (#565).
+commit_files() {
+  local sha="$1"
+  [ -z "$sha" ] && return 0
+  local cf="$COMMIT_FILES_CACHE_DIR/$sha"
+  if [ ! -f "$cf" ]; then
+    gh_pat api "repos/$OWNER/$NAME/commits/$sha" --jq '[.files[].filename]' \
+      >"$cf" 2>/dev/null || : >"$cf"
+  fi
+  cat "$cf"
+}
+
+# commit_touches_file <sha> <path> → exit 0 if the commit's file list
+# includes <path>, 1 otherwise. FAIL CLOSED (#565): a commit whose files
+# cannot be read (empty result) does NOT match, so a fetch failure can never
+# make a thread look actioned, and an agent commit on an UNRELATED file no
+# longer satisfies addressed-elsewhere for this thread.
+commit_touches_file() {
+  local sha="$1" path="$2" files
+  { [ -z "$sha" ] || [ -z "$path" ] || [ "$path" = "(no path)" ]; } && return 1
+  files=$(commit_files "$sha")
+  [ -z "$files" ] && return 1
+  printf '%s' "$files" | jq -e --arg p "$path" 'any(. == $p)' >/dev/null 2>&1
+}
+
 # classify_severity_local <body> → P0|P1|...|Nitpick|Trivial|Unknown
 # Mirrors the rollup helpers' classify_severity, anchored on the
 # first ~600 chars to avoid false-matching severity words deep in
@@ -564,9 +691,16 @@ fetch_pr_tag_data() {
   # PR_COMMITS_CACHE now includes `sha` so synth_rationale can cite
   # the matching commit. The predicate the rationale builds must
   # match derive_tag_class's predicate (CodeRabbit major on #308).
+  # login fallback chain (#565 round 8): .author.login is null for commits
+  # whose author email is not linked to a GitHub account — which is THIS
+  # repo's normal case (commits are authored as nathanjohnpayne with a
+  # placeholder .example email). So fall back to .commit.author.name (the git
+  # config name, e.g. "nathanjohnpayne", which IS in MERGEPATH_AGENT_AUTHORS)
+  # BEFORE the email, or agent fix commits are never recognized as
+  # agent-authored and addressed-elsewhere never fires.
   PR_COMMITS_CACHE=$(_fetch_paginated \
     "repos/$OWNER/$NAME/pulls/$PR_NUM/commits" \
-    '[.[] | {sha: (.sha // ""), login: (.author.login // .commit.author.email // ""), date: (.commit.author.date // .commit.committer.date // "")}]')
+    '[.[] | {sha: (.sha // ""), login: (.author.login // .commit.author.name // .commit.author.email // ""), date: (.commit.author.date // .commit.committer.date // "")}]')
 }
 
 # _fetch_paginated <base-url> <jq-projection> → JSON array on stdout.
@@ -751,13 +885,39 @@ fetch_manifest_templated_dests() {
     #    the yq semantics. A `consumers:` followed by a name SEQUENCE stays
     #    the cautious no-scope sentinel (awk can't reliably resolve
     #    name→repo cross-references), matching the prior behavior for lists.
-    MANIFEST_TEMPLATED_DESTS_CACHE=$(awk '
+    # Pre-extract top-level consumer repos so the awk path can resolve
+    # `consumers: all` to an actual repo slug list — matching what the yq
+    # pass-1 does via `$root.consumers | map(.repo) | join(",")`. Without
+    # this, the `consumers: all` sentinel matched every repo unconditionally,
+    # including foreign repos not in the consumers list (#554 item 1 / #556).
+    local _awk_all_repos
+    _awk_all_repos=$(awk '
+      /^consumers:/ { in_c=1; next }
+      in_c && /^[^[:space:]#]/ { in_c=0 }
+      in_c && /^[[:space:]]*repo:/ {
+        v=$0
+        sub(/^[[:space:]]*repo:[[:space:]]*/, "", v)
+        sub(/[[:space:]]*#.*$/, "", v)
+        gsub(/^[[:space:]]+|[[:space:]]+$|^["\047]|["\047]$/, "", v)
+        if (v != "") repos = repos (repos=="" ? "" : ",") v
+      }
+      END { print repos }
+    ' "$manifest" 2>/dev/null || true)
+    MANIFEST_TEMPLATED_DESTS_CACHE=$(awk -v all_repos="$_awk_all_repos" '
       function emit() {
         if (cur_type == "templated") {
           out = (cur_dest != "" ? cur_dest : cur_path)
           if (out != "") {
             if (cur_consumers_all) {
-              printf "%s\t__AWK_CONSUMERS_ALL__\n", out
+              # Resolve `consumers: all` to the actual consumer repo list so
+              # path_matches_templated_dest can check $REPO membership, mirroring
+              # the yq pass-1 behaviour. Fall back to no-scope if the list is
+              # empty (cannot determine membership → conservative non-match).
+              if (all_repos != "") {
+                printf "%s\t%s\n", out, all_repos
+              } else {
+                printf "%s\t__AWK_NO_CONSUMER_SCOPE__\n", out
+              }
             } else {
               printf "%s\t__AWK_NO_CONSUMER_SCOPE__\n", out
             }
@@ -813,12 +973,14 @@ path_matches_templated_dest() {
     dest="${line%%$'\t'*}"
     consumers="${line#*$'\t'}"
     [ "$file_path" = "$dest" ] || continue
-    # The awk fallback emits a scalar-`consumers: all` sentinel (#521).
-    # `all` means every consumer is in scope, so the current repo always
-    # qualifies — match unconditionally, mirroring the yq path which
-    # expands `all` to every consumer's repo slug.
+    # Legacy sentinel — the awk fallback previously emitted this when it
+    # detected `consumers: all` but could not resolve the consumer repo list.
+    # The awk path now resolves `all` to the actual repo slug list (matching
+    # the yq path), so this sentinel is no longer emitted in practice (#556).
+    # Kept as a safety net: if somehow emitted, fall through to no-scope
+    # (conservative non-match) rather than matching unconditionally.
     if [ "$consumers" = "__AWK_CONSUMERS_ALL__" ]; then
-      return 0
+      continue
     fi
     # The awk fallback emits this sentinel when it can't resolve
     # consumer-name → repo-slug (cross-references in awk are
@@ -885,15 +1047,93 @@ REPO_ROOT_FOR_MANIFEST="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # about WHERE the durable fix should live.)
 derive_tag_class() {
   local thread_json="$1"
+  # skip_routing (#565): when non-empty (the --resolve-actioned GATE path),
+  # the routing-only classes canonical-coverage / templated-render are NOT
+  # emitted — neither from a recorded marker (step 0) nor from the path
+  # checks (steps 1 / 1b) — so the ladder falls through to real ACTION
+  # evidence (addressed-elsewhere / rebuttal-recorded). The default (empty)
+  # keeps the routing-first ladder for the --auto-resolve-bots tag / daily
+  # rollup, where routing context is wanted. This decouples the actioned
+  # GATE (needs proof of action) from the routing TAG (proof of where a fix
+  # belongs): a fresh canonical-path finding is still NOT actioned, but a
+  # canonical-path thread that WAS fixed or rebutted now is (nathanpayne-codex
+  # P1 CHANGES_REQUESTED on #565 — routing was masking real action evidence).
+  local skip_routing="${2:-}"
   local thread_path
-  local thread_created
   local thread_body
   thread_path=$(printf '%s' "$thread_json" | jq -r '.path // ""')
-  thread_created=$(printf '%s' "$thread_json" | jq -r '.created // ""')
   thread_body=$(printf '%s' "$thread_json" | jq -r '.body // ""')
+  # NB: the original-finding timestamp (.created) is intentionally NOT used
+  # directly for the addressed-elsewhere check — that compares against the
+  # LATEST bot/reviewer comment via latest_nonagent_created (#565).
 
-  # 1. canonical-coverage
-  if path_matches_manifest "$thread_path"; then
+  # 0. honor an existing [mergepath-resolve: <class>] marker (#564, Codex
+  # P2 + CodeRabbit Major on #565). A prior resolve attempt — e.g. a
+  # deferred-to-followup that was tagged but whose resolve readback-failed,
+  # or a thread re-opened after tagging — leaves an agent-authored marker
+  # reply on the thread. That marker records an explicit classification
+  # decision and is preferred over the heuristic ladder below: without it,
+  # the rebuttal-recorded step (#3) mis-reads the marker reply itself (it is
+  # ≥30 chars and agent-authored) as a rebuttal. Mirrors
+  # daily-feedback-rollup-helpers.sh, which also prefers the recorded tag.
+  #
+  # STALENESS GUARD (CodeRabbit Major on #565): a marker is authoritative
+  # only as the agent's "last word". An ACTIONED marker followed by fresh
+  # non-agent (bot/reviewer) feedback is stale — honoring it would resolve a
+  # thread the bot just re-raised — so it is honored ONLY when it post-dates
+  # the most recent non-agent comment; otherwise it falls through to the
+  # ladder (which applies the same last-word rule to rebuttals). A SURFACE
+  # marker (nitpick-noted / deferred-to-followup) is honored regardless,
+  # because it only ever causes a skip — the fail-closed/safe outcome — even
+  # if later replies exist. Most-recent valid marker wins; an unrecognized
+  # class is ignored. `last_nonagent_idx` is reused by step 3.
+  local recorded_class="" rc_count rc_i rc_login rc_body rc_tag
+  local last_marker_idx=-1 last_nonagent_idx=-1
+  rc_count=$(printf '%s' "$thread_json" | jq '.all_comments | length' 2>/dev/null || echo 0)
+  rc_i=0
+  while [ "$rc_i" -lt "$rc_count" ]; do
+    rc_login=$(printf '%s' "$thread_json" | jq -r ".all_comments[$rc_i].author.login // \"\"")
+    if is_agent_author_local "$rc_login"; then
+      rc_body=$(printf '%s' "$thread_json" | jq -r ".all_comments[$rc_i].body // \"\"")
+      rc_tag=$(printf '%s' "$rc_body" \
+        | sed -n 's/.*\[mergepath-resolve:[[:space:]]*\([a-z][a-z-]*\)[[:space:]]*\].*/\1/p' | head -1)
+      if [ -n "$rc_tag" ]; then recorded_class="$rc_tag"; last_marker_idx=$rc_i; fi
+    else
+      last_nonagent_idx=$rc_i
+    fi
+    rc_i=$((rc_i + 1))
+  done
+  # Honor a recorded marker ONLY in the TAG path (default). The GATE path
+  # (--resolve-actioned / skip_routing) treats ANY marker as rationale only
+  # and falls through to re-derive fresh evidence below — so a stale marker
+  # (from an earlier deferral, a readback-failed resolve, or the older weak
+  # heuristic this patch replaces) can never resolve a thread without
+  # re-checking the fix commit / rebuttal against the latest comments. This
+  # closes the marker-staleness cluster on #565 (re-verify actioned markers;
+  # let later fixes override stale surface markers; don't let stale deferral
+  # tags mask later rebuttals). `last_nonagent_idx` is reused by step 3.
+  if [ -z "$skip_routing" ]; then
+    case "$recorded_class" in
+      addressed-elsewhere|rebuttal-recorded)
+        # Genuinely-actioned marker: honor only if it is the agent's last
+        # word, so a stale marker followed by fresh bot feedback cannot
+        # resolve a re-raised thread.
+        if [ "$last_marker_idx" -gt "$last_nonagent_idx" ]; then
+          echo "$recorded_class"
+          return
+        fi ;;
+      canonical-coverage|templated-render|nitpick-noted|deferred-to-followup)
+        # Routing / surface markers: honoring even a stale one only routes or
+        # skips (never a wrong resolve), so the TAG path honors it
+        # unconditionally to keep the recorded class flowing to the rollup.
+        echo "$recorded_class"
+        return ;;
+    esac
+  fi
+
+  # 1. canonical-coverage (routing — skipped in the GATE path so real action
+  # evidence on a canonical path is not masked, #565).
+  if [ -z "$skip_routing" ] && path_matches_manifest "$thread_path"; then
     echo "canonical-coverage"
     return
   fi
@@ -906,45 +1146,59 @@ derive_tag_class() {
   # the path predicate alone is the right signal: if a thread is
   # anchored on the templated dest, the durable fix is either in
   # mergepath's template or in the consumer's facts:* block.
-  if path_matches_templated_dest "$thread_path"; then
+  if [ -z "$skip_routing" ] && path_matches_templated_dest "$thread_path"; then
     echo "templated-render"
     return
   fi
 
-  # 2. addressed-elsewhere — agent-author commit on PR with
-  # authoredDate > createdAt AND (file in PR's changed-files OR
-  # changed-files unavailable). Per-file precision when we can get
-  # it; falls back to the rollup's per-PR weak heuristic when the
-  # files endpoint is unreachable.
+  # 2. addressed-elsewhere — an agent-authored commit that BOTH (a)
+  # post-dates the latest bot/reviewer comment (the #565 staleness guard)
+  # AND (b) actually TOUCHES the anchored file. Both are required.
+  #
+  # The earlier form gated on two independent PR-level facts — "the anchored
+  # file is in the PR's overall changed-file list" AND "some agent commit
+  # post-dates the re-raise" — which do not compose: an agent commit on an
+  # UNRELATED file could satisfy the date check while a stale/earlier commit
+  # was the only one touching the anchored file, so live feedback got
+  # resolved (nathanpayne-codex CHANGES_REQUESTED on #565). The PR /commits
+  # cache has no per-commit file list, so confirm per commit via
+  # commit_touches_file (cached). Fail closed: a commit whose files cannot
+  # be read does not qualify, and a pathless thread cannot be proven here.
   fetch_pr_tag_data
-  if [ -n "$thread_created" ] && [ -n "$PR_COMMITS_CACHE" ]; then
-    local file_match=false
-    if [ -n "$thread_path" ] && [ "$thread_path" != "(no path)" ]; then
-      if printf '%s' "$PR_FILES_CACHE" \
-         | jq -e --arg p "$thread_path" 'any(. == $p)' >/dev/null 2>&1; then
-        file_match=true
+  local last_nonagent_created
+  last_nonagent_created=$(latest_nonagent_created "$thread_json")
+  if [ -n "$last_nonagent_created" ] && [ -n "$PR_COMMITS_CACHE" ] \
+     && [ -n "$thread_path" ] && [ "$thread_path" != "(no path)" ]; then
+    # Cheap PR-level pre-filter: if the PR's overall changed-file list is
+    # known and does NOT include the anchored file, no commit touched it —
+    # skip the per-commit fetches. When the list is empty/unavailable we
+    # cannot pre-filter, so fall through to the authoritative per-commit
+    # check below (which is itself fail-closed).
+    local pr_touched_file=true
+    if [ -n "$PR_FILES_CACHE" ] && [ "$PR_FILES_CACHE" != "[]" ]; then
+      if ! printf '%s' "$PR_FILES_CACHE" \
+           | jq -e --arg p "$thread_path" 'any(. == $p)' >/dev/null 2>&1; then
+        pr_touched_file=false
       fi
     fi
-    # When PR_FILES_CACHE failed to populate (network error → '[]'),
-    # treat as match-any so we fall back to the per-PR heuristic
-    # rather than under-classifying.
-    if [ "$PR_FILES_CACHE" = "[]" ] || [ -z "$PR_FILES_CACHE" ]; then
-      file_match=true
-    fi
-    if $file_match; then
+    if $pr_touched_file; then
       local commit_count
       commit_count=$(printf '%s' "$PR_COMMITS_CACHE" | jq 'length' 2>/dev/null || echo 0)
       local i=0
       while [ "$i" -lt "$commit_count" ]; do
         local c_login
         local c_date
+        local c_sha
         c_login=$(printf '%s' "$PR_COMMITS_CACHE" | jq -r ".[$i].login // \"\"")
         c_date=$(printf '%s' "$PR_COMMITS_CACHE" | jq -r ".[$i].date // \"\"")
+        c_sha=$(printf '%s' "$PR_COMMITS_CACHE" | jq -r ".[$i].sha // \"\"")
+        # Order matters: cheap date/identity checks short-circuit BEFORE the
+        # per-commit file fetch, so we only fetch files for an agent commit
+        # that post-dates the re-raise.
         if [ -n "$c_login" ] && [ -n "$c_date" ] \
-           && [ "$c_date" \> "$thread_created" ] \
-           && is_agent_author_local "$c_login"; then
-          # Short SHA on stdout would be nice — emit the class and
-          # let the caller render the SHA into the rationale.
+           && [ "$c_date" \> "$last_nonagent_created" ] \
+           && is_agent_author_local "$c_login" \
+           && commit_touches_file "$c_sha" "$thread_path"; then
           echo "addressed-elsewhere"
           return
         fi
@@ -958,12 +1212,26 @@ derive_tag_class() {
   local reply_count
   reply_count=$(printf '%s' "$thread_json" | jq '.all_comments | length' 2>/dev/null || echo 0)
   if [ "$reply_count" -gt 1 ]; then
-    local k=1
+    # Only replies AFTER the bot's most recent comment count (CodeRabbit
+    # Major on #565): a rebuttal that predates a later bot re-raise is stale
+    # and must not mark the thread actioned. last_nonagent_idx was computed
+    # in step 0. Start the scan just past the last non-agent comment (but at
+    # least index 1, to always skip the original finding at index 0).
+    local k=$((last_nonagent_idx + 1))
+    [ "$k" -lt 1 ] && k=1
     while [ "$k" -lt "$reply_count" ]; do
       local r_login
+      local r_body
       local r_body_len
       r_login=$(printf '%s' "$thread_json" | jq -r ".all_comments[$k].author.login // \"\"")
-      r_body_len=$(printf '%s' "$thread_json" | jq -r ".all_comments[$k].body // \"\" | length")
+      r_body=$(printf '%s' "$thread_json" | jq -r ".all_comments[$k].body // \"\"")
+      r_body_len=${#r_body}
+      # Skip our own [mergepath-resolve: ...] marker replies — a resolution
+      # marker is not a rebuttal (step 0 already honored a recognized one;
+      # this also covers an unrecognized-class marker). Codex P2 on #565.
+      case "$r_body" in
+        *"[mergepath-resolve:"*) k=$((k + 1)); continue ;;
+      esac
       if [ -n "$r_login" ] && [ "$r_body_len" -ge 30 ] && is_agent_author_local "$r_login"; then
         echo "rebuttal-recorded"
         return
@@ -983,6 +1251,41 @@ derive_tag_class() {
   echo "deferred-to-followup"
 }
 
+# class_is_actioned <class> — exit 0 if the class is a DEMONSTRABLY-ACTIONED
+# class, 1 otherwise. This is the gate for --resolve-actioned (#564): only
+# resolve threads whose fix or accepted rebuttal is demonstrable from the
+# current PR state, leaving the rest unresolved so the weekly sweep keeps
+# surfacing them.
+#
+# Only two classes prove ACTION on this PR:
+#   addressed-elsewhere  an agent commit that touches the anchored file and
+#                        post-dates the latest re-raise (verified per-commit)
+#   rebuttal-recorded    a substantive agent rebuttal that post-dates the
+#                        latest re-raise on the thread
+#
+# This is intentionally STRICTER than (a subset of) the rollup's skip-set in
+# scripts/lib/daily-feedback-rollup-helpers.sh `tag_class_action`, which also
+# skips canonical-coverage and templated-render. Those are ROUTING classes —
+# derived from path/manifest membership alone, before any fix-commit or
+# rebuttal evidence. Routing tells you WHERE a durable fix belongs (upstream
+# in mergepath), NOT that one happened: a fresh, unfixed bot finding on a
+# canonical path (e.g. scripts/resolve-pr-threads.sh is itself canonical)
+# would classify as canonical-coverage. Treating that as actioned would
+# resolve live, unactioned feedback — the exact failure #564 guards against
+# (nathanpayne-codex P1 CHANGES_REQUESTED on #565). So routing classes are
+# EXCLUDED from the actioned gate; --auto-resolve-bots / the daily rollup
+# may still record canonical/templated context, but the actioned-only
+# resolver must not equate routing with action. Unknown classes are NOT
+# actioned — fail safe.
+class_is_actioned() {
+  case "$1" in
+    addressed-elsewhere|rebuttal-recorded)
+      return 0 ;;
+    *)
+      return 1 ;;
+  esac
+}
+
 # synth_rationale <class> <thread_json> → one-line free-form rationale
 # matching the class. Kept short (≤120 chars) so the reply stays
 # compact in the GitHub UI. The classifier reads only the tag in
@@ -991,18 +1294,18 @@ synth_rationale() {
   local class="$1"
   local thread_json="$2"
   local thread_path
-  local thread_created
   thread_path=$(printf '%s' "$thread_json" | jq -r '.path // ""')
-  thread_created=$(printf '%s' "$thread_json" | jq -r '.created // ""')
   local short_sha=""
   case "$class" in
     addressed-elsewhere)
       # Surface the SHA of a commit that actually satisfies
-      # derive_tag_class's predicate (agent-authored AND
-      # authoredDate > thread_created). Re-run the same check here
-      # so the cited SHA matches the one that triggered the
-      # classification — otherwise we could cite a pre-thread
-      # commit that didn't qualify.
+      # derive_tag_class's predicate (agent-authored AND authoredDate >
+      # the latest bot/reviewer comment). Re-run the SAME check here — using
+      # the same last_nonagent_created floor (#565) — so the cited SHA
+      # matches the one that triggered the classification rather than a
+      # pre-thread or stale commit.
+      local last_nonagent_created
+      last_nonagent_created=$(latest_nonagent_created "$thread_json")
       local commit_count i
       commit_count=$(printf '%s' "$PR_COMMITS_CACHE" | jq 'length' 2>/dev/null || echo 0)
       i=0
@@ -1012,8 +1315,9 @@ synth_rationale() {
         c_date=$(printf '%s' "$PR_COMMITS_CACHE" | jq -r ".[$i].date // \"\"")
         c_sha=$(printf '%s' "$PR_COMMITS_CACHE" | jq -r ".[$i].sha // \"\"")
         if [ -n "$c_login" ] && [ -n "$c_date" ] \
-           && { [ -z "$thread_created" ] || [ "$c_date" \> "$thread_created" ]; } \
-           && is_agent_author_local "$c_login"; then
+           && { [ -z "$last_nonagent_created" ] || [ "$c_date" \> "$last_nonagent_created" ]; } \
+           && is_agent_author_local "$c_login" \
+           && commit_touches_file "$c_sha" "$thread_path"; then
           short_sha="$c_sha"
           break
         fi
@@ -1068,8 +1372,11 @@ augment_pr_commits_with_sha() {
   if printf '%s' "$PR_COMMITS_CACHE" | jq -e '.[0].sha // empty' >/dev/null 2>&1; then
     return 0
   fi
+  # Same login fallback chain as fetch_pr_tag_data (#565 round 8):
+  # .commit.author.name before the (often-unlinked) email so agent-authored
+  # commits are recognized.
   PR_COMMITS_CACHE=$(gh_pat api "repos/$OWNER/$NAME/pulls/$PR_NUM/commits?per_page=100" \
-    --jq '[.[] | {sha: .sha, login: (.author.login // .commit.author.email // ""), date: (.commit.author.date // .commit.committer.date // "")}]' 2>/dev/null || echo "$PR_COMMITS_CACHE")
+    --jq '[.[] | {sha: .sha, login: (.author.login // .commit.author.name // .commit.author.email // ""), date: (.commit.author.date // .commit.committer.date // "")}]' 2>/dev/null || echo "$PR_COMMITS_CACHE")
 }
 
 # post_tag_reply — emit a `[mergepath-resolve: <class>] <rationale>`
@@ -1116,11 +1423,25 @@ post_tag_reply() {
 RESOLVED_COUNT=0
 SKIPPED_HUMAN=0
 SKIPPED_STALE=0
+# #564 --resolve-actioned: threads skipped because their derived class is
+# NOT demonstrably actioned (surface-set: nitpick-noted / deferred-to-
+# followup). Left unresolved on purpose so the weekly sweep still surfaces
+# them; counted so the exit code reflects that work remains.
+SKIPPED_NOT_ACTIONED=0
 WOULD_RESOLVE_COUNT=0
 FAILED_COUNT=0
 TAG_REPLY_POSTED=0
 TAG_REPLY_FAILED=0
 TAG_REPLY_SKIPPED=0
+# #564 — post-resolve readback. RESOLVED_IDS collects the GraphQL node IDs
+# of threads whose resolve mutation reported isResolved:true, so the
+# consolidated readback after the loop can re-read each and confirm the
+# state actually persisted. The loop runs in the parent shell (process
+# substitution below), so a plain array survives past it. READBACK_FAILED
+# counts threads that did NOT read back isResolved:true — a fail-closed
+# signal that forces a non-zero exit.
+RESOLVED_IDS=()
+READBACK_FAILED=0
 while IFS= read -r thread; do
   AUTHOR=$(echo "$thread" | jq -r .author)
   THREAD_ID=$(echo "$thread" | jq -r .id)
@@ -1135,11 +1456,20 @@ while IFS= read -r thread; do
     continue
   fi
 
-  # Current-HEAD check. The advertised contract is "resolve only when
-  # the latest comment is on the current HEAD" — a thread anchored to
-  # an older commit (or with no commit linkage at all) means the
-  # agent's most recent push hasn't been re-reviewed by the bot, so
-  # resolving it would force-clear an unaddressed finding.
+  # Current-HEAD check — applies to --auto-resolve-bots ONLY. The contract
+  # there is "resolve only when the latest comment is on the current HEAD":
+  # a thread anchored to an older commit means the agent's most recent push
+  # has not been re-reviewed by the bot, so resolving it would force-clear
+  # an unaddressed finding.
+  #
+  # --resolve-actioned BYPASSES this proxy (#565): pushing a fix commit
+  # advances HEAD while the bot's last comment still points at the previous
+  # commit, so this gate would skip a fixed-by-commit thread as "stale"
+  # before derive_tag_class could see the fix. Instead, --resolve-actioned
+  # relies on its stronger, direct evidence check (a fix commit touching the
+  # anchored file AFTER the latest bot/reviewer comment, or a rebuttal after
+  # the bot's last word) — so a later fix commit is recognized even when the
+  # bot has not re-commented on the new HEAD.
   #
   # Codex r1 on PR #172 caught that the previous check
   # `if [ -n "$COMMIT_OID" ] && [ "$COMMIT_OID" != "$HEAD_OID" ]`
@@ -1147,7 +1477,8 @@ while IFS= read -r thread; do
   # commit linkage in the GraphQL response would be force-resolved
   # silently. The safe default is the opposite: missing oid is
   # treated as stale.
-  if [ -z "$COMMIT_OID" ] || [ "$COMMIT_OID" = "null" ] || [ "$COMMIT_OID" != "$HEAD_OID" ]; then
+  if [ "$MODE" != "resolve-actioned" ] \
+     && { [ -z "$COMMIT_OID" ] || [ "$COMMIT_OID" = "null" ] || [ "$COMMIT_OID" != "$HEAD_OID" ]; }; then
     if [ -z "$COMMIT_OID" ] || [ "$COMMIT_OID" = "null" ]; then
       reason="no commit linkage"
     else
@@ -1157,6 +1488,35 @@ while IFS= read -r thread; do
     echo "    Push a fix commit (or rebuttal reply) to re-trigger the bot, then retry."
     SKIPPED_STALE=$((SKIPPED_STALE + 1))
     continue
+  fi
+
+  # #564 --resolve-actioned: gate the resolve on demonstrable action.
+  # Derive the thread's class BEFORE the dry-run / tag steps, but ONLY in
+  # resolve-actioned mode — auto-resolve-bots keeps its existing behavior
+  # (resolve every current-HEAD bot thread to clear the conversation gate;
+  # the daily rollup re-surfaces deferrals), and in particular must NOT
+  # make tag-data API calls on a --dry-run. Threads whose class is not in
+  # the actioned skip-set are left unresolved so the weekly sweep keeps
+  # surfacing them.
+  thread_class=""
+  thread_class_computed=false
+  if [ "$MODE" = "resolve-actioned" ]; then
+    fetch_pr_tag_data
+    augment_pr_commits_with_sha
+    # GATE path: classify with routing skipped, so a canonical/templated
+    # thread that was actually fixed/rebutted resolves on its action
+    # evidence, while a fresh routing-only finding still falls through to a
+    # non-actioned class and is left for the sweep (#565).
+    thread_class=$(derive_tag_class "$thread" skip-routing)
+    thread_class_computed=true
+    if ! class_is_actioned "$thread_class"; then
+      echo "  SKIP (not demonstrably actioned: $thread_class): [$AUTHOR] $PATH_"
+      echo "    $EXCERPT"
+      echo "    Left unresolved so the weekly sweep still surfaces it. Fix or"
+      echo "    rebut the finding, or defer it via --auto-resolve-bots --rationale."
+      SKIPPED_NOT_ACTIONED=$((SKIPPED_NOT_ACTIONED + 1))
+      continue
+    fi
   fi
 
   if $DRY_RUN; then
@@ -1194,13 +1554,21 @@ while IFS= read -r thread; do
       # fixture. Calling here also fulfills the "one-shot cache reused
       # across threads" intention — fetch_pr_tag_data's TAG_DATA_FETCHED
       # short-circuit only works if it's set in the loop's shell.
-      fetch_pr_tag_data
-      # Need the augmented commits cache (with .sha) for the
-      # addressed-elsewhere rationale; the bare cache from
-      # fetch_pr_tag_data doesn't carry .sha. derive_tag_class only
-      # needs login + date so it runs against either shape.
-      augment_pr_commits_with_sha
-      tag_class=$(derive_tag_class "$thread")
+      #
+      # #564: resolve-actioned mode already derived the class (and warmed
+      # the caches) above — reuse it so derive_tag_class / synth_rationale
+      # run at most once per thread.
+      if ! $thread_class_computed; then
+        fetch_pr_tag_data
+        # Need the augmented commits cache (with .sha) for the
+        # addressed-elsewhere rationale; the bare cache from
+        # fetch_pr_tag_data doesn't carry .sha. derive_tag_class only
+        # needs login + date so it runs against either shape.
+        augment_pr_commits_with_sha
+        thread_class=$(derive_tag_class "$thread")
+        thread_class_computed=true
+      fi
+      tag_class="$thread_class"
       tag_rationale=$(synth_rationale "$tag_class" "$thread")
     fi
     if post_tag_reply "$THREAD_ID" "$tag_class" "$tag_rationale"; then
@@ -1216,24 +1584,36 @@ while IFS= read -r thread; do
 
   # Identity check moved out of the loop in #293 r2 — see the
   # single-gate block above the loop.
-  if gh_pat api graphql -f query='
+  #
+  # #564: capture the mutation's returned `thread.isResolved` rather than
+  # discarding the response. A mutation that returns HTTP 200 but
+  # isResolved!=true did NOT actually resolve the thread, so it must count
+  # as FAILED, not RESOLVED. Threads confirmed true here are collected into
+  # RESOLVED_IDS for the consolidated reviewThreads readback after the loop.
+  resolve_state=""
+  if mutation_out=$(gh_pat api graphql -f query='
     mutation($id: ID!) {
       resolveReviewThread(input: {threadId: $id}) {
         thread { isResolved }
       }
     }
-  ' -F id="$THREAD_ID" >/dev/null 2>&1; then
+  ' -F id="$THREAD_ID" 2>/dev/null); then
+    resolve_state=$(printf '%s' "$mutation_out" \
+      | jq -r '.data.resolveReviewThread.thread.isResolved' 2>/dev/null || echo "")
+  fi
+  if [ "$resolve_state" = "true" ]; then
     echo "  RESOLVED [$AUTHOR] $PATH_"
     RESOLVED_COUNT=$((RESOLVED_COUNT + 1))
+    RESOLVED_IDS+=("$THREAD_ID")
   else
-    echo "  FAILED [$AUTHOR] $PATH_ — mutation rejected" >&2
+    echo "  FAILED [$AUTHOR] $PATH_ — mutation rejected (returned isResolved=${resolve_state:-none})" >&2
     FAILED_COUNT=$((FAILED_COUNT + 1))
   fi
 done < <(printf '%s\n' "$UNRESOLVED")
 
 echo ""
 if $DRY_RUN; then
-  echo "(dry-run; no threads modified) — would-resolve: $WOULD_RESOLVE_COUNT, skipped (human): $SKIPPED_HUMAN, skipped (stale-HEAD): $SKIPPED_STALE"
+  echo "(dry-run; no threads modified) — would-resolve: $WOULD_RESOLVE_COUNT, skipped (human): $SKIPPED_HUMAN, skipped (stale-HEAD): $SKIPPED_STALE, skipped (not-actioned): $SKIPPED_NOT_ACTIONED"
   # Codex r2 on PR #172: dry-run previously exited 0 when only
   # current-HEAD bot threads remained (because dry-run does not mutate
   # them and they didn't increment SKIPPED_*). Callers would treat
@@ -1242,23 +1622,91 @@ if $DRY_RUN; then
   # human-skipped, or stale-skipped). The only exit-0 path through
   # auto-resolve-bots --dry-run is "no unresolved threads at all"
   # which is already short-circuited above (UNRESOLVED is empty).
-  if [ "$WOULD_RESOLVE_COUNT" -gt 0 ] || [ "$SKIPPED_HUMAN" -gt 0 ] || [ "$SKIPPED_STALE" -gt 0 ]; then
+  if [ "$WOULD_RESOLVE_COUNT" -gt 0 ] || [ "$SKIPPED_HUMAN" -gt 0 ] || [ "$SKIPPED_STALE" -gt 0 ] || [ "$SKIPPED_NOT_ACTIONED" -gt 0 ]; then
     exit 3
   fi
   exit 0
 fi
-echo "Resolved: $RESOLVED_COUNT  Skipped (human): $SKIPPED_HUMAN  Skipped (stale-HEAD): $SKIPPED_STALE  Failed: $FAILED_COUNT"
+
+# --- post-resolve readback (#564) ------------------------------------------
+# Acceptance criterion: "Actioned review feedback is resolved through an
+# identity-checked resolveReviewThread path before merge, with a follow-up
+# reviewThreads readback confirming isResolved: true." The per-thread
+# mutation return value is checked in the loop above; this is the SEPARATE
+# confirming read. We re-read each just-resolved thread via the top-level
+# `nodes(ids:)` lookup — O(resolved), no pagination, and it reads back
+# exactly the set we mutated (and is syntactically distinct from the
+# enumeration `reviewThreads` query).
+#
+# Fail CLOSED: any thread that does not read back isResolved:true (state
+# drift, eventual-consistency lag, an id that no longer resolves, or a
+# token that could write but a later read that cannot) increments
+# READBACK_FAILED and forces a non-zero exit, so a caller never treats an
+# unconfirmed resolve as a clean conversation-resolution gate. A readback
+# that confirms nothing is never treated as "all good".
+#
+# `nodes(ids:)` caps at 100 nodes per query, so batch — a single PR run
+# resolving >100 threads is vanishingly rare, but the batch loop keeps the
+# confirmation complete if it ever happens.
+if [ "${#RESOLVED_IDS[@]}" -gt 0 ]; then
+  rb_total=${#RESOLVED_IDS[@]}
+  rb_start=0
+  while [ "$rb_start" -lt "$rb_total" ]; do
+    rb_batch=("${RESOLVED_IDS[@]:$rb_start:100}")
+    rb_start=$((rb_start + 100))
+    # Build the GraphQL ID-array literal by JSON-encoding the ids. GitHub
+    # node IDs are documented as OPAQUE, so do not assume a charset or parse
+    # them — JSON encoding (jq) escapes any content correctly, making the
+    # inlined literal injection-safe for any id without a charset whitelist
+    # (CodeRabbit on #565). A JSON string array is also a valid GraphQL
+    # list-of-strings literal. Empty / drifted ids simply fail the per-id
+    # readback below (fail closed).
+    rb_ids_json=$(printf '%s\n' "${rb_batch[@]}" | jq -R . | jq -s -c .)
+    rb_query="query { nodes(ids: ${rb_ids_json}) { ... on PullRequestReviewThread { id isResolved } } }"
+    if ! rb_resp=$(gh_pat api graphql -f query="$rb_query" 2>&1); then
+      echo "  READBACK FAILED: reviewThreads readback query errored: $rb_resp" >&2
+      # Fail closed — count every id in this batch as unconfirmed.
+      for rb_id in "${rb_batch[@]}"; do READBACK_FAILED=$((READBACK_FAILED + 1)); done
+      continue
+    fi
+    for rb_id in "${rb_batch[@]}"; do
+      rb_state=$(printf '%s' "$rb_resp" \
+        | jq -r --arg id "$rb_id" \
+            '(.data.nodes // []) | map(select(.id == $id)) | .[0].isResolved
+             | if . == null then "missing" else tostring end' 2>/dev/null \
+        || echo "missing")
+      if [ "$rb_state" != "true" ]; then
+        echo "  READBACK FAILED [$rb_id]: isResolved=$rb_state (expected true)" >&2
+        READBACK_FAILED=$((READBACK_FAILED + 1))
+      fi
+    done
+  done
+  if [ "$READBACK_FAILED" -gt 0 ]; then
+    echo "Readback: $READBACK_FAILED of $rb_total resolved thread(s) did NOT confirm isResolved:true — failing closed." >&2
+  else
+    echo "Readback: all $rb_total resolved thread(s) confirmed isResolved:true."
+  fi
+fi
+
+echo "Resolved: $RESOLVED_COUNT  Skipped (human): $SKIPPED_HUMAN  Skipped (stale-HEAD): $SKIPPED_STALE  Skipped (not-actioned): $SKIPPED_NOT_ACTIONED  Failed: $FAILED_COUNT  Readback-failed: $READBACK_FAILED"
 if ! $NO_TAG_REPLY; then
   echo "Tag replies: posted=$TAG_REPLY_POSTED  failed=$TAG_REPLY_FAILED"
 fi
 # Codex r1 on PR #172: previously this exited 0 even with stale or
 # human-authored threads remaining — callers would treat it as "all
 # clear" and proceed to merge into a still-BLOCKED PR. Exit codes:
-#   2 = mutation failure (transient: gh/network)
+#   2 = mutation failure (transient: gh/network), a resolve mutation that
+#       did not return isResolved:true, OR a post-resolve readback that
+#       could not confirm isResolved:true (#564 — fail closed)
 #   3 = unresolved threads remain (human or stale-bot) — PR still
 #       conversation-resolution-blocked; address and retry
 #   0 = no unresolved threads on current HEAD
-[ "$FAILED_COUNT" -gt 0 ] && exit 2
+# Explicit `if` (not `[ a ] && exit`): two OR-ed conditions, and an
+# `&& exit` chain would be ambiguous under set -e (see the SKIPPED block
+# below). A readback failure is as fail-closed as a mutation failure.
+if [ "$FAILED_COUNT" -gt 0 ] || [ "$READBACK_FAILED" -gt 0 ]; then
+  exit 2
+fi
 # Use an explicit `if`, not `[ a ] || [ b ] && exit 3`. In that
 # one-liner `&&` and `||` are equal-precedence and left-associative,
 # so it parses as `([ a ] || [ b ]) && exit 3` — and under
@@ -1267,7 +1715,7 @@ fi
 # non-zero; whether that trips `set -e` depends on subtle list-tail
 # rules. The `if` form is unambiguous and matches the block above.
 # (CodeRabbit Major, #271/#272.)
-if [ "$SKIPPED_HUMAN" -gt 0 ] || [ "$SKIPPED_STALE" -gt 0 ]; then
+if [ "$SKIPPED_HUMAN" -gt 0 ] || [ "$SKIPPED_STALE" -gt 0 ] || [ "$SKIPPED_NOT_ACTIONED" -gt 0 ]; then
   exit 3
 fi
 exit 0

--- a/tests/test_465_fail_closed.sh
+++ b/tests/test_465_fail_closed.sh
@@ -96,11 +96,12 @@ assert_grep "D7: weekly-feedback-sweep drops the persisted checkout token (#548)
 # so the #548 invariant holds for the WHOLE file (Codex #550 P2 caught that the
 # failure-notify checkout was initially missed). Propagation-safe: skip if absent.
 if [ -f "$W/weekly-feedback-sweep.yml" ]; then
-  _wfs_pc=$(grep -c 'persist-credentials: false' "$W/weekly-feedback-sweep.yml")
-  if [ "$_wfs_pc" -ge 2 ]; then
-    pass "D7: weekly-feedback-sweep hardens BOTH checkouts (#548 / Codex #550)"
+  _wfs_co=$(grep -c 'uses:.*actions/checkout' "$W/weekly-feedback-sweep.yml" || true)
+  _wfs_pc=$(grep -c 'persist-credentials: false' "$W/weekly-feedback-sweep.yml" || true)
+  if [ "$_wfs_co" -gt 0 ] && [ "$_wfs_pc" -eq "$_wfs_co" ]; then
+    pass "D7: weekly-feedback-sweep hardens ALL $_wfs_co checkout(s) (#548 / Codex #550)"
   else
-    fail "D7: weekly-feedback-sweep both checkouts (#548): $_wfs_pc persist-credentials, expected >= 2"
+    fail "D7: weekly-feedback-sweep checkouts (#548): $_wfs_pc persist-credentials vs $_wfs_co checkouts (expected equal)"
   fi
 else
   echo "SKIP: D7 weekly-feedback-sweep both checkouts (absent)"; SKIP=$((SKIP + 1))
@@ -128,12 +129,22 @@ assert_grep "D7: daily-feedback-rollup drops the persisted checkout token (#548 
 # persisted token on ALL its checkouts (gh-with-explicit-token only, no authed
 # git). Count-based so a regression of any one checkout is caught.
 if [ -f "$W/agent-review.yml" ]; then
-  _ar=$(grep -c 'persist-credentials: false' "$W/agent-review.yml")
-  if [ "$_ar" -ge 4 ]; then pass "D7: agent-review hardens all 4 checkouts (#550)"; else fail "D7: agent-review checkouts (#550): $_ar persist-credentials, expected >= 4"; fi
+  _ar_co=$(grep -c 'uses:.*actions/checkout' "$W/agent-review.yml" || true)
+  _ar=$(grep -c 'persist-credentials: false' "$W/agent-review.yml" || true)
+  if [ "$_ar_co" -gt 0 ] && [ "$_ar" -eq "$_ar_co" ]; then
+    pass "D7: agent-review hardens all $_ar_co checkout(s) (#550)"
+  else
+    fail "D7: agent-review checkouts (#550): $_ar persist-credentials vs $_ar_co checkouts (expected equal)"
+  fi
 else echo "SKIP: D7 agent-review (absent)"; SKIP=$((SKIP + 1)); fi
 if [ -f "$W/auto-clear-blocking-labels.yml" ]; then
-  _ac=$(grep -c 'persist-credentials: false' "$W/auto-clear-blocking-labels.yml")
-  if [ "$_ac" -ge 2 ]; then pass "D7: auto-clear hardens both checkouts (#550)"; else fail "D7: auto-clear checkouts (#550): $_ac persist-credentials, expected >= 2"; fi
+  _ac_co=$(grep -c 'uses:.*actions/checkout' "$W/auto-clear-blocking-labels.yml" || true)
+  _ac=$(grep -c 'persist-credentials: false' "$W/auto-clear-blocking-labels.yml" || true)
+  if [ "$_ac_co" -gt 0 ] && [ "$_ac" -eq "$_ac_co" ]; then
+    pass "D7: auto-clear hardens all $_ac_co checkout(s) (#550)"
+  else
+    fail "D7: auto-clear checkouts (#550): $_ac persist-credentials vs $_ac_co checkouts (expected equal)"
+  fi
 else echo "SKIP: D7 auto-clear (absent)"; SKIP=$((SKIP + 1)); fi
 
 # Defect 8 (#550 Codex P1): secret-bearing dispatchable workflows guard the JOB
@@ -150,6 +161,23 @@ assert_grep "D8: pr-audit guards dispatch to the default branch (#550)" \
   "$W/pr-audit.yml" 'if: github.ref_name == github.event.repository.default_branch'
 assert_grep "D8: daily-feedback-rollup guards dispatch to the default branch (#550 Codex)" \
   "$W/daily-feedback-rollup.yml" 'if: github.ref_name == github.event.repository.default_branch'
+
+# Defect 9 (#557): load-config must ALSO run on approved pull_request_review
+# events. The auto-merge-on-approval require_approval gate reads
+# needs.load-config.outputs.reviewers on the direct-approval path; if
+# load-config is skipped on review events that list is empty, the gate defaults
+# REVIEWERS_JSON to [] and rejects every approver as unregistered, so
+# approval-triggered auto-merge never arms (regressing #544 / #495). Job-scoped
+# (extract the load-config block) so it cannot false-match the auto-merge gate's
+# own pull_request_review branch.
+if [ -f "$W/agent-review.yml" ]; then
+  _lc_block=$(awk '/^  load-config:/{f=1;print;next} /^  [A-Za-z._-]+:/{f=0} f{print}' "$W/agent-review.yml")
+  if printf '%s\n' "$_lc_block" | grep -q 'pull_request_review'; then
+    pass "D9: load-config runs on pull_request_review so the arming gate sees reviewers (#557)"
+  else
+    fail "D9: load-config must gate on pull_request_review (#557) — direct-approval arming regressed"
+  fi
+else echo "SKIP: D9 agent-review (absent)"; SKIP=$((SKIP + 1)); fi
 
 echo ""
 echo "test_465_fail_closed: $PASS passed, $FAIL failed, $SKIP skipped"

--- a/tests/test_audit_propagation_lane.sh
+++ b/tests/test_audit_propagation_lane.sh
@@ -209,7 +209,7 @@ NO_MANIFEST_DIR="$WORKDIR/no-manifest"; mkdir -p "$NO_MANIFEST_DIR"
 NOYQ_PATH_521="/usr/bin:/bin:/usr/sbin:/sbin"
 set +e
 OUT=$( cd "$NO_MANIFEST_DIR" && PATH="$NOYQ_PATH_521" OP_PREFLIGHT_CACHE_DIR="$EMPTY_CACHE" \
-  MERGEPATH_AGENT="nobody-xyz" env -u GH_TOKEN "$SCRIPT" --repos __none__ 2>&1 )
+  MERGEPATH_AGENT="nobody-xyz" env -u GH_TOKEN -u GITHUB_TOKEN -u OP_PREFLIGHT_REVIEWER_PAT "$SCRIPT" --repos __none__ 2>&1 )
 RC=$?
 set -e
 if [ "$RC" = "3" ] && echo "$OUT" | grep -qi "reviewer token" \

--- a/tests/test_check_no_bare_gh_writes.sh
+++ b/tests/test_check_no_bare_gh_writes.sh
@@ -93,6 +93,21 @@ assert_clean   "escaped dollar-paren in dquotes exempt"      'echo "\$(gh repo c
 # the masking fix must not over-match plain documentation text.
 assert_clean   "gh write text outside subst exempt"  'echo "$(date -u) create Project v2: gh project create --owner o --title t"'
 
+# #553 (Major): the echo/printf exemption must cover ONLY the echo/printf
+# command, NOT a second command chained after a top-level separator. `echo ok;
+# gh pr merge 1` previously slipped through because the branch returned exempt
+# without scanning past the `;`. Re-check the tail after the first top-level
+# (unquoted, non-substitution) separator, recursively. Echoed TEXT, pipes into
+# non-gh commands, and chained WRAPPED writes stay exempt.
+assert_flagged "echo then ;-chained bare gh merge caught"     'echo ok; gh pr merge 1'
+assert_flagged "echo then &&-chained bare gh merge caught"    'echo done && gh pr merge 1'
+assert_flagged "printf then ;-chained gh secret set caught"   "printf '%s' done; gh secret set X"
+assert_flagged "double echo then chained bare gh merge caught" 'echo a; echo b; gh pr merge 1'
+assert_flagged "echo piped into bare gh merge caught"         'echo body | gh pr merge 1'
+assert_clean   "echoed gh-write TEXT (no chained cmd) exempt"  'echo "gh pr merge 1 is documented here"'
+assert_clean   "echo piped into a non-gh command exempt"       'echo ok | grep gh'
+assert_clean   "echo then ;-chained WRAPPED gh merge exempt"   'echo ok; scripts/gh-as-author.sh -- gh pr merge 1'
+
 echo ""
 echo "test_check_no_bare_gh_writes: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/tests/test_coderabbit_automerge_rate_limit_gate.sh
+++ b/tests/test_coderabbit_automerge_rate_limit_gate.sh
@@ -53,6 +53,18 @@ assert_rc "full rate_limit_stalled payload, engaged + above-threshold → procee
 assert_rc "full payload, engaged + under-threshold → block" 1 \
   '{"pr_number":1,"status":"rate_limit_stalled","rate_limit_retries":2,"codex_failover_requested":true,"waited_seconds":120}' false
 
+# --- status gate (#554 fix 1): wrong/absent status blocks even with failover=true ---
+assert_rc "status=cleared + failover=true + above-threshold → block (only rate_limit_stalled ok)" 1 \
+  '{"status":"cleared","codex_failover_requested":true}' true
+assert_rc "status=timeout + failover=true + above-threshold → block" 1 \
+  '{"status":"timeout","codex_failover_requested":true}' true
+assert_rc "absent status field + failover=true + above-threshold → block" 1 \
+  '{"codex_failover_requested":true}' true
+
+# --- boolean precision (#554 fix 1): string "true" must not satisfy the gate ---
+assert_rc "codex_failover_requested as string-true + rate_limit_stalled → block (must be JSON boolean)" 1 \
+  '{"status":"rate_limit_stalled","codex_failover_requested":"true"}' true
+
 echo "----"
 echo "test_coderabbit_automerge_rate_limit_gate: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tests/test_daily_feedback_rollup.sh
+++ b/tests/test_daily_feedback_rollup.sh
@@ -159,6 +159,7 @@ assert_action() {
 assert_action "addressed-elsewhere"   "skip"
 assert_action "canonical-coverage"    "skip"
 assert_action "rebuttal-recorded"     "skip"
+assert_action "templated-render"      "skip"      # #568: routing/skip class
 assert_action "nitpick-noted"         "surface"
 assert_action "deferred-to-followup"  "surface"
 assert_action "future-unknown-class"  "surface"   # spec: err on surface

--- a/tests/test_gh_as_reviewer.sh
+++ b/tests/test_gh_as_reviewer.sh
@@ -173,7 +173,7 @@ fi
 reset_log
 unset OP_PREFLIGHT_REVIEWER_PAT
 set +e
-GH_TOKEN="reviewer-token" run_wrapper -- gh pr review 123 --comment --body "ok" >/dev/null 2>&1
+GITHUB_TOKEN= GH_TOKEN="reviewer-token" run_wrapper -- gh pr review 123 --comment --body "ok" >/dev/null 2>&1
 rc=$?
 set -e
 if [ "$rc" -ne 0 ]; then
@@ -197,7 +197,7 @@ fi
 reset_log
 unset OP_PREFLIGHT_REVIEWER_PAT
 set +e
-err=$(GH_TOKEN="author-token" run_wrapper -- gh pr review 123 --comment --body "ok" 2>&1 >/dev/null)
+err=$(GITHUB_TOKEN= GH_TOKEN="author-token" run_wrapper -- gh pr review 123 --comment --body "ok" 2>&1 >/dev/null)
 rc=$?
 set -e
 # The wrapped write (gh pr review) must run under the keyring token, never

--- a/tests/test_gh_pr_guard.sh
+++ b/tests/test_gh_pr_guard.sh
@@ -784,6 +784,64 @@ assert_rc_contains "quoted env -S without a literal gh fails closed (#551 Codex)
 assert_rc_contains "plain env prefix still surfaces the gh write (#551 regression)" 2 "token-verifying wrapper" \
   'env FOO=bar gh pr merge 123 --admin'
 
+# #553 (CodeRabbit Critical): a command substitution in COMMAND position can
+# synthesize the executable name ($(printf "\147\150") is octal for gh), so the
+# raw command carries no literal gh. The fast-path now force-tokenizes a
+# command-position cmdsub, and the walk treats the flattened placeholder as a
+# potential gh, failing closed on any pr/issue WRITE that follows. A placeholder
+# NOT followed by a guarded write subcommand stays allowed.
+assert_rc_contains "cmdsub-synth pr merge fails closed (#553)" 2 "wrapper" \
+  '$(printf "\147\150") pr merge 123 --admin'
+assert_rc_contains "backtick-synth issue comment fails closed (#553)" 2 "wrapper" \
+  '`printf "\147\150"` issue comment 5 --body hi'
+assert_rc_contains "assignment-prefixed cmdsub-synth pr merge fails closed (#553)" 2 "wrapper" \
+  'FOO=1 $(printf "\147\150") pr merge 1'
+assert_rc_contains "separator-then cmdsub-synth pr merge fails closed (#553 empirical)" 2 "wrapper" \
+  'gh --version ; $(printf "\147\150") pr merge 123 --admin'
+assert_rc_contains "command-position cmdsub with NO gh write stays allowed (#553)" 0 "" \
+  '$(date -u) >/dev/null'
+# #553 regression: a benign command-position cmdsub (the ubiquitous
+# `eval "$(brew shellenv)"`) before a WRAPPED write must NOT false-trip the
+# compound #348 block. An interim fix counted the placeholder as a gh
+# invocation in the pre-scan; the synth bypass is caught by the main walk, not
+# the compound pre-scan, so the pre-scan must ignore the placeholder.
+assert_rc_contains "eval cmdsub before a wrapped write is allowed (#553)" 0 "" \
+  'eval "$(/opt/homebrew/bin/brew shellenv)" && scripts/gh-as-author.sh -- gh pr merge 1 --repo o/r --squash'
+
+# #560 (residual of #553): a command-position cmdsub-synthesized gh must fail
+# closed even after a prefix command + options (command -p, env -i), a
+# value-taking flag (env -u NAME), or a quoted env assignment (FOO="a b"). The
+# command-position forward pass tracks position through prefix/flag/assignment
+# tokens (via prefix_flag_takes_value), not just the immediate previous token.
+assert_rc_contains "command -p cmdsub-synth pr merge fails closed (#560)" 2 "wrapper" \
+  'command -p $(printf "\147\150") pr merge 1'
+assert_rc_contains "env -i cmdsub-synth pr merge fails closed (#560)" 2 "wrapper" \
+  'env -i $(printf "\147\150") pr merge 1'
+assert_rc_contains "quoted-assignment cmdsub-synth pr merge fails closed (#560)" 2 "wrapper" \
+  'FOO="bar baz" $(printf "\147\150") pr merge 1'
+assert_rc_contains "value-flag arg then cmdsub-synth pr merge fails closed (#560)" 2 "wrapper" \
+  'env -u FOO $(printf "\147\150") pr merge 1'
+assert_rc_contains "sudo -n cmdsub-synth issue comment fails closed (#560)" 2 "wrapper" \
+  'sudo -n $(printf "\147\150") issue comment 5 --body hi'
+# Controls: a cmdsub CONSUMED as a value-taking flag's argument is NOT command
+# position (env -u $(...) -> the synth is the var NAME, `pr merge` is the cmd),
+# and an echo argument just prints. Both stay allowed.
+assert_rc_contains "cmdsub as value-taking flag arg stays allowed (#560)" 0 "" \
+  'env -u $(printf "\147\150") pr merge 1'
+assert_rc_contains "cmdsub as echo argument stays allowed (#560)" 0 "" \
+  'echo $(printf "\147\150") pr merge'
+
+# #553 fix (b): the merge-state jq counts an un-timestamped PENDING re-run as
+# non-green even when a timestamped SUCCESS exists for the same check (the prior
+# max_by(.t) mis-ranked the empty-timestamp PENDING behind the SUCCESS, so an
+# UNSTABLE PR with a check still re-running could merge before CI finished).
+GH_JQ_def=$(grep -m1 '^GH_JQ=' "$HOOK")
+eval "$GH_JQ_def"
+_ng=$(printf '%s' '{"statusCheckRollup":[{"name":"ci","conclusion":"SUCCESS","completedAt":"2026-06-28T10:00:00Z"},{"name":"ci","state":"PENDING"}],"labels":[]}' | jq -r "$GH_JQ" | sed -n '3p')
+if [ "${_ng:-0}" -ge 1 ]; then pass "merge-state jq: un-timestamped PENDING re-run counts non-green (#553)"; else fail "merge-state jq (#553): expected non-green >= 1, got '$_ng'"; fi
+_ng2=$(printf '%s' '{"statusCheckRollup":[{"name":"ci","conclusion":"SUCCESS","completedAt":"2026-06-28T10:00:00Z"},{"name":"lint","conclusion":"SUCCESS","completedAt":"2026-06-28T11:00:00Z"}],"labels":[]}' | jq -r "$GH_JQ" | sed -n '3p')
+if [ "${_ng2:-x}" = "0" ]; then pass "merge-state jq: all-terminal-green stays 0 (no false block) (#553)"; else fail "merge-state jq (#553): expected 0, got '$_ng2'"; fi
+
 echo ""
 echo "test_gh_pr_guard: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/test_merge_clearance_gate.sh
+++ b/tests/test_merge_clearance_gate.sh
@@ -782,10 +782,12 @@ else
   fail "expected check FAIL on drifted job name (#533); got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2
 fi
 
-# Case C (positive control): a correctly-named JOB satisfies the assertion.
-# The check proceeds past the workflow-shape pre-flight (and runs its own
-# fixture suite). We only assert the job-name assertion does NOT fire — i.e.
-# the check does not emit the job-name FAIL line and exits clean.
+# Case C (positive control): a correctly-named JOB satisfies the job-name
+# assertion. We only assert the job-name FAIL line was NOT emitted — we do
+# not assert RC=0 here because the check also runs its own fixture suite,
+# and a pre-existing unrelated failure there would couple this test to the
+# state of unrelated fixtures (#556). The job-name assertion is structural;
+# the RC of the nested fixture run is a separate concern.
 WF_OK="$WORKDIR/wf-ok.yml"
 {
   write_wf_header
@@ -802,7 +804,8 @@ set +e
 OUT=$(MCG_SKIP_FIX3_SELFTEST=1 MERGE_CLEARANCE_WORKFLOW="$WF_OK" "$CHECK_BIN" 2>&1)
 RC=$?
 set -e
-if [ "$RC" -eq 0 ] && ! echo "$OUT" | grep -q "must define a JOB named"; then
+if ! echo "$OUT" | grep -q "must define a JOB named" \
+   && echo "$OUT" | grep -q "check_merge_clearance_gate:"; then
   pass "correctly-named JOB → job-name assertion passes (#533)"
 else
   fail "expected job-name assertion to pass on a correct job name (#533); got rc=$RC"; echo "$OUT" | sed 's/^/      /' >&2

--- a/tests/test_op_preflight_check.sh
+++ b/tests/test_op_preflight_check.sh
@@ -1207,7 +1207,7 @@ test_deploy_full_fetch_fail_closed_structural() {
 # can read which mode ran.
 # ---------------------------------------------------------------------------
 test_preflight_mode_is_exported() {
-  # Cache-hit path: a fresh review cache must emit `export OP_PREFLIGHT_MODE`.
+  # Sub-case A: cache-hit path — a fresh review cache must emit `export OP_PREFLIGHT_MODE`.
   local case_dir="$WORKDIR/mode-export-cachehit"
   make_fresh_cache "$case_dir" claude "rev-pat-m" "author-pat-m"
   local out rc=0
@@ -1222,6 +1222,40 @@ test_preflight_mode_is_exported() {
     return
   fi
   pass "test_preflight_mode_is_exported: OP_PREFLIGHT_MODE exported on cache-hit path (#521)"
+
+  # Sub-case B: cold/full-fetch path — a review run with no cache must still
+  # emit `export OP_PREFLIGHT_MODE=review` in its output (#556).
+  local ff_dir="$WORKDIR/mode-export-fullfetch"
+  local ff_cache="$ff_dir/cache"
+  local ff_bin="$ff_dir/bin"
+  mkdir -p "$ff_dir" "$ff_cache" "$ff_bin"
+  # op stub: handle inject (returns PATs), reject everything else.
+  cat > "$ff_bin/op" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  inject)
+    printf '%s\n' "REVIEWER_PAT=ff-reviewer-pat"
+    printf '%s\n' "AUTHOR_PAT=ff-author-pat"
+    ;;
+  *)
+    echo "unexpected op call: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$ff_bin/op"
+  rc=0
+  out=$(PATH="$ff_bin:$STUB_DIR:$PATH" OP_PREFLIGHT_CACHE_DIR="$ff_cache" \
+    "$SCRIPT" --agent claude --mode review --skip-ssh 2>/dev/null) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "test_preflight_mode_is_exported: full-fetch --mode review rc=$rc"
+    return
+  fi
+  if ! echo "$out" | grep -q "export OP_PREFLIGHT_MODE=review"; then
+    fail "test_preflight_mode_is_exported: full-fetch path did not export OP_PREFLIGHT_MODE; out=$out"
+    return
+  fi
+  pass "test_preflight_mode_is_exported: OP_PREFLIGHT_MODE exported on full-fetch path (#556)"
 }
 
 test_check_fresh_cache

--- a/tests/test_op_preflight_token_mode.sh
+++ b/tests/test_op_preflight_token_mode.sh
@@ -65,7 +65,7 @@ case "\${1:-}" in
         echo "FATAL: token mode attempted author PAT read" >&2
         exit 66
         ;;
-      op://Private/c2v6emkwppjzjjaq2bdqk3wnlm/credential|op://Private/4x6wslp3f6pal5t6h3jhhe63ie/credential)
+      op://Private/FAKESENTINEL0ID0000000000001/credential|op://Private/FAKESENTINEL0ID0000000000002/credential)
         echo "FATAL: token mode attempted deploy secret read" >&2
         exit 67
         ;;
@@ -236,7 +236,11 @@ test_token_mode_agents() {
       fail "test_token_mode_agents($agent): token mode used op inject"
       return
     fi
-    if grep -q "FAKEAUTHORITEMID00000000000\\|c2v6emkwppjzjjaq2bdqk3wnlm\\|4x6wslp3f6pal5t6h3jhhe63ie" "$OP_LOG"; then
+    # The two IDs here are out-of-scope test sentinels (not reviewer/author PAT
+    # UUIDs from REVIEW_POLICY.md). Using fake IDs keeps raw op item IDs out of
+    # tracked test files per repo guidance. The first ID is a pre-existing fake;
+    # the remaining two are replaced with structurally-similar fake sentinels.
+    if grep -q "FAKEAUTHORITEMID00000000000\\|FAKESENTINEL0ID0000000000001\\|FAKESENTINEL0ID0000000000002" "$OP_LOG"; then
       fail "test_token_mode_agents($agent): token mode attempted out-of-scope op item"
       return
     fi

--- a/tests/test_resolve_pr_threads_rationale_tag.sh
+++ b/tests/test_resolve_pr_threads_rationale_tag.sh
@@ -105,6 +105,10 @@ make_gh_stub() {
   local threads_json="$2"
   local files_json="$3"
   local commits_json="$4"
+  # #565: per-commit file map (sha -> [filenames]) for the
+  # addressed-elsewhere commit_touches_file check. Defaults to empty so the
+  # many call sites that never reach a per-commit fetch need not pass it.
+  local commit_files_map="${5:-{}}"
   cat > "$stub_path" <<GH_STUB
 #!/usr/bin/env bash
 echo "ARGV: \$*" >> "\$GH_ARGV_LOG"
@@ -140,6 +144,19 @@ case "\$1" in
           echo '{"data":{"addPullRequestReviewThreadReply":{"comment":{"id":"C_kwT1"}}}}'
         elif grep -q "resolveReviewThread" "\$GH_ARGV_LOG.lastcall"; then
           echo '{"data":{"resolveReviewThread":{"thread":{"isResolved":true}}}}'
+        elif grep -q "nodes(ids:" "\$GH_ARGV_LOG.lastcall"; then
+          # #564 post-resolve readback. The script re-reads each resolved
+          # thread via the top-level nodes(ids:) lookup. Return ONLY the ids
+          # the readback query actually requested (parsed from the recorded
+          # argv) so a wrong nodes(ids:) list built by the script is caught
+          # — CodeRabbit on #565 — each resolved unless
+          # GH_STUB_READBACK_UNRESOLVED names it (which exercises the
+          # fail-closed readback path).
+          __req=\$(grep -oE 'nodes\(ids: \[[^]]*\]' "\$GH_ARGV_LOG.lastcall" | head -1 | sed -E 's/^nodes\(ids: //')
+          [ -z "\$__req" ] && __req='[]'
+          cat <<'JSON_READBACK' | jq -c --argjson req "\$__req" --arg kf "\${GH_STUB_READBACK_UNRESOLVED:-}" '{data:{nodes:[.data.repository.pullRequest.reviewThreads.nodes[] | select(.id as \$i | \$req | index(\$i)) | {id, isResolved: (if .id == \$kf then false else true end)}]}}'
+${threads_json}
+JSON_READBACK
         else
           # reviewThreads pagination query.
           cat <<'JSON_THREADS'
@@ -163,6 +180,15 @@ JSON_FILES
         cat <<'JSON_COMMITS'
 ${commits_json}
 JSON_COMMITS
+        ;;
+      "repos/"*"/commits/"*)
+        # #565 per-commit files: extract the sha (last path segment) and
+        # return its file list from the provided sha->[filenames] map (or []
+        # if absent). The script calls this with --jq '[.files[].filename]',
+        # so (like the /files and /commits stubs) return the already-
+        # transformed array of filenames directly.
+        __sha="\${2##*/}"
+        printf '%s' '${commit_files_map}' | jq -c --arg s "\$__sha" '.[\$s] // []'
         ;;
       "repos/"*"/pulls/"*)
         # HEAD oid fetch — the script calls this with --jq .head.sha
@@ -222,7 +248,9 @@ FILES_T1='["scripts/foo.sh","scripts/bar.sh"]'
 COMMITS_T1='[{"sha":"abc1234567","login":"nathanpayne-claude","date":"2026-01-02T00:00:00Z"}]'
 
 GH_ARGV_LOG="$SCRATCH/t1.log"; : > "$GH_ARGV_LOG"
-make_gh_stub "$SCRATCH/gh-real" "$THREADS_T1" "$FILES_T1" "$COMMITS_T1"
+# #565: the fix commit abc1234567 must be shown to TOUCH scripts/foo.sh for
+# addressed-elsewhere to hold (per-commit file verification).
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T1" "$FILES_T1" "$COMMITS_T1" '{"abc1234567":["scripts/foo.sh"]}'
 make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
 
 set +e
@@ -675,6 +703,769 @@ else
   echo "  FAIL: no-yq fallback did not emit templated-render for consumers: all dest (rc=$rc)" >&2
   echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
   echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG_B" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 9 (#564): post-resolve readback confirms isResolved:true. After a
+# successful resolve, the script must re-read the thread via the top-level
+# nodes(ids:) lookup and report the confirmation. Assert (a) the readback
+# query was actually issued, (b) the confirmation line is printed, and
+# (c) the script exits 0.
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 9: post-resolve readback confirms isResolved:true (#564)"
+
+# Non-manifest path → deferred-to-followup class; readback is independent
+# of the class, so any resolvable bot thread on current HEAD exercises it.
+THREADS_T9='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_9","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"docs/readback.md","body":"Some finding","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"HEADCURRENT"}}]},
+   "allComments":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Some finding","databaseId":9001}]}
+  }
+]}}}}}'
+FILES_T9='[]'
+COMMITS_T9='[]'
+
+GH_ARGV_LOG="$SCRATCH/t9.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T9" "$FILES_T9" "$COMMITS_T9"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --auto-resolve-bots 2>&1
+)
+rc=$?
+set -e
+
+if [ "$rc" -eq 0 ] \
+   && grep -q 'nodes(ids:' "$GH_ARGV_LOG" \
+   && grep -q 'Readback: all 1 resolved thread(s) confirmed isResolved:true' <<<"$out"; then
+  pass=$((pass + 1))
+  echo "  PASS: readback query issued and confirmed isResolved:true (rc=0)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: post-resolve readback did not confirm as expected (rc=$rc)" >&2
+  echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 10 (#564): post-resolve readback FAILS CLOSED. If the readback
+# reports isResolved:false for a thread the mutation claimed to resolve
+# (state drift / eventual-consistency lag / a write that did not stick),
+# the script must NOT report success: it prints a READBACK FAILED line and
+# exits 2. Drive this by forcing the stub's readback branch to return
+# isResolved:false for the resolved thread id via GH_STUB_READBACK_UNRESOLVED.
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 10: post-resolve readback fails closed on unconfirmed resolve (#564)"
+
+THREADS_T10='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_10","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"docs/readback.md","body":"Some finding","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"HEADCURRENT"}}]},
+   "allComments":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Some finding","databaseId":10001}]}
+  }
+]}}}}}'
+FILES_T10='[]'
+COMMITS_T10='[]'
+
+GH_ARGV_LOG="$SCRATCH/t10.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T10" "$FILES_T10" "$COMMITS_T10"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  GH_STUB_READBACK_UNRESOLVED="PRT_10" \
+  PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --auto-resolve-bots 2>&1
+)
+rc=$?
+set -e
+
+if [ "$rc" -eq 2 ] \
+   && grep -q 'READBACK FAILED \[PRT_10\]' <<<"$out" \
+   && grep -q 'failing closed' <<<"$out"; then
+  pass=$((pass + 1))
+  echo "  PASS: unconfirmed readback → READBACK FAILED + exit 2 (fail closed)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: readback did not fail closed on isResolved:false (rc=$rc, expected 2)" >&2
+  echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 11 (#564): --resolve-actioned RESOLVES a demonstrably-actioned
+# thread. A ≥30-char agent reply classifies as rebuttal-recorded (an
+# actioned skip-set class, manifest-independent), so --resolve-actioned
+# must tag, resolve, and confirm it via the readback — exit 0.
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 11: --resolve-actioned resolves an actioned-class thread (#564)"
+
+THREADS_T11='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_11","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"docs/notes.md","body":"Some non-canonical finding","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"HEADCURRENT"}}]},
+   "allComments":{"nodes":[
+     {"author":{"login":"coderabbitai"},"body":"Some non-canonical finding","databaseId":11001},
+     {"author":{"login":"nathanpayne-claude"},"body":"Disagree — this is intentional for the propagation path; see #200 for context.","databaseId":11002}
+   ]}
+  }
+]}}}}}'
+FILES_T11='[]'
+COMMITS_T11='[]'
+
+GH_ARGV_LOG="$SCRATCH/t11.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T11" "$FILES_T11" "$COMMITS_T11"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --resolve-actioned 2>&1
+)
+rc=$?
+set -e
+
+if [ "$rc" -eq 0 ] \
+   && grep -q 'resolveReviewThread' "$GH_ARGV_LOG" \
+   && grep -q 'FIELD: body=\[mergepath-resolve: rebuttal-recorded\]' "$GH_ARGV_LOG" \
+   && grep -q 'Readback: all 1 resolved thread(s) confirmed isResolved:true' <<<"$out" \
+   && ! grep -q 'not demonstrably actioned' <<<"$out"; then
+  pass=$((pass + 1))
+  echo "  PASS: actioned (rebuttal-recorded) thread resolved + confirmed under --resolve-actioned"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: --resolve-actioned did not resolve the actioned thread (rc=$rc)" >&2
+  echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 12 (#564): --resolve-actioned SKIPS a non-actioned thread. A bot
+# finding with no badge, no fix commit, and no agent reply classifies as
+# deferred-to-followup (a surface-set class). --resolve-actioned must LEAVE
+# IT UNRESOLVED: no resolveReviewThread mutation, a "not demonstrably
+# actioned" skip line, and exit 3 (work remains) so the sweep still sees it.
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 12: --resolve-actioned skips a non-actioned (deferred) thread (#564)"
+
+THREADS_T12='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_12","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"docs/random.md","body":"Some opaque finding without a badge","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"HEADCURRENT"}}]},
+   "allComments":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Some opaque finding without a badge","databaseId":12001}]}
+  }
+]}}}}}'
+FILES_T12='[]'
+COMMITS_T12='[]'
+
+GH_ARGV_LOG="$SCRATCH/t12.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T12" "$FILES_T12" "$COMMITS_T12"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --resolve-actioned 2>&1
+)
+rc=$?
+set -e
+
+if [ "$rc" -eq 3 ] \
+   && grep -q 'SKIP (not demonstrably actioned: deferred-to-followup)' <<<"$out" \
+   && ! grep -q 'resolveReviewThread' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: non-actioned thread left unresolved (no mutation), exit 3"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: --resolve-actioned did not skip the non-actioned thread (rc=$rc)" >&2
+  echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 13 (#564, Codex P2 on #565): a deferred-marked thread with no real
+# action evidence is left unresolved by --resolve-actioned. The GATE ignores
+# recorded markers and re-derives fresh evidence (#565): the marker reply is
+# ≥30 chars and agent-authored, but step 3's marker guard excludes it, so the
+# ladder finds no fix/rebuttal and classifies deferred-to-followup → skipped
+# (no mutation, exit 3). (It must NOT be mis-read as rebuttal-recorded.)
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 13: --resolve-actioned leaves a deferred-marked, unfixed thread unresolved (#564 / Codex #565)"
+
+THREADS_T13='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_13","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"docs/marked.md","body":"Some finding deferred earlier","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"HEADCURRENT"}}]},
+   "allComments":{"nodes":[
+     {"author":{"login":"coderabbitai"},"body":"Some finding deferred earlier","databaseId":13001},
+     {"author":{"login":"nathanpayne-claude"},"body":"[mergepath-resolve: deferred-to-followup] deferred to follow-up; resolving for branch-protection conversation gate.","databaseId":13002}
+   ]}
+  }
+]}}}}}'
+FILES_T13='[]'
+COMMITS_T13='[]'
+
+GH_ARGV_LOG="$SCRATCH/t13.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T13" "$FILES_T13" "$COMMITS_T13"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --resolve-actioned 2>&1
+)
+rc=$?
+set -e
+
+if [ "$rc" -eq 3 ] \
+   && grep -q 'SKIP (not demonstrably actioned: deferred-to-followup)' <<<"$out" \
+   && ! grep -q 'resolveReviewThread' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: existing deferred marker honored — thread left unresolved (no mutation), exit 3"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: deferred marker not honored under --resolve-actioned (rc=$rc)" >&2
+  echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 14 (#564, CodeRabbit Major on #565): a STALE actioned marker is NOT
+# honored when the bot posts fresh feedback after it. Thread: finding →
+# agent rebuttal → [mergepath-resolve: rebuttal-recorded] marker → bot
+# RE-RAISES. The marker (and the rebuttal) predate the bot's last word, so
+# --resolve-actioned must NOT resolve — it classifies deferred-to-followup
+# and leaves the thread unresolved (no mutation, exit 3).
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 14: --resolve-actioned ignores a stale actioned marker after a bot re-raise (#565)"
+
+THREADS_T14='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_14","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"docs/stale.md","body":"Original finding","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"HEADCURRENT"}}]},
+   "allComments":{"nodes":[
+     {"author":{"login":"coderabbitai"},"body":"Original finding","databaseId":14001},
+     {"author":{"login":"nathanpayne-claude"},"body":"Disagree — intentional for the propagation path; see #200 for the rationale.","databaseId":14002},
+     {"author":{"login":"nathanpayne-claude"},"body":"[mergepath-resolve: rebuttal-recorded] agent rebuttal posted on thread; resolving.","databaseId":14003},
+     {"author":{"login":"coderabbitai"},"body":"Still a problem after your rebuttal — please reconsider.","databaseId":14004}
+   ]}
+  }
+]}}}}}'
+FILES_T14='[]'
+COMMITS_T14='[]'
+
+GH_ARGV_LOG="$SCRATCH/t14.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T14" "$FILES_T14" "$COMMITS_T14"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --resolve-actioned 2>&1
+)
+rc=$?
+set -e
+
+if [ "$rc" -eq 3 ] \
+   && grep -q 'SKIP (not demonstrably actioned: deferred-to-followup)' <<<"$out" \
+   && ! grep -q 'resolveReviewThread' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: stale actioned marker after a bot re-raise is not honored — thread left unresolved, exit 3"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: stale actioned marker was honored under --resolve-actioned (rc=$rc)" >&2
+  echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 15 (#564, CodeRabbit Major on #565): the same staleness rule on the
+# rebuttal heuristic (no marker). Thread: finding → agent rebuttal → bot
+# RE-RAISES. The rebuttal predates the bot's last word, so it must NOT count
+# as rebuttal-recorded; --resolve-actioned leaves the thread unresolved.
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 15: --resolve-actioned ignores a stale rebuttal after a bot re-raise (#565)"
+
+THREADS_T15='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_15","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"docs/stale2.md","body":"Original finding two","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"HEADCURRENT"}}]},
+   "allComments":{"nodes":[
+     {"author":{"login":"coderabbitai"},"body":"Original finding two","databaseId":15001},
+     {"author":{"login":"nathanpayne-claude"},"body":"Disagree — intentional for the propagation path; see #200 for the rationale.","databaseId":15002},
+     {"author":{"login":"coderabbitai"},"body":"Still a problem after your rebuttal — please reconsider.","databaseId":15003}
+   ]}
+  }
+]}}}}}'
+FILES_T15='[]'
+COMMITS_T15='[]'
+
+GH_ARGV_LOG="$SCRATCH/t15.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T15" "$FILES_T15" "$COMMITS_T15"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --resolve-actioned 2>&1
+)
+rc=$?
+set -e
+
+if [ "$rc" -eq 3 ] \
+   && grep -q 'SKIP (not demonstrably actioned: deferred-to-followup)' <<<"$out" \
+   && ! grep -q 'resolveReviewThread' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: stale rebuttal after a bot re-raise is not counted — thread left unresolved, exit 3"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: stale rebuttal was counted as actioned under --resolve-actioned (rc=$rc)" >&2
+  echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 16 (#564, nathanpayne-codex CHANGES_REQUESTED on #565): the
+# addressed-elsewhere staleness guard. A fix commit that post-dates the
+# ORIGINAL finding but PRE-dates a later bot re-raise must NOT count as
+# actioning the thread. Thread: finding @ T0 → fix commit @ T1 (T0<T1) →
+# bot re-raise @ T2 (T1<T2). --resolve-actioned must classify
+# deferred-to-followup (not addressed-elsewhere) and leave it unresolved.
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 16: --resolve-actioned ignores a fix commit that predates a bot re-raise (#565)"
+
+THREADS_T16='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_16","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"scripts/foo.sh","body":"Original finding on foo","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"HEADCURRENT"}}]},
+   "allComments":{"nodes":[
+     {"author":{"login":"coderabbitai"},"body":"Original finding on foo","databaseId":16001,"createdAt":"2026-01-01T00:00:00Z"},
+     {"author":{"login":"coderabbitai"},"body":"Your fix did not address this — still broken.","databaseId":16002,"createdAt":"2026-01-03T00:00:00Z"}
+   ]}
+  }
+]}}}}}'
+# Agent fix commit at 2026-01-02 — AFTER the finding (T0) but BEFORE the
+# re-raise (T2=2026-01-03). Touches the anchored file.
+FILES_T16='["scripts/foo.sh"]'
+COMMITS_T16='[{"sha":"def4567890","login":"nathanpayne-claude","date":"2026-01-02T00:00:00Z"}]'
+
+GH_ARGV_LOG="$SCRATCH/t16.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T16" "$FILES_T16" "$COMMITS_T16"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --resolve-actioned 2>&1
+)
+rc=$?
+set -e
+
+if [ "$rc" -eq 3 ] \
+   && grep -q 'SKIP (not demonstrably actioned: deferred-to-followup)' <<<"$out" \
+   && ! grep -q 'resolveReviewThread' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: stale fix commit (predates bot re-raise) is not addressed-elsewhere — left unresolved, exit 3"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: stale fix commit was treated as addressed-elsewhere under --resolve-actioned (rc=$rc)" >&2
+  echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 17 (#564, nathanpayne-codex CHANGES_REQUESTED on #565): a later
+# agent commit on an UNRELATED file must NOT make addressed-elsewhere hold
+# for a thread anchored on a different file. Thread on scripts/foo.sh; the
+# PR's overall file list includes foo.sh (so the old PR-level check passed),
+# but the only qualifying agent commit touched scripts/bar.sh — NOT foo.sh.
+# Per-commit verification must reject it → --resolve-actioned leaves the
+# thread unresolved (no mutation, exit 3).
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 17: --resolve-actioned rejects addressed-elsewhere when the commit touched another file (#565)"
+
+THREADS_T17='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_17","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"scripts/foo.sh","body":"Finding on foo, never fixed","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"HEADCURRENT"}}]},
+   "allComments":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Finding on foo, never fixed","databaseId":17001,"createdAt":"2026-01-01T00:00:00Z"}]}
+  }
+]}}}}}'
+# PR overall touched BOTH files; the later agent commit touched only bar.sh.
+FILES_T17='["scripts/foo.sh","scripts/bar.sh"]'
+COMMITS_T17='[{"sha":"bar9999999","login":"nathanpayne-claude","date":"2026-01-02T00:00:00Z"}]'
+# Per-commit map: bar9999999 touched scripts/bar.sh ONLY (not foo.sh).
+CFILES_T17='{"bar9999999":["scripts/bar.sh"]}'
+
+GH_ARGV_LOG="$SCRATCH/t17.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T17" "$FILES_T17" "$COMMITS_T17" "$CFILES_T17"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --resolve-actioned 2>&1
+)
+rc=$?
+set -e
+
+if [ "$rc" -eq 3 ] \
+   && grep -q 'SKIP (not demonstrably actioned: deferred-to-followup)' <<<"$out" \
+   && ! grep -q 'resolveReviewThread' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: commit on an unrelated file is not addressed-elsewhere — thread left unresolved, exit 3"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: unrelated-file commit was treated as addressed-elsewhere (rc=$rc)" >&2
+  echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 18 (#564, nathanpayne-codex P1 CHANGES_REQUESTED on #565): a fresh
+# bot finding on a canonical manifest path with NO fix commit and NO
+# rebuttal must be LEFT UNRESOLVED by --resolve-actioned. The GATE skips
+# routing (skip_routing), so the thread no longer short-circuits to
+# canonical-coverage; it falls through to a non-actioned class (here
+# deferred-to-followup) and is skipped — routing alone never resolves.
+# (The fixture manifest, rewritten by Test 8, marks
+# scripts/resolve-pr-threads.sh canonical.)
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 18: --resolve-actioned does NOT resolve a fresh, unfixed canonical-path thread (#565)"
+
+THREADS_T18='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_18","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"scripts/resolve-pr-threads.sh","body":"Fresh unfixed finding on a canonical path","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"HEADCURRENT"}}]},
+   "allComments":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Fresh unfixed finding on a canonical path","databaseId":18001,"createdAt":"2026-01-01T00:00:00Z"}]}
+  }
+]}}}}}'
+FILES_T18='["scripts/resolve-pr-threads.sh"]'
+COMMITS_T18='[]'
+
+GH_ARGV_LOG="$SCRATCH/t18.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T18" "$FILES_T18" "$COMMITS_T18"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --resolve-actioned 2>&1
+)
+rc=$?
+set -e
+
+if [ "$rc" -eq 3 ] \
+   && grep -q 'SKIP (not demonstrably actioned:' <<<"$out" \
+   && ! grep -q 'resolveReviewThread' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: routing-only canonical thread left unresolved (no mutation), exit 3"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: routing-only canonical thread was treated as actioned (rc=$rc)" >&2
+  echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 19 (#564, nathanpayne-codex P1 CHANGES_REQUESTED on #565): the
+# counterpart to Test 18 — a canonical-path thread that WAS actually fixed
+# MUST resolve. Before the skip_routing gate path, derive_tag_class returned
+# canonical-coverage (routing, step 1) before checking the fix commit
+# (step 2), so a real fix on a canonical path was masked and skipped. With
+# routing skipped in the gate, the fix commit touching the anchored
+# canonical file classifies as addressed-elsewhere → resolved + readback.
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 19: --resolve-actioned DOES resolve a fixed canonical-path thread (#565)"
+
+THREADS_T19='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_19","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"scripts/resolve-pr-threads.sh","body":"Finding on a canonical path that we then fixed","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"HEADCURRENT"}}]},
+   "allComments":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Finding on a canonical path that we then fixed","databaseId":19001,"createdAt":"2026-01-01T00:00:00Z"}]}
+  }
+]}}}}}'
+FILES_T19='["scripts/resolve-pr-threads.sh"]'
+# Agent fix commit AFTER the finding, touching the anchored canonical file.
+COMMITS_T19='[{"sha":"can1234567","login":"nathanpayne-claude","date":"2026-01-02T00:00:00Z"}]'
+CFILES_T19='{"can1234567":["scripts/resolve-pr-threads.sh"]}'
+
+GH_ARGV_LOG="$SCRATCH/t19.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T19" "$FILES_T19" "$COMMITS_T19" "$CFILES_T19"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(
+  GH_ARGV_LOG="$GH_ARGV_LOG" \
+  RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 \
+  PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 \
+    --repo test/repo --resolve-actioned 2>&1
+)
+rc=$?
+set -e
+
+if [ "$rc" -eq 0 ] \
+   && grep -q 'resolveReviewThread' "$GH_ARGV_LOG" \
+   && grep -q 'FIELD: body=\[mergepath-resolve: addressed-elsewhere\]' "$GH_ARGV_LOG" \
+   && grep -q 'Readback: all 1 resolved thread(s) confirmed isResolved:true' <<<"$out"; then
+  pass=$((pass + 1))
+  echo "  PASS: fixed canonical-path thread resolved as addressed-elsewhere + readback-confirmed"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: fixed canonical-path thread was NOT resolved under --resolve-actioned (rc=$rc)" >&2
+  echo "    script output:" >&2; echo "$out" | sed 's/^/      /' >&2
+  echo "    captured argv (tail):" >&2; tail -20 "$GH_ARGV_LOG" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 20 (#565 Codex P2 "let later fixes override stale surface markers"):
+# a thread with a stale [mergepath-resolve: deferred-to-followup] marker BUT
+# a later fix commit touching the anchored file must RESOLVE — the GATE
+# ignores the marker and re-derives addressed-elsewhere from the fix.
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 20: --resolve-actioned lets a later fix override a stale deferred marker (#565)"
+
+THREADS_T20='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_20","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"docs/x.md","body":"Finding later fixed","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"HEADCURRENT"}}]},
+   "allComments":{"nodes":[
+     {"author":{"login":"coderabbitai"},"body":"Finding later fixed","databaseId":20001,"createdAt":"2026-01-01T00:00:00Z"},
+     {"author":{"login":"nathanpayne-claude"},"body":"[mergepath-resolve: deferred-to-followup] deferred earlier; resolving for the gate.","databaseId":20002,"createdAt":"2026-01-02T00:00:00Z"}
+   ]}
+  }
+]}}}}}'
+FILES_T20='["docs/x.md"]'
+COMMITS_T20='[{"sha":"fix2020abc","login":"nathanpayne-claude","date":"2026-01-03T00:00:00Z"}]'
+CFILES_T20='{"fix2020abc":["docs/x.md"]}'
+
+GH_ARGV_LOG="$SCRATCH/t20.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T20" "$FILES_T20" "$COMMITS_T20" "$CFILES_T20"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(GH_ARGV_LOG="$GH_ARGV_LOG" RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 --repo test/repo --resolve-actioned 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" -eq 0 ] \
+   && grep -q 'resolveReviewThread' "$GH_ARGV_LOG" \
+   && grep -q 'FIELD: body=\[mergepath-resolve: addressed-elsewhere\]' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: later fix overrides the stale deferred marker — resolved as addressed-elsewhere"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: stale deferred marker masked the later fix (rc=$rc)" >&2
+  echo "$out" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 21 (#565 Codex P2 "re-verify actioned markers before resolving"): a
+# thread carrying an [mergepath-resolve: addressed-elsewhere] marker but NO
+# actual qualifying commit must NOT resolve — the GATE re-derives evidence
+# and finds none.
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 21: --resolve-actioned re-verifies a stale addressed-elsewhere marker, skips (#565)"
+
+THREADS_T21='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_21","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"docs/y.md","body":"Finding never actually fixed","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"HEADCURRENT"}}]},
+   "allComments":{"nodes":[
+     {"author":{"login":"coderabbitai"},"body":"Finding never actually fixed","databaseId":21001,"createdAt":"2026-01-01T00:00:00Z"},
+     {"author":{"login":"nathanpayne-claude"},"body":"[mergepath-resolve: addressed-elsewhere] addressed by commit deadbeef.","databaseId":21002,"createdAt":"2026-01-02T00:00:00Z"}
+   ]}
+  }
+]}}}}}'
+FILES_T21='[]'
+COMMITS_T21='[]'
+
+GH_ARGV_LOG="$SCRATCH/t21.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T21" "$FILES_T21" "$COMMITS_T21"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(GH_ARGV_LOG="$GH_ARGV_LOG" RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 --repo test/repo --resolve-actioned 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" -eq 3 ] && ! grep -q 'resolveReviewThread' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: stale addressed-elsewhere marker without a real commit is re-verified and skipped"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: stale addressed-elsewhere marker resolved without re-verification (rc=$rc)" >&2
+  echo "$out" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 22 (#565 Codex P2 "reject rationale overrides in actioned mode"):
+# --resolve-actioned with --rationale is rejected (exit 1), never resolves.
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 22: --resolve-actioned --rationale is rejected (#565)"
+
+GH_ARGV_LOG="$SCRATCH/t22.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T4" "$FILES_T4" "$COMMITS_T4"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(GH_ARGV_LOG="$GH_ARGV_LOG" RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 --repo test/repo --resolve-actioned --rationale "manual note" 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" -eq 1 ] \
+   && grep -q 'not valid with --resolve-actioned' <<<"$out" \
+   && ! grep -q 'resolveReviewThread' "$GH_ARGV_LOG"; then
+  pass=$((pass + 1))
+  echo "  PASS: --resolve-actioned --rationale rejected with exit 1, no mutation"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: --rationale not rejected under --resolve-actioned (rc=$rc)" >&2
+  echo "$out" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 23 (#565 Codex P2 "allow later fix commits past the stale-thread
+# gate"): a fixed-by-commit thread whose bot comment is on an OLDER commit
+# (commit_oid != HEAD) must still RESOLVE under --resolve-actioned — the
+# gate bypasses the current-HEAD stale skip and relies on the fix evidence.
+# (--auto-resolve-bots would skip this thread as stale-HEAD.)
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 23: --resolve-actioned resolves a fixed thread whose bot comment is on an older commit (#565)"
+
+THREADS_T23='{"data":{"repository":{"pullRequest":{"reviewThreads":{"totalCount":1,"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"id":"PRT_23","isResolved":false,"isOutdated":false,
+   "commentsFirst":{"nodes":[{"author":{"login":"coderabbitai"},"path":"docs/z.md","body":"Finding fixed by a later commit","createdAt":"2026-01-01T00:00:00Z"}]},
+   "commentsLast":{"nodes":[{"commit":{"oid":"OLDCOMMIT0"}}]},
+   "allComments":{"nodes":[{"author":{"login":"coderabbitai"},"body":"Finding fixed by a later commit","databaseId":23001,"createdAt":"2026-01-01T00:00:00Z"}]}
+  }
+]}}}}}'
+FILES_T23='["docs/z.md"]'
+COMMITS_T23='[{"sha":"fix2323abc","login":"nathanpayne-claude","date":"2026-01-02T00:00:00Z"}]'
+CFILES_T23='{"fix2323abc":["docs/z.md"]}'
+
+GH_ARGV_LOG="$SCRATCH/t23.log"; : > "$GH_ARGV_LOG"
+make_gh_stub "$SCRATCH/gh-real" "$THREADS_T23" "$FILES_T23" "$COMMITS_T23" "$CFILES_T23"
+make_gh_wrapper "$SCRATCH/gh" "$SCRATCH/gh-real"
+
+set +e
+out=$(GH_ARGV_LOG="$GH_ARGV_LOG" RESOLVE_PR_THREADS_SKIP_IDENTITY_CHECK=1 PATH="$SCRATCH:$PATH" \
+  env -u OP_PREFLIGHT_REVIEWER_PAT -u GH_TOKEN \
+  bash "$FIXTURE_ROOT/scripts/resolve-pr-threads.sh" 99999 --repo test/repo --resolve-actioned 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" -eq 0 ] \
+   && grep -q 'resolveReviewThread' "$GH_ARGV_LOG" \
+   && grep -q 'FIELD: body=\[mergepath-resolve: addressed-elsewhere\]' "$GH_ARGV_LOG" \
+   && ! grep -q 'SKIP (stale' <<<"$out"; then
+  pass=$((pass + 1))
+  echo "  PASS: stale-HEAD fixed thread resolved via evidence (current-HEAD gate bypassed)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: stale-HEAD fixed thread not resolved under --resolve-actioned (rc=$rc)" >&2
+  echo "$out" | sed 's/^/      /' >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Test 24 (#565 round-8 P1): commit-cache login normalization. GitHub
+# returns author.login=null for commits whose author email is not linked to
+# a GitHub account — THIS repo's normal case (commits are authored as
+# nathanjohnpayne with a placeholder .example email). The commit-cache login
+# projection must fall back to .commit.author.name (= nathanjohnpayne, an
+# agent author) BEFORE the unlinked email, or fixed-by-commit feedback is
+# never recognized as agent-authored and addressed-elsewhere never fires.
+# ─────────────────────────────────────────────────────────────────────
+echo
+echo "Test 24: commit-cache login falls back to .commit.author.name when author.login is null (#565)"
+
+# (a) The exact projection both builders use must map a null-author commit to
+#     the git author name (the #565-round-8 reviewer's live shape).
+RAW_COMMITS_T24='[{"sha":"deadbeef","author":null,"commit":{"author":{"name":"nathanjohnpayne","email":"nathan@nathanjohnpayne.example","date":"2026-01-02T00:00:00Z"}}}]'
+PROJECTED_LOGIN=$(printf '%s' "$RAW_COMMITS_T24" | jq -r '[.[] | {login: (.author.login // .commit.author.name // .commit.author.email // "")}][0].login')
+if [ "$PROJECTED_LOGIN" = "nathanjohnpayne" ]; then
+  pass=$((pass + 1))
+  echo "  PASS: null author.login -> .commit.author.name (nathanjohnpayne)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: projection gave [$PROJECTED_LOGIN], expected nathanjohnpayne" >&2
+fi
+
+# (b) BOTH commit-cache builders in the script carry the .commit.author.name
+#     fallback (regression guard against either reverting).
+BUILDER_HITS=$(grep -c '\.author\.login // \.commit\.author\.name // \.commit\.author\.email' "$SCRIPT")
+if [ "$BUILDER_HITS" -ge 2 ]; then
+  pass=$((pass + 1))
+  echo "  PASS: both commit-cache builders include the .commit.author.name fallback ($BUILDER_HITS)"
+else
+  fail=$((fail + 1))
+  echo "  FAIL: expected >=2 builders with .commit.author.name fallback, found $BUILDER_HITS" >&2
 fi
 
 echo

--- a/tests/test_template_substitution.sh
+++ b/tests/test_template_substitution.sh
@@ -799,6 +799,50 @@ for tpl in "$ESM_TEMPLATE" "$CJS_TEMPLATE"; do
 done
 
 # ---------------------------------------------------------------------------
+# 15. Strict-mode conditional existence-check regression (#555)
+#     >>> if key and >>> if !key on an UNSET fact must NOT hard-fail under
+#     MERGEPATH_TEMPLATE_STRICT=1. The documented contract scopes strict mode
+#     to a *substitution* of an unset fact, not a set-ness test.
+# ---------------------------------------------------------------------------
+
+# 15a: strict mode + bare-key conditional on unset fact → skips block (lenient)
+r=$(render_case "before
+// >>> if has_ts
+typescript line
+// <<<
+after
+" "MERGEPATH_TEMPLATE_STRICT=1")
+expect_output "15a strict mode: bare-key conditional on unset fact skips block (no rc 3)" "$r" "before
+after"
+
+# 15b: strict mode + !key conditional on unset fact → includes block (lenient)
+r=$(render_case "before
+// >>> if !has_ts
+no typescript
+// <<<
+after
+" "MERGEPATH_TEMPLATE_STRICT=1")
+expect_output "15b strict mode: !key conditional on unset fact includes block (no rc 3)" "$r" "before
+no typescript
+after"
+
+# 15c: strict mode + bare-key on a SET fact still renders the block.
+r=$(render_case "before
+// >>> if has_ts
+typescript line
+// <<<
+after
+" "MERGEPATH_TEMPLATE_STRICT=1" "MERGEPATH_FACT_HAS_TS=1")
+expect_output "15c strict mode: bare-key conditional on set fact includes block" "$r" "before
+typescript line
+after"
+
+# 15d: strict mode + substitution of an unset fact still hard-fails (rc 3).
+r=$(render_case "value: {{missing_key}}
+" "MERGEPATH_TEMPLATE_STRICT=1")
+expect_rc "15d strict mode: {{substitution}} of unset fact still hard-fails (rc 3)" "$r" 3
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
Bulk sync to [mergepath@75eae1c](https://github.com/nathanjohnpayne/mergepath/commit/75eae1c521d48fa41fd68400c968b896c92b06f2) — verbatim canonical/kit mirror per `.mergepath-sync.yml`.

Opened by `scripts/sync-to-downstream.sh --sync-all` (v0.4.0-layer3-sync-all, see [#168](https://github.com/nathanjohnpayne/mergepath/issues/168)). Unlike a per-commit propagation PR, this replays the **current HEAD state of every canonical + kit path** so a consumer that has fallen behind reaches a clean steady state in one shot.

## Canonical paths synced
  - scripts/op-preflight.sh
  - scripts/lib/preflight-helpers.sh
  - scripts/lib/gh-retry-helpers.sh
  - scripts/lib/gh-token-resolver.sh
  - scripts/lib/manifest-fact-helpers.sh
  - scripts/lib/template-substitution.sh
  - scripts/lib/reviewers-helpers.sh
  - scripts/coderabbit-wait.sh
  - scripts/coderabbit-automerge-rate-limit-gate.sh
  - scripts/codex-review-request.sh
  - scripts/codex-review-check.sh
  - scripts/codex-record-feedback.sh
  - scripts/phase-4b-classifier.sh
  - scripts/post-phase-4b-handoff.sh
  - scripts/codex-p1-gate.sh
  - scripts/audit-propagation-lane.sh
  - tests/test_audit_propagation_lane.sh
  - scripts/merge-clearance-gate.sh
  - scripts/daily-feedback-rollup.sh
  - scripts/lib/daily-feedback-rollup-helpers.sh
  - scripts/disagreement-detector.cjs
  - scripts/resolve-pr-threads.sh
  - scripts/request-label-removal.sh
  - scripts/gh-as-author.sh
  - scripts/gh-as-reviewer.sh
  - scripts/identity-check.sh
  - scripts/hooks/gh-pr-guard.sh
  - scripts/hooks/label-removal-guard.sh
  - tests/test_gh_pr_guard.sh
  - tests/test_gh_as_author.sh
  - tests/test_gh_as_reviewer.sh
  - tests/test_gh_wrapper_parallel.sh
  - tests/test_check_no_bare_gh_writes.sh
  - tests/test_identity_check.sh
  - tests/test_coderabbit_wait_identity_derivation.sh
  - tests/test_coderabbit_wait_status_probe.sh
  - tests/test_coderabbit_wait_paused.sh
  - tests/test_coderabbit_wait_codex_failover.sh
  - tests/test_coderabbit_automerge_rate_limit_gate.sh
  - tests/test_verify_propagation_pr.sh
  - tests/test_match_protected_paths.sh
  - tests/test_codex_p1_gate.sh
  - tests/test_codex_review_request_ack.sh
  - tests/test_codex_review_request_trigger_only.sh
  - tests/test_codex_review_request_entry.sh
  - tests/test_codex_review_check_resolution.sh
  - tests/test_465_fail_closed.sh
  - tests/test_codex_record_feedback.sh
  - tests/test_merge_clearance_gate.sh
  - tests/test_disagreement_detector.sh
  - tests/test_post_phase_4b_handoff.sh
  - tests/test_op_preflight_check.sh
  - tests/test_op_preflight_token_mode.sh
  - tests/test_helper_autosource.sh
  - tests/test_preflight_agent_name.sh
  - tests/test_resolve_pr_threads_rationale_tag.sh
  - tests/test_daily_feedback_rollup.sh
  - tests/test_template_substitution.sh
  - tests/test_export_consumer_facts.sh
  - tests/test_check_coderabbit_config.sh
  - tests/test_check_propagation_closure.sh
  - .github/pull_request_template.md
  - .github/workflows/agent-review.yml
  - .github/workflows/pr-review-policy.yml
  - .github/workflows/dependabot-auto-merge.yml
  - .github/workflows/auto-clear-blocking-labels.yml
  - .github/workflows/pr-audit.yml
  - .github/workflows/codex-p1-gate.yml
  - .github/workflows/merge-clearance-gate.yml
  - .github/workflows/daily-feedback-rollup.yml

## Kit paths synced
  - .github/ISSUE_TEMPLATE/ (kit, allow-extras)
  - scripts/ci/ (kit, allow-extras)
  - scripts/gh-projects/ (kit, allow-extras)
  - scripts/workflow/ (kit, allow-extras)

## Templated paths rendered (per-consumer facts applied)
  - eslint.config.js (templated, rendered from examples/eslint.config.js)


Authoring-Agent: claude

## Self-Review
- Correctness: mirrors mergepath@75eae1c HEAD state verbatim per the manifest. Each path was already reviewed in its upstream PR.
- Regression risk: low. Verbatim mirror; kit paths use allow-extras semantics so consumer-only files are kept.
- Style: N/A (mirror).
- Test coverage: relies on the consumer repo CI. No test changes shipped.
- Security: no new attack surface; `.sync-overrides.yml` was honored per-consumer so documented divergences are untouched.