### PR TITLE
test(mux): behavioral coverage for settled embed short-circuit + reduced-motion play button

### DIFF
--- a/tests/project-pages.test.js
+++ b/tests/project-pages.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { existsSync, readFileSync, readdirSync } from 'fs';
 import { resolve, join } from 'path';
 
@@ -448,6 +448,74 @@ describe('Project Pages — screenshot aspect variants', () => {
     expect(muxScript).toMatch(/muxEmbedStatus===['"]error['"]/);
     expect(muxScript).toContain('Promise.resolve()');
   });
+
+  it.each(['loaded', 'error'])(
+    '#265 regression: loadMuxEmbed short-circuits when script[data-mux-embed] is already settled (%s)',
+    async (settledStatus) => {
+      const html = readDistHtml('projects/swipe-watch/index.html');
+      setupDOM(html);
+
+      // The bundle's top-level module logic reads `window.matchMedia`
+      // eagerly; jsdom doesn't implement it, so stub it before importing.
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn((query) => ({
+          matches: false,
+          media: query,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          onchange: null,
+          dispatchEvent: vi.fn(),
+        })),
+      });
+
+      const moduleSrcs = Array.from(
+        html.matchAll(/<script type="module" src="([^"]+)"/g),
+        (match) => match[1],
+      );
+      const muxSrc = moduleSrcs.find((src) =>
+        readFileSync(resolve(DIST, src.replace(/^\//, '')), 'utf-8').includes(
+          'https://cdn.jsdelivr.net/npm/mux-embed@5.18.0',
+        ),
+      );
+      expect(muxSrc, 'Mux runtime module not found').toBeTruthy();
+
+      // Pre-seed a settled mux-embed script tag, mirroring a page revisit
+      // where the embed already finished loading (or failed) earlier, and
+      // spy on its listener registration: a broken settled-branch check
+      // would re-attach 'load'/'error' listeners that can never fire on
+      // this inert stub tag, hanging the loader's promise forever.
+      const existingScript = document.createElement('script');
+      existingScript.setAttribute('data-mux-embed', 'true');
+      existingScript.dataset.muxEmbedStatus = settledStatus;
+      const addEventListenerSpy = vi.spyOn(existingScript, 'addEventListener');
+      document.head.appendChild(existingScript);
+
+      // Import the built module fresh (cache-busted) so its top-level
+      // loadMuxEmbed() invocation runs against our seeded DOM state.
+      await import(
+        /* @vite-ignore */ resolve(DIST, muxSrc.replace(/^\//, '')) + `?settled-${settledStatus}`
+      );
+
+      // Give the module's Promise chain a tick to settle.
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(
+        addEventListenerSpy,
+        'loadMuxEmbed must not attach load/error listeners to an already-settled script',
+      ).not.toHaveBeenCalled();
+
+      const muxEmbedScripts = document.querySelectorAll('script[data-mux-embed]');
+      expect(
+        muxEmbedScripts.length,
+        'loadMuxEmbed must not append a new script when one is already settled',
+      ).toBe(1);
+      expect(muxEmbedScripts[0]).toBe(existingScript);
+      expect(existingScript.dataset.muxEmbedStatus).toBe(settledStatus);
+    },
+  );
 
   it('only Swipe Watch opts into the Mux hero today', () => {
     for (const slug of projectSlugs.filter((projectSlug) => projectSlug !== 'swipe-watch')) {

--- a/tests/responsive/swipe-watch-mux-fallback.spec.ts
+++ b/tests/responsive/swipe-watch-mux-fallback.spec.ts
@@ -64,6 +64,9 @@ test('Swipe Watch hero honors prefers-reduced-motion: no autoplay, poster + play
   // Explicit play is an opt-in to motion: with the stream aborted, the
   // normal failure path now applies and the animated GIF may load.
   await playButton.click();
+  await expect(frame).toHaveAttribute('data-playback-state', /^(loading|fallback)$/);
+  await expect(playButton).toBeHidden();
   await expect(frame).toHaveAttribute('data-playback-state', 'fallback', { timeout: 7000 });
   await expect(fallback).toHaveAttribute('src', /\/images\/projects\/swipe-watch-hero\.gif$/);
+  await expect(playButton).toBeVisible();
 });


### PR DESCRIPTION
Authoring-Agent: claude

Closes #565
Closes #576

## Changes

- #565: tests/project-pages.test.js — added a real behavioral regression test for the settled mux-embed script branch in the loadMuxEmbed() function of ProjectMuxPlayer.astro. The prior test only string-matched substrings in the built bundle, which would still pass even if the conditional logic were inverted or broken. The new test dynamically imports the built module against a seeded DOM (a script[data-mux-embed] element with dataset.muxEmbedStatus set to loaded or error) and asserts the loader does not attach new load/error listeners and does not append a duplicate script tag. Verified the test actually catches the regression by temporarily reverting the settled-check in the source and confirming both new test cases fail, then restored the source.
- #576: tests/responsive/swipe-watch-mux-fallback.spec.ts — added the missing play-button visibility assertions (hidden during the loading/fallback transition, visible again once settled) to the reduced-motion Swipe Watch Mux test, mirroring the sibling non-reduced-motion test just above it.

## Verification

- npm install then npm run build (astro build) — succeeds (0 errors). Note: a clean checkout in this sandbox needed @astrojs/markdown-remark installed as an optional peer dependency to build at all; this is pre-existing environment/toolchain drift unrelated to this change (already listed in package-lock.json as an optional peerDependency of astro) and is not part of this diff.
- npx astro check — 0 errors, 0 warnings (pre-existing hints only, unchanged from baseline).
- npx eslint tests/project-pages.test.js tests/responsive/swipe-watch-mux-fallback.spec.ts — clean.
- npx prettier --check on both changed files — clean.
- npx vitest run (full suite) — 245 passed / 5 failed, same 5 pre-existing failures present on a clean main checkout before this change (confirmed via git stash + rerun), unrelated to Mux/ProjectMuxPlayer (located in sitemap-frontmatter, responsive-layout, and a pre-existing quote-style mismatch in the unrelated Safari-safe hero config assertion caused by a minifier version difference in this sandbox). Both new test cases in tests/project-pages.test.js pass.
- tests/responsive/swipe-watch-mux-fallback.spec.ts is a Playwright e2e spec requiring a live browser; not run in this sandbox (no browser infra available). The diff mirrors the existing, already-passing sibling assertions in the same file exactly, so the risk is low.

## Self-Review

Both fixes verified against the current code before editing (issue bodies matched what is on main). The #565 test was checked for tautology risk by temporarily reverting the settled-check in ProjectMuxPlayer.astro and confirming both new parametrized cases fail with a clear assertion message, then restoring the source and rebuilding clean. The #576 diff is a mechanical mirror of the already-covered sibling test in the same file. No files under .github/ touched. Diff is 72 lines across two test files, well under the review-size threshold.